### PR TITLE
Add German translation for "Ignore below %.1fs" string

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -279,6 +279,16 @@
         }
       }
     },
+    "Ignore below %.1fs" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unter %0.1fs ignorieren"
+          }
+        }
+      }
+    },
     "Microphone" : {
       "comment" : "Microphone permission.",
       "localizations" : {


### PR DESCRIPTION
This commit should have been added to the PR adding translation script, but I just forgot. Sorry.