### PR TITLE
feat: allow set hotkey double-tap toggle for all hot keys

### DIFF
--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -154,20 +154,18 @@ struct SettingsView: View {
 					}
 				}
 
-				// Double-tap toggle (for key+modifier combinations)
-				if hotKey.key != nil {
-					Label {
-						Toggle("Use double-tap only", isOn: $store.hexSettings.useDoubleTapOnly)
-						Text("Recommended for custom hotkeys to avoid interfering with normal usage")
-							.font(.caption)
-							.foregroundColor(.secondary)
-					} icon: {
-						Image(systemName: "hand.tap")
-					}
+				// Double-tap toggle
+				Label {
+					Toggle("Use double-tap only", isOn: $store.hexSettings.useDoubleTapOnly)
+					Text("Recommended for custom hotkeys to avoid interfering with normal usage")
+						.font(.caption)
+						.foregroundColor(.secondary)
+				} icon: {
+					Image(systemName: "hand.tap")
 				}
 
 				// Minimum key time (for modifier-only shortcuts)
-				if store.hexSettings.hotkey.key == nil {
+				if store.hexSettings.hotkey.key == nil, !store.hexSettings.useDoubleTapOnly {
 					Label {
 						Slider(value: $store.hexSettings.minimumKeyTime, in: 0.0 ... 2.0, step: 0.1) {
 							Text("Ignore below \(store.hexSettings.minimumKeyTime, specifier: "%.1f")s")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX**
  * The “Use double-tap only” toggle is now always visible in the Hot Key section when a hotkey is set, improving discoverability and reducing confusion.
  * The Minimum Key Time slider appears only when no hotkey is assigned and double-tap-only is off, preventing conflicting configurations.
  * Overall, settings visibility is streamlined to better reflect current selections, providing a clearer and more consistent configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->