### PR TITLE
Output language

### DIFF
--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -23,6 +23,7 @@ struct SettingsFeature {
     @Shared(.hexSettings) var hexSettings: HexSettings
     @Shared(.isSettingHotKey) var isSettingHotKey: Bool = false
 
+    var languages: IdentifiedArrayOf<Language> = []
     var currentModifiers: Modifiers = .init(modifiers: [])
 
     // Permissions
@@ -74,6 +75,15 @@ struct SettingsFeature {
         }
 
       case .task:
+        if let url = Bundle.main.url(forResource: "languages", withExtension: "json"),
+          let data = try? Data(contentsOf: url),
+          let languages = try? JSONDecoder().decode([Language].self, from: data)
+        {
+          state.languages = IdentifiedArray(uniqueElements: languages)
+        } else {
+          print("Failed to load languages")
+        }
+
         // Listen for key events (existing)
         return .run { send in
           await send(.checkPermissions)

--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -68,6 +68,17 @@ struct SettingsView: View {
 				)
 			}
 
+			Label {
+				Picker("Output Language", selection: $store.hexSettings.outputLanguage) {
+					ForEach(store.languages, id: \.id) { language in
+						Text(language.name).tag(language.code)
+					}
+				}
+				.pickerStyle(.menu)
+			} icon: {
+				Image(systemName: "globe")
+			}
+
 			// --- Hot Key Section ---
 			Section("Hot Key") {
 				let hotKey = store.hexSettings.hotkey

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -263,12 +263,21 @@ private extension TranscriptionFeature {
     state.isTranscribing = true
     state.error = nil
     let model = state.hexSettings.selectedModel
+    let language = state.hexSettings.outputLanguage
 
     return .run { send in
       do {
         await soundEffect.play(.stopRecording)
         let audioURL = await recording.stopRecording()
-        let result = try await transcription.transcribe(audioURL, model) { _ in }
+
+        // Create transcription options with the selected language
+        let decodeOptions = DecodingOptions(
+          language: language,
+          detectLanguage: language == nil, // Only auto-detect if no language specified
+          chunkingStrategy: .vad
+        )
+
+        let result = try await transcription.transcribe(audioURL, model, decodeOptions) { _ in }
         print("Transcribed audio from URL: \(audioURL) to text: \(result)")
         await send(.transcriptionResult(result))
       } catch {

--- a/Hex/Models/HexSettings.swift
+++ b/Hex/Models/HexSettings.swift
@@ -10,6 +10,7 @@ struct HexSettings: Codable, Equatable {
 	var showDockIcon: Bool = true
 	var selectedModel: String = "openai_whisper-large-v3-v20240930"
 	var preventSystemSleep: Bool = true
+	var outputLanguage: String? = nil
 
 	// Define coding keys to match struct properties
 	enum CodingKeys: String, CodingKey {
@@ -19,6 +20,7 @@ struct HexSettings: Codable, Equatable {
 		case showDockIcon
 		case selectedModel
 		case preventSystemSleep
+		case outputLanguage
 	}
 
 	init(
@@ -27,7 +29,8 @@ struct HexSettings: Codable, Equatable {
 		openOnLogin: Bool = false,
 		showDockIcon: Bool = true,
 		selectedModel: String = "openai_whisper-large-v3-v20240930",
-		preventSystemSleep: Bool = true
+		preventSystemSleep: Bool = true,
+		on outputLanguage: String? = nil
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
 		self.hotkey = hotkey
@@ -35,6 +38,7 @@ struct HexSettings: Codable, Equatable {
 		self.showDockIcon = showDockIcon
 		self.selectedModel = selectedModel
 		self.preventSystemSleep = preventSystemSleep
+		self.outputLanguage = outputLanguage
 	}
 
 	// Custom decoder that handles missing fields
@@ -54,6 +58,7 @@ struct HexSettings: Codable, Equatable {
 			?? "openai_whisper-large-v3-v20240930"
 		preventSystemSleep =
 			try container.decodeIfPresent(Bool.self, forKey: .preventSystemSleep) ?? true
+		outputLanguage = try container.decodeIfPresent(String.self, forKey: .outputLanguage)
 	}
 }
 

--- a/Hex/Models/Language.swift
+++ b/Hex/Models/Language.swift
@@ -1,0 +1,15 @@
+import Dependencies
+import Foundation
+
+// Represents a single language option
+struct Language: Codable, Identifiable, Hashable, Equatable {
+    let code: String? // nil is used for the "Auto" option
+    let name: String
+    
+    var id: String { code ?? "auto" }
+}
+
+// Container for the language data loaded from JSON
+struct LanguageList: Codable {
+    let languages: [Language]
+}

--- a/Hex/Resources/Data/languages.json
+++ b/Hex/Resources/Data/languages.json
@@ -1,0 +1,233 @@
+[
+    {
+        "name": "Auto"
+    },
+    {
+        "code": "af",
+        "name": "Afrikaans"
+    },
+    {
+        "code": "ar",
+        "name": "Arabic"
+    },
+    {
+        "code": "hy",
+        "name": "Armenian"
+    },
+    {
+        "code": "az",
+        "name": "Azerbaijani"
+    },
+    {
+        "code": "be",
+        "name": "Belarusian"
+    },
+    {
+        "code": "bs",
+        "name": "Bosnian"
+    },
+    {
+        "code": "bg",
+        "name": "Bulgarian"
+    },
+    {
+        "code": "ca",
+        "name": "Catalan"
+    },
+    {
+        "code": "zh",
+        "name": "Chinese"
+    },
+    {
+        "code": "hr",
+        "name": "Croatian"
+    },
+    {
+        "code": "cs",
+        "name": "Czech"
+    },
+    {
+        "code": "da",
+        "name": "Danish"
+    },
+    {
+        "code": "nl",
+        "name": "Dutch"
+    },
+    {
+        "code": "en",
+        "name": "English"
+    },
+    {
+        "code": "et",
+        "name": "Estonian"
+    },
+    {
+        "code": "fi",
+        "name": "Finnish"
+    },
+    {
+        "code": "fr",
+        "name": "French"
+    },
+    {
+        "code": "gl",
+        "name": "Galician"
+    },
+    {
+        "code": "de",
+        "name": "German"
+    },
+    {
+        "code": "el",
+        "name": "Greek"
+    },
+    {
+        "code": "he",
+        "name": "Hebrew"
+    },
+    {
+        "code": "hi",
+        "name": "Hindi"
+    },
+    {
+        "code": "hu",
+        "name": "Hungarian"
+    },
+    {
+        "code": "is",
+        "name": "Icelandic"
+    },
+    {
+        "code": "id",
+        "name": "Indonesian"
+    },
+    {
+        "code": "it",
+        "name": "Italian"
+    },
+    {
+        "code": "ja",
+        "name": "Japanese"
+    },
+    {
+        "code": "kn",
+        "name": "Kannada"
+    },
+    {
+        "code": "kk",
+        "name": "Kazakh"
+    },
+    {
+        "code": "ko",
+        "name": "Korean"
+    },
+    {
+        "code": "lv",
+        "name": "Latvian"
+    },
+    {
+        "code": "lt",
+        "name": "Lithuanian"
+    },
+    {
+        "code": "mk",
+        "name": "Macedonian"
+    },
+    {
+        "code": "ms",
+        "name": "Malay"
+    },
+    {
+        "code": "mr",
+        "name": "Marathi"
+    },
+    {
+        "code": "mi",
+        "name": "Maori"
+    },
+    {
+        "code": "ne",
+        "name": "Nepali"
+    },
+    {
+        "code": "no",
+        "name": "Norwegian"
+    },
+    {
+        "code": "fa",
+        "name": "Persian"
+    },
+    {
+        "code": "pl",
+        "name": "Polish"
+    },
+    {
+        "code": "pt",
+        "name": "Portuguese"
+    },
+    {
+        "code": "ro",
+        "name": "Romanian"
+    },
+    {
+        "code": "ru",
+        "name": "Russian"
+    },
+    {
+        "code": "sr",
+        "name": "Serbian"
+    },
+    {
+        "code": "sk",
+        "name": "Slovak"
+    },
+    {
+        "code": "sl",
+        "name": "Slovenian"
+    },
+    {
+        "code": "es",
+        "name": "Spanish"
+    },
+    {
+        "code": "sw",
+        "name": "Swahili"
+    },
+    {
+        "code": "sv",
+        "name": "Swedish"
+    },
+    {
+        "code": "tl",
+        "name": "Tagalog"
+    },
+    {
+        "code": "ta",
+        "name": "Tamil"
+    },
+    {
+        "code": "th",
+        "name": "Thai"
+    },
+    {
+        "code": "tr",
+        "name": "Turkish"
+    },
+    {
+        "code": "uk",
+        "name": "Ukrainian"
+    },
+    {
+        "code": "ur",
+        "name": "Urdu"
+    },
+    {
+        "code": "vi",
+        "name": "Vietnamese"
+    },
+    {
+        "code": "cy",
+        "name": "Welsh"
+    }
+]


### PR DESCRIPTION
This PR fixes #7 

I added a JSON for all supported language according to the [Whisper documentation](https://platform.openai.com/docs/guides/speech-to-text/supported-languages/#supported-languages). That is loaded on startup, and a dropdown enables selecting the output language.
In my testing, translation hasn't been super reliable, but that's a Whisper problem, and not a Hex problem as far as I can tell.