### PR TITLE
Add note to say Hex is only available on apple silicon macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Press-and-hold a hotkey to transcribe your voice and paste the result wherever you're typing.
 
 **[Download Hex for macOS](https://hex-updates.s3.us-east-1.amazonaws.com/hex-latest.dmg)**
+> **Note:** Hex is currently only available for **Apple Silicon** Macs.
 
 I've opened-sourced the project in the hopes that others will find it useful! We rely on the awesome [WhisperKit](https://github.com/argmaxinc/WhisperKit) for transcription, and the incredible [Swift Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture) for structuring the app. Please open issues with any questions or feedback! ❤️
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a note specifying that Hex is currently only available for Apple Silicon Macs.

Fixes #47 