### PR TITLE
Fix non-modifier key combination recognition

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -425,6 +425,9 @@
         }
       }
     },
+    "Quit" : {
+
+    },
     "Recommended for custom hotkeys to avoid interfering with normal usage" : {
 
     },


### PR DESCRIPTION
This pull request refines the handling of hotkeys in the `HotKeyProcessor` class and includes a minor addition to the `Localizable.xcstrings` file. The most important changes focus on improving the logic for matching and releasing hotkeys, particularly for modifier-only hotkeys.

### Improvements to HotKey Matching and Releasing Logic:

* [`HotKeyProcessor.swift`](diffhunk://#diff-6ec5c630e04d87a4478cbf8b15ebbcb64fb04201029fca2493f3de5db34ccd06L204-R211): Updated the `chordMatchesHotkey` method to differentiate between key+modifier hotkeys and modifier-only hotkeys. For key+modifier hotkeys, both the key and modifiers must match exactly, while for modifier-only hotkeys, only the required modifiers need to be present, allowing additional modifiers without affecting the match.

* [`HotKeyProcessor.swift`](diffhunk://#diff-6ec5c630e04d87a4478cbf8b15ebbcb64fb04201029fca2493f3de5db34ccd06L222-R238): Refined the `isReleaseForActiveHotkey` method to handle releases differently for key+modifier hotkeys and modifier-only hotkeys. For key+modifier hotkeys, the key must be nil, and modifiers must match exactly. For modifier-only hotkeys, the key must be nil, and the specific modifiers in the hotkey must no longer be pressed.

### Localization Update:

* [`Localizable.xcstrings`](diffhunk://#diff-4272165e609ceb45988f02a03bafa28c2c60e952efc50e81c85f6a2ca2cb9cf9R427-R429): Added a placeholder entry for the "Quit" key, likely as part of future localization improvements.

Also fixes #63