### PR TITLE
Add text capitalization options

### DIFF
--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -244,6 +244,17 @@ struct SettingsView: View {
 				} icon: {
 					Image(systemName: "pause")
 				}
+				
+				Label {
+					Picker("Text Capitalization", selection: $store.hexSettings.textCapitalization) {
+						ForEach(TextCapitalization.allCases, id: \.self) { option in
+							Text(option.displayName).tag(option)
+						}
+					}
+					.pickerStyle(.menu)
+				} icon: {
+					Image(systemName: "textformat")
+				}
 			} header: {
 				Text("General")
 			}

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -313,12 +313,25 @@ private extension TranscriptionFeature {
       return .none
     }
 
+    // Apply text capitalization based on user setting
+    let processedResult: String
+    switch state.hexSettings.textCapitalization {
+    case .asTranscribed:
+      processedResult = result
+    case .smartLowercase:
+      // Convert to lowercase but preserve standalone "I"
+      processedResult = result.lowercased()
+        .replacingOccurrences(of: "\\bi\\b", with: "I", options: .regularExpression)
+    case .allLowercase:
+      processedResult = result.lowercased()
+    }
+
     // Compute how long we recorded
     let duration = state.recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
 
     // Continue with storing the final result in the background
     return finalizeRecordingAndStoreTranscript(
-      result: result,
+      result: processedResult,
       duration: duration,
       transcriptionHistory: state.$transcriptionHistory
     )

--- a/Hex/Models/HexSettings.swift
+++ b/Hex/Models/HexSettings.swift
@@ -2,6 +2,20 @@ import ComposableArchitecture
 import Dependencies
 import Foundation
 
+enum TextCapitalization: String, CaseIterable, Codable {
+	case asTranscribed = "as_transcribed"
+	case smartLowercase = "smart_lowercase"
+	case allLowercase = "all_lowercase"
+	
+	var displayName: String {
+		switch self {
+		case .asTranscribed: return "As Transcribed"
+		case .smartLowercase: return "Smart Lowercase"
+		case .allLowercase: return "All Lowercase"
+		}
+	}
+}
+
 // To add a new setting, add a new property to the struct, the CodingKeys enum, and the custom decoder
 struct HexSettings: Codable, Equatable {
 	var soundEffectsEnabled: Bool = true
@@ -19,6 +33,7 @@ struct HexSettings: Codable, Equatable {
 	var selectedMicrophoneID: String? = nil
 	var saveTranscriptionHistory: Bool = true
 	var maxHistoryEntries: Int? = nil
+	var textCapitalization: TextCapitalization = .asTranscribed
 
 	// Define coding keys to match struct properties
 	enum CodingKeys: String, CodingKey {
@@ -37,6 +52,7 @@ struct HexSettings: Codable, Equatable {
 		case selectedMicrophoneID
 		case saveTranscriptionHistory
 		case maxHistoryEntries
+		case textCapitalization
 	}
 
 	init(
@@ -54,7 +70,8 @@ struct HexSettings: Codable, Equatable {
 		outputLanguage: String? = nil,
 		selectedMicrophoneID: String? = nil,
 		saveTranscriptionHistory: Bool = true,
-		maxHistoryEntries: Int? = nil
+		maxHistoryEntries: Int? = nil,
+		textCapitalization: TextCapitalization = .asTranscribed
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
 		self.hotkey = hotkey
@@ -71,6 +88,7 @@ struct HexSettings: Codable, Equatable {
 		self.selectedMicrophoneID = selectedMicrophoneID
 		self.saveTranscriptionHistory = saveTranscriptionHistory
 		self.maxHistoryEntries = maxHistoryEntries
+		self.textCapitalization = textCapitalization
 	}
 
 	// Custom decoder that handles missing fields
@@ -104,6 +122,8 @@ struct HexSettings: Codable, Equatable {
 		saveTranscriptionHistory =
 			try container.decodeIfPresent(Bool.self, forKey: .saveTranscriptionHistory) ?? true
 		maxHistoryEntries = try container.decodeIfPresent(Int.self, forKey: .maxHistoryEntries)
+		textCapitalization =
+			try container.decodeIfPresent(TextCapitalization.self, forKey: .textCapitalization) ?? .asTranscribed
 	}
 }
 


### PR DESCRIPTION
i normally use all lowercase letters for communication style and wanted hex to support the option to do so automatically. some people prefer "I" to still be capitalized, so added an extra options for this too. ideally, this would just be taken from mac's input settings, but there isn't an easy way or an api to do so, so i decided to go with an explicit setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Text Capitalization" option to the General settings, allowing users to choose how transcribed text is formatted: as transcribed, smart lowercase, or all lowercase.

- **Improvements**
  - Transcription results now automatically apply the selected text capitalization preference before saving or pasting.

- **Settings**
  - Settings are updated to remember and restore your chosen text capitalization mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->