### PR TITLE
Show changelog

### DIFF
--- a/Hex.xcodeproj/project.pbxproj
+++ b/Hex.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		47E05E0A2D44525B00D26DA6 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E092D44525B00D26DA6 /* Dependencies */; };
 		47E05E0C2D44525B00D26DA6 /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E0B2D44525B00D26DA6 /* DependenciesMacros */; };
 		47E05E272D44555500D26DA6 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E262D44555500D26DA6 /* WhisperKit */; };
+		B5045C972D78DED500D0A119 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = B5045C962D78DED500D0A119 /* MarkdownUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 				476BAD3E2D47E7880088C61F /* Sparkle in Frameworks */,
 				47E05E272D44555500D26DA6 /* WhisperKit in Frameworks */,
 				47E05E0A2D44525B00D26DA6 /* Dependencies in Frameworks */,
+				B5045C972D78DED500D0A119 /* MarkdownUI in Frameworks */,
 				47E05E052D444EF800D26DA6 /* Sauce in Frameworks */,
 				4765045E2D45900200C7EA60 /* Pow in Frameworks */,
 				47E05E0C2D44525B00D26DA6 /* DependenciesMacros in Frameworks */,
@@ -162,6 +164,7 @@
 				47E05E262D44555500D26DA6 /* WhisperKit */,
 				4765045D2D45900200C7EA60 /* Pow */,
 				476BAD3D2D47E7880088C61F /* Sparkle */,
+				B5045C962D78DED500D0A119 /* MarkdownUI */,
 			);
 			productName = Hex;
 			productReference = 47E05DEE2D444EC600D26DA6 /* Hex.app */;
@@ -202,6 +205,7 @@
 				47E05E252D44555500D26DA6 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 				4765045C2D45900200C7EA60 /* XCRemoteSwiftPackageReference "Pow" */,
 				476BAD3C2D47E7880088C61F /* XCRemoteSwiftPackageReference "Sparkle" */,
+				B5045C952D78DED500D0A119 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 47E05DEF2D444EC600D26DA6 /* Products */;
@@ -555,6 +559,14 @@
 				kind = branch;
 			};
 		};
+		B5045C952D78DED500D0A119 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -592,6 +604,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 47E05E252D44555500D26DA6 /* XCRemoteSwiftPackageReference "WhisperKit" */;
 			productName = WhisperKit;
+		};
+		B5045C962D78DED500D0A119 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5045C952D78DED500D0A119 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Hex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Hex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9a83fdd027d20e5b04602ba1929b1b38e6e1fb317d87ab6347648e5add4d9ef0",
+  "originHash" : "59bf00219a966d82c75a54eb4322a9b59a51c689972d1f70957352575925a174",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
       }
     },
     {
@@ -65,6 +74,15 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
@@ -116,6 +134,15 @@
       "state" : {
         "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
         "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     },
     {

--- a/Hex/Features/Settings/ChangelogView.swift
+++ b/Hex/Features/Settings/ChangelogView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import MarkdownUI
+
+struct ChangelogView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Changelog")
+                    .font(.title)
+                    .padding(.bottom, 10)
+
+                if let changelogPath = Bundle.main.path(forResource: "changelog", ofType: "md"),
+                    let changelogContent = try? String(
+                        contentsOfFile: changelogPath, encoding: .utf8)
+                {
+                    Markdown(changelogContent)
+                } else {
+                    Text("Changelog could not be loaded.")
+                        .foregroundColor(.red)
+                }
+
+                Spacer()
+
+                Button("Close") {
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 20)
+            }
+            .padding()
+        }
+    }
+}

--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 struct SettingsView: View {
 	@Bindable var store: StoreOf<SettingsFeature>
-	@State var isInfoPopTipShown: Bool = false
 	@State var viewModel = CheckForUpdatesViewModel.shared
+	@State private var showingChangelog = false
 
 	var body: some View {
 		Form {
@@ -169,6 +169,19 @@ struct SettingsView: View {
 						viewModel.checkForUpdates()
 					}
 					.buttonStyle(.bordered)
+				}
+				HStack {
+					Label("Changelog", systemImage: "doc.text")
+					Spacer()
+					Button("Show Changelog") {
+						showingChangelog.toggle()
+					}
+					.buttonStyle(.bordered)
+					.sheet(isPresented: $showingChangelog, onDismiss: {
+						showingChangelog = false
+					}) {
+						ChangelogView()
+					}
 				}
 				HStack {
 					Label("Hex is open source", systemImage: "apple.terminal.on.rectangle")

--- a/Hex/Resources/changelog.md
+++ b/Hex/Resources/changelog.md
@@ -1,0 +1,2 @@
+### 0.1.26
+- Add changelog

--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ Hex is organized into several directories, each serving a specific purpose:
     - Stores user preferences like hotkey settings and sound preferences.
   - `HotKey.swift`
     - Represents the hotkey configuration.
+
+- **`Resources/`**
+  - Contains the app's assets, including the app icon and sound effects.
+  - `changelog.md`
+    - A log of changes to the app.
+  - `Data/languages.json`
+    - A list of supported languages for transcription.
+  - `Audio/`
+    - Sound effects for user feedback.


### PR DESCRIPTION
This PR partially addresses #27 by adding a button to show the changelog saved in `Resources`. To render it correctly, the [MarkdownUI](https://github.com/gonzalezreal/swift-markdown-ui) dependency was added.

The popup looks like this:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/c556e805-bdda-4c26-9a33-59f89ed53991" />
