### PR TITLE
Fix for #69

### DIFF
--- a/Hex.xcodeproj/project.xcworkspace/xcuserdata/inspektorpidozra.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/Hex.xcodeproj/project.xcworkspace/xcuserdata/inspektorpidozra.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -209,7 +209,7 @@ struct SettingsView: View {
 
 				Label {
 					Toggle("Use clipboard to insert", isOn: $store.hexSettings.useClipboardPaste)
-					Text("Use clipboard to insert text. Fast but may not restore all clipboard content.\nTurn off to use simulated keypresses. Slower, but doesn't need to restore clipboard")
+					Text("Fast but may not restore all clipboard content.\nTurn off to insert by simulating keypresses: slower, doesn't need to restore the clipboard, and works in apps that don't open in a window, like Spotlight, Raycast, or Alfred.")
 				} icon: {
 					Image(systemName: "doc.on.doc.fill")
 				}
@@ -310,4 +310,17 @@ struct SettingsView: View {
 		}
 		.enableInjection()
 	}
+}
+
+#Preview {
+  SettingsView(
+	store: Store(
+	  initialState: SettingsFeature.State(
+		hexSettings: Shared(wrappedValue: HexSettings(), .hexSettings),
+		isSettingHotKey: false,
+		transcriptionHistory: Shared(wrappedValue: .init(), .transcriptionHistory)
+	  ),
+	  reducer: { SettingsFeature() }
+	)
+  )
 }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -263,6 +263,9 @@
         }
       }
     },
+    "Fast but may not restore all clipboard content.\nTurn off to insert by simulating keypresses: slower, doesn't need to restore the clipboard, and works in apps that don't open in a window, like Spotlight, Raycast, or Alfred." : {
+
+    },
     "General" : {
       "comment" : "General section in Settings Header.",
       "localizations" : {
@@ -339,7 +342,6 @@
     },
     "Microphone" : {
       "comment" : "Microphone permission.",
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -350,9 +352,6 @@
       }
     },
     "Microphone Selection" : {
-
-    },
-    "Microphone!" : {
 
     },
     "Model" : {
@@ -632,6 +631,7 @@
     },
     "Use clipboard to insert text. Fast but may not restore all clipboard content.\nTurn off to use simulated keypresses. Slower, but doesn't need to restore clipboard" : {
       "comment" : "More info on \"use clipboard to insert\" toggle in general section.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
### Preface:
I’m not a dev, first time using Git. All code changes were made by AI, but they seem to work fine.

### Changes:
1. Switched from AppleScript to low-level key simulation. 
AppleScript depended on your current macOS input layout. So if you were using Latin and tried to dictate in Cyrillic, it just typed "a" for everything. Now it works regardless of layout.

3. Updated the "Use clipboard to insert" menu item description.  
   It now makes it clearer that turning this off lets Hex paste into apps that don’t use standard windows.

---

### P.S.
I didn’t actually change "Localizable.xcstrings", but it shows up in the PR. Would be good to remove it if the PR gets accepted—I can’t delete it myself.