### PR TITLE
Add translations for Changelog and actually use them in xcode

### DIFF
--- a/Hex.xcodeproj/project.pbxproj
+++ b/Hex.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		47E05E0C2D44525B00D26DA6 /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E0B2D44525B00D26DA6 /* DependenciesMacros */; };
 		47E05E272D44555500D26DA6 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E262D44555500D26DA6 /* WhisperKit */; };
 		B5045C972D78DED500D0A119 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = B5045C962D78DED500D0A119 /* MarkdownUI */; };
+		B53356002D7B8D4900E5F542 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B53355FF2D7B8D4900E5F542 /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,6 +33,7 @@
 		473544542D445959001FBCB5 /* Testing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Testing.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework; sourceTree = DEVELOPER_DIR; };
 		478637A52D48725900319BFA /* HexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		47E05DEE2D444EC600D26DA6 /* Hex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hex.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B53355FF2D7B8D4900E5F542 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -98,6 +100,7 @@
 		47E05DE52D444EC600D26DA6 = {
 			isa = PBXGroup;
 			children = (
+				B53355FF2D7B8D4900E5F542 /* Localizable.xcstrings */,
 				47E05DF02D444EC600D26DA6 /* Hex */,
 				478637A62D48725900319BFA /* HexTests */,
 				4735444F2D445936001FBCB5 /* Frameworks */,
@@ -230,6 +233,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B53356002D7B8D4900E5F542 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -51,6 +51,26 @@
         }
       }
     },
+    "Changelog" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Änderungen"
+          }
+        }
+      }
+    },
+    "Changelog could not be loaded." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Änderungen konnten nicht geladen werden."
+          }
+        }
+      }
+    },
     "Check for Updates" : {
       "comment" : "Check for updates button in About section of Settings",
       "localizations" : {
@@ -69,6 +89,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suche nach Updates…"
+          }
+        }
+      }
+    },
+    "Close" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließen"
           }
         }
       }
@@ -388,6 +418,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Einstellungen…"
+          }
+        }
+      }
+    },
+    "Show Changelog" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Änderungen anzeigen"
           }
         }
       }


### PR DESCRIPTION
This PR actually adds the localization to Xcode and adds translations for changelog related strings.
I seem to have forgotten to add localizations to the Xcode project in the original PR #30 