### PR TITLE
Change text color to white and adjust background mix for improved visibility

### DIFF
--- a/Hex/Features/Settings/HotKeyView.swift
+++ b/Hex/Features/Settings/HotKeyView.swift
@@ -64,12 +64,12 @@ struct KeyView: View {
   var body: some View {
     Text(text)
       .font(.title.weight(.bold))
-      .foregroundColor(.primary)
+      .foregroundColor(.white)
       .frame(width: 48, height: 48)
       .background(
         RoundedRectangle(cornerRadius: 8)
           .fill(
-            .black.mix(with: .primary, by: 0.2)
+            .black.mix(with: .white, by: 0.2)
               .shadow(.inner(color: .white.opacity(0.3), radius: 1, y: 1))
               .shadow(.inner(color: .white.opacity(0.1), radius: 5, y: 8))
               .shadow(.inner(color: .black.opacity(0.3), radius: 1, y: -3))


### PR DESCRIPTION
This PR improves the visual appearance of the hot key buttons by adjusting the color scheme for better contrast and readability.
Changes
Changed text color from .primary to .white for better contrast
Updated background mix from .black.mix(with: .primary, by: 0.2) to .black.mix(with: .white, by: 0.2) for consistent styling
Visual Comparison
| Before | After |
|--------|-------|
| <img width="665" alt="Screenshot 2025-05-15 at 10 20 36" src="https://github.com/user-attachments/assets/831b8a42-c147-4e87-96e8-041ce777d4cb" /> | <img width="564" alt="Screenshot 2025-05-15 at 10 47 02" src="https://github.com/user-attachments/assets/5566c568-7574-4400-8cad-54bfe8314800" /> |
| <img width="661" alt="Screenshot 2025-05-15 at 10 20 57" src="https://github.com/user-attachments/assets/b4c0fc1d-372d-45b1-bcf7-259d2edbab6c" />|<img width="564" alt="Screenshot 2025-05-15 at 10 47 17" src="https://github.com/user-attachments/assets/4ec6e758-f4d5-4b49-b276-d86987d5deb2" />|

The updated styling provides better visibility and a more polished appearance for the hot key configuration interface.