### PR TITLE
Automatically detect output language

### DIFF
--- a/Hex/Clients/TranscriptionClient.swift
+++ b/Hex/Clients/TranscriptionClient.swift
@@ -187,6 +187,7 @@ actor TranscriptionClientLive {
 
     let decodeOptions = DecodingOptions(
       language: nil, // TODO: Allow the user to set ther preferred language in Settings
+      detectLanguage: true,
       chunkingStrategy: .vad
     )
 


### PR DESCRIPTION
This PR fixes #3 

I found out [here](https://github.com/argmaxinc/WhisperKit/issues/235), that all you need to do to set the output language to the input language, is to set detectLanguage to true.