### PR TITLE
Refactor audio pausing logic to fix not pausing when audio is playing on non-primary output.

### DIFF
--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -283,23 +283,22 @@ actor RecordingClientLive {
 
   func startRecording() async {
     // If audio is playing on the default output, pause it.
-    if await isAudioPlayingOnDefaultOutput() && hexSettings.pauseMediaOnRecord {
-      print("Audio is playing on the default output; pausing it for recording.")
+    if hexSettings.pauseMediaOnRecord {
       // First, pause all media applications using their AppleScript interface.
       pausedPlayers = await pauseAllMediaApplications()
       // If no specific players were paused, pause generic media using the media key.
       if pausedPlayers.isEmpty {
-        await MainActor.run {
-          sendMediaKey()
+        if await isAudioPlayingOnDefaultOutput() {
+          print("Audio is playing on the default output; pausing it for recording.")
+          await MainActor.run {
+            sendMediaKey()
+          }
+          didPauseMedia = true
+          print("Media was playing; pausing it for recording.")
         }
-        didPauseMedia = true
-        print("Media was playing; pausing it for recording.")
       } else {
         print("Paused media players: \(pausedPlayers.joined(separator: ", "))")
       }
-    } else {
-      print("Audio is not playing on the default output; not pausing it.")
-      didPauseMedia = false
     }
 
     let settings: [String: Any] = [

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -133,25 +133,25 @@ func pauseAllMediaApplications() async -> [String] {
       // VLC has a different AppleScript interface
       scriptParts.append("""
       try
-        tell application "VLC"
-          if it is running then
-          tell application "VLC" to set isVLCplaying to playing
+        set appName to "VLC"
+        if application appName is running then
+          tell application appName to set isVLCplaying to playing
             if isVLCplaying then
-              tell application "VLC" to play
-              set end of pausedPlayers to "VLC"
+              tell application appName to play
+              set end of pausedPlayers to appName
             end if
-          end if
-        end tell
+        end if
       end try
       """)
     } else {
       // Standard interface for Music/iTunes/Spotify
       scriptParts.append("""
       try
-        tell application "\(appName)"
+        set appName to "\(appName)"
+        tell application appName
           if it is running and player state is playing then
             pause
-            set end of pausedPlayers to "\(appName)"
+            set end of pausedPlayers to appName
           end if
         end tell
       end try
@@ -217,11 +217,9 @@ func resumeMediaApplications(_ players: [String]) async {
       // Standard interface for Music/iTunes/Spotify
       scriptParts.append("""
       try
-        tell application "\(player)"
-          if it is running then
-            play
-          end if
-        end tell
+        if application "\(player)" is running then
+          tell application "\(player)" to play
+        end if
       end try
       """)
     }

--- a/Hex/Resources/changelog.md
+++ b/Hex/Resources/changelog.md
@@ -1,3 +1,5 @@
+- Rework audio pausing logic to make it more reliable
+
 ### 0.1.26
 - Add changelog
 - Add option to set minimum record time


### PR DESCRIPTION
I sometimes have this weird behavior in macOS where the first audio output is paused, but the secondary audio (which most of the time Spotify) is actually playing. And before this PR, Hex would not pause any audio because of the detection logic.
This is now fixed as we run the script for each individual application first and if that doesn't pause then we check if the primary output is playing.