### PR TITLE
Add option to use simulated keyboard instead of clipboard

### DIFF
--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct SettingsView: View {
 	@Bindable var store: StoreOf<SettingsFeature>
+	@State var isInfoPopTipShown: Bool = false
 
 	var body: some View {
 		Form {
@@ -109,6 +110,13 @@ struct SettingsView: View {
 					Toggle("Show Dock Icon", isOn: $store.hexSettings.showDockIcon)
 				} icon: {
 					Image(systemName: "dock.rectangle")
+				}
+
+				Label {
+					Toggle("Use clipboard to insert", isOn: $store.hexSettings.useClipboardPaste)
+					Text("Use clipboard to insert text. Fast but may not restore all clipboard content.\nTurn off to use simulated keypresses. Slower, but doesn't need to restore clipboard")
+				} icon: {
+					Image(systemName: "doc.on.doc.fill")
 				}
 
 				Label {

--- a/Hex/Models/HexSettings.swift
+++ b/Hex/Models/HexSettings.swift
@@ -9,6 +9,7 @@ struct HexSettings: Codable, Equatable {
 	var openOnLogin: Bool = false
 	var showDockIcon: Bool = true
 	var selectedModel: String = "openai_whisper-large-v3-v20240930"
+	var useClipboardPaste: Bool = true
 	var preventSystemSleep: Bool = true
 
 	// Define coding keys to match struct properties
@@ -18,6 +19,7 @@ struct HexSettings: Codable, Equatable {
 		case openOnLogin
 		case showDockIcon
 		case selectedModel
+		case useClipboardPaste
 		case preventSystemSleep
 	}
 
@@ -27,6 +29,7 @@ struct HexSettings: Codable, Equatable {
 		openOnLogin: Bool = false,
 		showDockIcon: Bool = true,
 		selectedModel: String = "openai_whisper-large-v3-v20240930",
+		useClipboardPaste: Bool = true,
 		preventSystemSleep: Bool = true
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
@@ -34,6 +37,7 @@ struct HexSettings: Codable, Equatable {
 		self.openOnLogin = openOnLogin
 		self.showDockIcon = showDockIcon
 		self.selectedModel = selectedModel
+		self.useClipboardPaste = useClipboardPaste
 		self.preventSystemSleep = preventSystemSleep
 	}
 
@@ -52,6 +56,7 @@ struct HexSettings: Codable, Equatable {
 		selectedModel =
 			try container.decodeIfPresent(String.self, forKey: .selectedModel)
 			?? "openai_whisper-large-v3-v20240930"
+		useClipboardPaste = try container.decodeIfPresent(Bool.self, forKey: .useClipboardPaste) ?? true
 		preventSystemSleep =
 			try container.decodeIfPresent(Bool.self, forKey: .preventSystemSleep) ?? true
 	}


### PR DESCRIPTION
This PR partially addresses #20 by adding the option to use simulated key presses instead of the clipboard to insert transcriptions.
I have also added a little bit of an explanation for when you should use which one.