### PR TITLE
fix #58

### DIFF
--- a/Hex/App/HexApp.swift
+++ b/Hex/App/HexApp.swift
@@ -17,6 +17,12 @@ struct HexApp: App {
 			Button("Settings...") {
 				appDelegate.presentSettingsView()
 			}.keyboardShortcut(",")
+			
+			Divider()
+			
+			Button("Quit") {
+				NSApplication.shared.terminate(nil)
+			}.keyboardShortcut("q")
 		} label: {
 			let image: NSImage = {
 				let ratio = $0.size.height / $0.size.width


### PR DESCRIPTION
This pull request adds a "Quit" button to the app's menu in `HexApp.swift`, improving user accessibility for exiting the application.

Menu updates:

* [`Hex/App/HexApp.swift`](diffhunk://#diff-f6ab6f0f052b34a18a4cb1a588f6f18b26f8ee63f8c7cdb825c93448d1e0bbfeR20-R25): Added a "Quit" button with a keyboard shortcut (`Cmd+Q`) to the app menu. A `Divider` was also added for better visual separation between the "Settings" and "Quit" options.