### PR TITLE
Use entire HotKey form row for onTap

### DIFF
--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -73,13 +73,16 @@ struct SettingsView: View {
 				let hotKey = store.hexSettings.hotkey
 				let key = store.isSettingHotKey ? nil : hotKey.key
 				let modifiers = store.isSettingHotKey ? store.currentModifiers : hotKey.modifiers
-
-				HotKeyView(modifiers: modifiers, key: key, isActive: store.isSettingHotKey)
-					.onTapGesture {
-						store.send(.startSettingHotKey)
-					}
-					.animation(.spring(), value: key)
-					.animation(.spring(), value: modifiers)
+				HStack{
+					Spacer()
+					HotKeyView(modifiers: modifiers, key: key, isActive: store.isSettingHotKey)
+						.animation(.spring(), value: key)
+						.animation(.spring(), value: modifiers)
+					Spacer()
+				}.contentShape(Rectangle())
+				.onTapGesture {
+					store.send(.startSettingHotKey)
+				}
 			}
 
 			// --- Sound Section ---


### PR DESCRIPTION
This somewhat addresses #9 by making it, so the entire row is clickable and therefore if the visualization breaks, people can still update their keyboard shortcuts.
In my opinion, it also makes the UI slightly more intuitive.