### PR TITLE
Make titlebar nolonger transparent, as that looks bad when scrolling down

### DIFF
--- a/Hex/App/HexAppDelegate.swift
+++ b/Hex/App/HexAppDelegate.swift
@@ -62,12 +62,12 @@ class HexAppDelegate: NSObject, NSApplicationDelegate {
 			backing: .buffered,
 			defer: false
 		)
-		settingsWindow.titlebarAppearsTransparent = true
 		settingsWindow.titleVisibility = .visible
 		settingsWindow.contentView = NSHostingView(rootView: settingsView)
 		settingsWindow.makeKeyAndOrderFront(nil)
 		settingsWindow.isReleasedWhenClosed = false
 		settingsWindow.center()
+        settingsWindow.toolbarStyle = NSWindow.ToolbarStyle.unified
 		NSApp.activate(ignoringOtherApps: true)
 		self.settingsWindow = settingsWindow
 	}


### PR DESCRIPTION
With there now being more settings, they can overlap with the title bar when scrolling down.
This PR fixes that by using the unified toolbar style instead of a transparent one.