### PR TITLE
Add UI controls and feature for toggling left/right modifier key preferences: Fix #103

### DIFF
--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -381,7 +381,7 @@ actor RecordingClientLive {
     
     var deviceName: CFString? = nil
     var size = UInt32(MemoryLayout<CFString?>.size)
-    var deviceNamePtr: UnsafeMutableRawPointer = .allocate(byteCount: Int(size), alignment: MemoryLayout<CFString?>.alignment)
+    let deviceNamePtr: UnsafeMutableRawPointer = .allocate(byteCount: Int(size), alignment: MemoryLayout<CFString?>.alignment)
     defer { deviceNamePtr.deallocate() }
     
     let status = AudioObjectGetPropertyData(

--- a/Hex/Features/Settings/SettingsView.swift
+++ b/Hex/Features/Settings/SettingsView.swift
@@ -152,6 +152,17 @@ struct SettingsView: View {
 					.onTapGesture {
 						store.send(.startSettingHotKey)
 					}
+
+					// Modifier side controls - only show when not setting hotkey and has modifiers
+					if !store.isSettingHotKey && !hotKey.modifiers.isEmpty {
+						ModifierSideControls(
+							modifiers: hotKey.modifiers,
+							onUpdateSide: { modifierType, newSide in
+								store.send(.updateModifierSide(modifierType, newSide))
+							}
+						)
+						.transition(.opacity.combined(with: .move(edge: .top)))
+					}
 				}
 
 				// Double-tap toggle (for key+modifier combinations)

--- a/Hex/Features/Transcription/HotKeyProcessor.swift
+++ b/Hex/Features/Transcription/HotKeyProcessor.swift
@@ -201,9 +201,10 @@ extension HotKeyProcessor {
     // MARK: - Helpers
 
     private func chordMatchesHotkey(_ e: KeyEvent) -> Bool {
-        // For hotkeys that include a key, both the key and modifiers must match exactly
+        // For hotkeys that include a key, both the key and modifiers must match
+        // Using the side-aware matching logic
         if hotkey.key != nil {
-            return e.key == hotkey.key && e.modifiers == hotkey.modifiers
+            return e.key == hotkey.key && e.modifiers.matches(hotkey.modifiers)
         } else {
             // For modifier-only hotkeys, we just check that all required modifiers are present
             // This allows other modifiers to be pressed without affecting the match
@@ -228,8 +229,8 @@ extension HotKeyProcessor {
         if hotkey.key != nil {
             // For key+modifier hotkeys, we need to check:
             // 1. Key is released (key == nil)
-            // 2. Modifiers match exactly what was in the hotkey
-            return e.key == nil && e.modifiers == hotkey.modifiers
+            // 2. Modifiers match what was in the hotkey (considering sides)
+            return e.key == nil && e.modifiers.matches(hotkey.modifiers)
         } else {
             // For modifier-only hotkeys, we check:
             // 1. Key is nil

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -137,7 +137,7 @@ private extension TranscriptionFeature {
   /// Effect to start monitoring hotkey events through the `keyEventMonitor`.
   func startHotKeyMonitoringEffect() -> Effect<Action> {
     .run { send in
-      var hotKeyProcessor: HotKeyProcessor = .init(hotkey: HotKey(key: nil, modifiers: [.option]))
+      var hotKeyProcessor: HotKeyProcessor = .init(hotkey: HotKey(key: nil, modifiers: [.option()]))
       @Shared(.isSettingHotKey) var isSettingHotKey: Bool
       @Shared(.hexSettings) var hexSettings: HexSettings
 

--- a/Hex/Models/HexSettings.swift
+++ b/Hex/Models/HexSettings.swift
@@ -5,7 +5,7 @@ import Foundation
 // To add a new setting, add a new property to the struct, the CodingKeys enum, and the custom decoder
 struct HexSettings: Codable, Equatable {
 	var soundEffectsEnabled: Bool = true
-	var hotkey: HotKey = .init(key: nil, modifiers: [.option])
+	var hotkey: HotKey = .init(key: nil, modifiers: [.option()])
 	var openOnLogin: Bool = false
 	var showDockIcon: Bool = true
 	var selectedModel: String = "openai_whisper-large-v3-v20240930"
@@ -41,7 +41,7 @@ struct HexSettings: Codable, Equatable {
 
 	init(
 		soundEffectsEnabled: Bool = true,
-		hotkey: HotKey = .init(key: nil, modifiers: [.option]),
+		hotkey: HotKey = .init(key: nil, modifiers: [.option()]),
 		openOnLogin: Bool = false,
 		showDockIcon: Bool = true,
 		selectedModel: String = "openai_whisper-large-v3-v20240930",
@@ -82,7 +82,7 @@ struct HexSettings: Codable, Equatable {
 			try container.decodeIfPresent(Bool.self, forKey: .soundEffectsEnabled) ?? true
 		hotkey =
 			try container.decodeIfPresent(HotKey.self, forKey: .hotkey)
-				?? .init(key: nil, modifiers: [.option])
+				?? .init(key: nil, modifiers: [.option()])
 		openOnLogin = try container.decodeIfPresent(Bool.self, forKey: .openOnLogin) ?? false
 		showDockIcon = try container.decodeIfPresent(Bool.self, forKey: .showDockIcon) ?? true
 		selectedModel =

--- a/Hex/Models/HotKey.swift
+++ b/Hex/Models/HotKey.swift
@@ -7,33 +7,211 @@
 import Cocoa
 import Sauce
 
+// MARK: - Modifier Side
+public enum ModifierSide: String, Codable, Equatable {
+  case left
+  case right
+  case either
+}
+
+// MARK: - Modifier
 public enum Modifier: Identifiable, Codable, Equatable, Hashable, Comparable {
-  case command
-  case option
-  case shift
-  case control
+  case command(ModifierSide = .either)
+  case option(ModifierSide = .either)
+  case shift(ModifierSide = .either)
+  case control(ModifierSide = .either)
   case fn
 
-  public var id: Self { self }
+  // For backward compatibility during decoding
+  private enum CodingKeys: String, CodingKey {
+    case type, side
+  }
+
+  public enum ModifierType: String, Codable {
+    case command, option, shift, control, fn
+  }
+
+  public init(from decoder: Decoder) throws {
+    // Try to decode as a single value string first (old format)
+    do {
+      let singleValue = try decoder.singleValueContainer()
+      let oldValue = try singleValue.decode(String.self)
+
+      // Handle old format
+      switch oldValue {
+      case "command": self = .command()
+      case "option": self = .option()
+      case "shift": self = .shift()
+      case "control": self = .control()
+      case "fn": self = .fn
+      default:
+        throw DecodingError.dataCorruptedError(
+          in: singleValue,
+          debugDescription: "Unknown modifier: \(oldValue)"
+        )
+      }
+      return
+    } catch {
+      // If single value decode failed, try keyed container (new format)
+    }
+
+    // Handle new format with side information
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(ModifierType.self, forKey: .type)
+    let side = try container.decodeIfPresent(ModifierSide.self, forKey: .side) ?? .either
+
+    switch type {
+    case .command: self = .command(side)
+    case .option: self = .option(side)
+    case .shift: self = .shift(side)
+    case .control: self = .control(side)
+    case .fn: self = .fn
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    // For backward compatibility, encode as simple string when side is .either
+    switch self {
+    case .command(let side) where side == .either:
+      var container = encoder.singleValueContainer()
+      try container.encode("command")
+    case .option(let side) where side == .either:
+      var container = encoder.singleValueContainer()
+      try container.encode("option")
+    case .shift(let side) where side == .either:
+      var container = encoder.singleValueContainer()
+      try container.encode("shift")
+    case .control(let side) where side == .either:
+      var container = encoder.singleValueContainer()
+      try container.encode("control")
+    case .fn:
+      var container = encoder.singleValueContainer()
+      try container.encode("fn")
+    default:
+      // For specific left/right sides, use the new format
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      switch self {
+      case .command(let side):
+        try container.encode(ModifierType.command, forKey: .type)
+        try container.encode(side, forKey: .side)
+      case .option(let side):
+        try container.encode(ModifierType.option, forKey: .type)
+        try container.encode(side, forKey: .side)
+      case .shift(let side):
+        try container.encode(ModifierType.shift, forKey: .type)
+        try container.encode(side, forKey: .side)
+      case .control(let side):
+        try container.encode(ModifierType.control, forKey: .type)
+        try container.encode(side, forKey: .side)
+      case .fn:
+        try container.encode(ModifierType.fn, forKey: .type)
+      }
+    }
+  }
+
+  public var id: String {
+    switch self {
+    case .command(let side): return "command_\(side.rawValue)"
+    case .option(let side): return "option_\(side.rawValue)"
+    case .shift(let side): return "shift_\(side.rawValue)"
+    case .control(let side): return "control_\(side.rawValue)"
+    case .fn: return "fn"
+    }
+  }
+
+  public var baseType: ModifierType {
+    switch self {
+    case .command: return .command
+    case .option: return .option
+    case .shift: return .shift
+    case .control: return .control
+    case .fn: return .fn
+    }
+  }
+
+  public var side: ModifierSide? {
+    switch self {
+    case .command(let side), .option(let side), .shift(let side), .control(let side):
+      return side
+    case .fn:
+      return nil
+    }
+  }
 
   public var stringValue: String {
+    let baseSymbol: String
     switch self {
-    case .option:
-      return "⌥"
-    case .shift:
-      return "⇧"
-    case .command:
-      return "⌘"
-    case .control:
-      return "⌃"
-    case .fn:
-      return "fn"
+    case .option: baseSymbol = "⌥"
+    case .shift: baseSymbol = "⇧"
+    case .command: baseSymbol = "⌘"
+    case .control: baseSymbol = "⌃"
+    case .fn: return "fn"
     }
+
+    // Add L/R prefix for specific sides
+    if let side = self.side, side != .either {
+      return "\(side == .left ? "L" : "R")\(baseSymbol)"
+    }
+    return baseSymbol
+  }
+
+  // For Comparable conformance
+  public static func < (lhs: Modifier, rhs: Modifier) -> Bool {
+    // First compare by base type
+    if lhs.baseType != rhs.baseType {
+      return lhs.baseType.rawValue < rhs.baseType.rawValue
+    }
+    // Then by side (either < left < right)
+    let lhsSide = lhs.side?.rawValue ?? "either"
+    let rhsSide = rhs.side?.rawValue ?? "either"
+    return lhsSide < rhsSide
+  }
+
+  // Check if this modifier matches another (considering sides)
+  public func matches(_ other: Modifier) -> Bool {
+    // Must be same base type
+    guard self.baseType == other.baseType else { return false }
+
+    // Handle fn key (no sides)
+    if case .fn = self { return true }
+
+    // Check side compatibility
+    guard let thisSide = self.side, let otherSide = other.side else { return false }
+
+    // Either matches everything
+    if thisSide == .either || otherSide == .either { return true }
+
+    // Otherwise must be exact match
+    return thisSide == otherSide
   }
 }
 
 public struct Modifiers: Codable, Equatable, ExpressibleByArrayLiteral {
   var modifiers: Set<Modifier>
+
+  // Custom Codable implementation for backward compatibility
+  private enum CodingKeys: String, CodingKey {
+    case modifiers
+  }
+
+  public init(from decoder: Decoder) throws {
+    // First try to decode as a direct array (old format)
+    if let singleContainer = try? decoder.singleValueContainer(),
+       let modifierArray = try? singleContainer.decode([Modifier].self) {
+      self.modifiers = Set(modifierArray)
+    } else {
+      // Otherwise decode as object with modifiers key (new format)
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let modifierArray = try container.decode([Modifier].self, forKey: .modifiers)
+      self.modifiers = Set(modifierArray)
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    // Always encode as a direct array for simplicity and backward compatibility
+    var singleContainer = encoder.singleValueContainer()
+    try singleContainer.encode(Array(modifiers))
+  }
 
   var sorted: [Modifier] {
     // If this is a hyperkey combination (all four modifiers), 
@@ -45,10 +223,10 @@ public struct Modifiers: Codable, Equatable, ExpressibleByArrayLiteral {
   }
   
   public var isHyperkey: Bool {
-    return modifiers.contains(.command) && 
-           modifiers.contains(.option) && 
-           modifiers.contains(.shift) && 
-           modifiers.contains(.control)
+    return containsBaseType(.command) &&
+           containsBaseType(.option) &&
+           containsBaseType(.shift) &&
+           containsBaseType(.control)
   }
 
   public var isEmpty: Bool {
@@ -67,8 +245,54 @@ public struct Modifiers: Codable, Equatable, ExpressibleByArrayLiteral {
     modifiers.contains(modifier)
   }
 
+  // Check if any modifier with the same base type exists
+  public func containsBaseType(_ baseType: Modifier.ModifierType) -> Bool {
+    modifiers.contains { $0.baseType == baseType }
+  }
+
+  // Check if this set matches another considering side compatibility
+  public func matches(_ other: Modifiers) -> Bool {
+    // For each modifier in self, there must be a matching one in other
+    for modifier in modifiers {
+      var found = false
+      for otherModifier in other.modifiers {
+        if modifier.matches(otherModifier) {
+          found = true
+          break
+        }
+      }
+      if !found { return false }
+    }
+
+    // And vice versa - each modifier in other must match one in self
+    for otherModifier in other.modifiers {
+      var found = false
+      for modifier in modifiers {
+        if otherModifier.matches(modifier) {
+          found = true
+          break
+        }
+      }
+      if !found { return false }
+    }
+
+    return true
+  }
+
+  // Check if this is a subset considering side compatibility
   public func isSubset(of other: Modifiers) -> Bool {
-    modifiers.isSubset(of: other.modifiers)
+    // For modifier-only hotkeys, check if all our modifiers match something in other
+    for modifier in modifiers {
+      var found = false
+      for otherModifier in other.modifiers {
+        if modifier.matches(otherModifier) {
+          found = true
+          break
+        }
+      }
+      if !found { return false }
+    }
+    return true
   }
 
   public func isDisjoint(with other: Modifiers) -> Bool {
@@ -85,17 +309,18 @@ public struct Modifiers: Codable, Equatable, ExpressibleByArrayLiteral {
 
   public static func from(cocoa: NSEvent.ModifierFlags) -> Self {
     var modifiers: Set<Modifier> = []
+    // For Cocoa flags, we default to .either since NSEvent doesn't provide side info
     if cocoa.contains(.option) {
-      modifiers.insert(.option)
+      modifiers.insert(.option(.either))
     }
     if cocoa.contains(.shift) {
-      modifiers.insert(.shift)
+      modifiers.insert(.shift(.either))
     }
     if cocoa.contains(.command) {
-      modifiers.insert(.command)
+      modifiers.insert(.command(.either))
     }
     if cocoa.contains(.control) {
-      modifiers.insert(.control)
+      modifiers.insert(.control(.either))
     }
     if cocoa.contains(.function) {
       modifiers.insert(.fn)
@@ -103,13 +328,84 @@ public struct Modifiers: Codable, Equatable, ExpressibleByArrayLiteral {
     return .init(modifiers: modifiers)
   }
 
+  // Device-specific modifier masks from IOKit
+  // These allow us to detect left vs right modifiers
+  private static let NX_DEVICELCTLKEYMASK: UInt64    = 0x00000001
+  private static let NX_DEVICELSHIFTKEYMASK: UInt64  = 0x00000002
+  private static let NX_DEVICERSHIFTKEYMASK: UInt64  = 0x00000004
+  private static let NX_DEVICELCMDKEYMASK: UInt64    = 0x00000008
+  private static let NX_DEVICERCMDKEYMASK: UInt64    = 0x00000010
+  private static let NX_DEVICELALTKEYMASK: UInt64    = 0x00000020
+  private static let NX_DEVICERALTKEYMASK: UInt64    = 0x00000040
+  private static let NX_DEVICERCTLKEYMASK: UInt64    = 0x00002000
+
   public static func from(carbonFlags: CGEventFlags) -> Modifiers {
     var modifiers: Set<Modifier> = []
-    if carbonFlags.contains(.maskShift) { modifiers.insert(.shift) }
-    if carbonFlags.contains(.maskControl) { modifiers.insert(.control) }
-    if carbonFlags.contains(.maskAlternate) { modifiers.insert(.option) }
-    if carbonFlags.contains(.maskCommand) { modifiers.insert(.command) }
-    if carbonFlags.contains(.maskSecondaryFn) { modifiers.insert(.fn) }
+    let rawFlags = carbonFlags.rawValue
+
+    // Check for Shift keys
+    if carbonFlags.contains(.maskShift) {
+      // Try to determine left/right from device-specific flags
+      let hasLeftShift = (rawFlags & NX_DEVICELSHIFTKEYMASK) != 0
+      let hasRightShift = (rawFlags & NX_DEVICERSHIFTKEYMASK) != 0
+
+      if hasLeftShift && !hasRightShift {
+        modifiers.insert(.shift(.left))
+      } else if hasRightShift && !hasLeftShift {
+        modifiers.insert(.shift(.right))
+      } else {
+        // Either both or indeterminate - use either
+        modifiers.insert(.shift(.either))
+      }
+    }
+
+    // Check for Control keys
+    if carbonFlags.contains(.maskControl) {
+      let hasLeftControl = (rawFlags & NX_DEVICELCTLKEYMASK) != 0
+      let hasRightControl = (rawFlags & NX_DEVICERCTLKEYMASK) != 0
+
+      if hasLeftControl && !hasRightControl {
+        modifiers.insert(.control(.left))
+      } else if hasRightControl && !hasLeftControl {
+        modifiers.insert(.control(.right))
+      } else {
+        modifiers.insert(.control(.either))
+      }
+    }
+
+    // Check for Option/Alt keys
+    if carbonFlags.contains(.maskAlternate) {
+      let hasLeftAlt = (rawFlags & NX_DEVICELALTKEYMASK) != 0
+      let hasRightAlt = (rawFlags & NX_DEVICERALTKEYMASK) != 0
+
+      if hasLeftAlt && !hasRightAlt {
+        modifiers.insert(.option(.left))
+      } else if hasRightAlt && !hasLeftAlt {
+        modifiers.insert(.option(.right))
+      } else {
+        modifiers.insert(.option(.either))
+      }
+    }
+
+    // Check for Command keys
+    if carbonFlags.contains(.maskCommand) {
+      let hasLeftCmd = (rawFlags & NX_DEVICELCMDKEYMASK) != 0
+      let hasRightCmd = (rawFlags & NX_DEVICERCMDKEYMASK) != 0
+
+      if hasLeftCmd && !hasRightCmd {
+        modifiers.insert(.command(.left))
+      } else if hasRightCmd && !hasLeftCmd {
+        modifiers.insert(.command(.right))
+      } else {
+        modifiers.insert(.command(.either))
+      }
+    }
+
+    // Check for Function key
+    if carbonFlags.contains(.maskSecondaryFn) {
+      modifiers.insert(.fn)
+    }
+
     return .init(modifiers: modifiers)
   }
 }

--- a/HexTests/HexTests.swift
+++ b/HexTests/HexTests.swift
@@ -18,9 +18,9 @@ struct HexTests {
     @Test
     func pressAndHold_startsRecordingOnHotkey_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
             ]
         )
     }
@@ -28,9 +28,9 @@ struct HexTests {
     @Test
     func pressAndHold_startsRecordingOnHotkey_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
             ]
         )
     }
@@ -39,10 +39,10 @@ struct HexTests {
     @Test
     func pressAndHold_stopsRecordingOnHotkeyRelease_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.command()], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
     }
@@ -50,9 +50,9 @@ struct HexTests {
     @Test
     func pressAndHold_stopsRecordingOnHotkeyRelease_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 ScenarioStep(time: 0.2, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
@@ -61,10 +61,10 @@ struct HexTests {
     @Test
     func pressAndHold_stopsRecordingOnHotkeyRelease_multipleModifiers() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option, .command]),
+            hotkey: HotKey(key: nil, modifiers: [.option(), .command()]),
             steps: [
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: false),
-                ScenarioStep(time: 0.1, key: nil, modifiers: [.option, .command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.option(), .command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 ScenarioStep(time: 0.2, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
@@ -74,12 +74,12 @@ struct HexTests {
     @Test
     func pressAndHold_cancelsOnOtherKeyPress_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
                 // Initial hotkey press
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Different key press within cancel threshold
-                ScenarioStep(time: 0.5, key: .b, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.5, key: .b, modifiers: [.command()], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
     }
@@ -88,12 +88,12 @@ struct HexTests {
     @Test
     func pressAndHold_cancelsOnOtherModifierPress_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // Initial hotkey press (option)
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Press a different modifier within cancel threshold
-                ScenarioStep(time: 0.5, key: nil, modifiers: [.option, .command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.5, key: nil, modifiers: [.option(), .command()], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
     }
@@ -102,12 +102,12 @@ struct HexTests {
     @Test
     func pressAndHold_doesNotCancelAfterThreshold_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
                 // Initial hotkey press
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Different key press after cancel threshold
-                ScenarioStep(time: 1.5, key: .b, modifiers: [.command], expectedOutput: nil, expectedIsMatched: true),
+                ScenarioStep(time: 1.5, key: .b, modifiers: [.command()], expectedOutput: nil, expectedIsMatched: true),
             ]
         )
     }
@@ -115,12 +115,12 @@ struct HexTests {
     @Test
     func pressAndHold_doesNotCancelAfterThreshold_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // Initial hotkey press
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Different modifier press after cancel threshold
-                ScenarioStep(time: 1.5, key: nil, modifiers: [.option, .command], expectedOutput: nil, expectedIsMatched: true),
+                ScenarioStep(time: 1.5, key: nil, modifiers: [.option(), .command()], expectedOutput: nil, expectedIsMatched: true),
             ]
         )
     }
@@ -130,16 +130,16 @@ struct HexTests {
     @Test
     func pressAndHold_doesNotTriggerOnBackslide_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
                 // They press the hotkey with an extra modifier
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command, .shift], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command(), .shift()], expectedOutput: nil, expectedIsMatched: false),
                 // And then release the extra modifier, nothing should happen
-                ScenarioStep(time: 0.1, key: .a, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: .a, modifiers: [.command()], expectedOutput: nil, expectedIsMatched: false),
                 // Then if they release everything, the hotkey should trigger
                 ScenarioStep(time: 0.2, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
                 // And try to press the hotkey again, it should start recording
-                ScenarioStep(time: 0.3, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.3, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
             ]
         )
     }
@@ -148,20 +148,20 @@ struct HexTests {
     @Test
     func doubleTapLock_startsRecordingOnDoubleTap_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
-                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command()], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Release all modifiers
                 ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
                 // Press modifier again
-                ScenarioStep(time: 0.15, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.15, key: nil, modifiers: [.command()], expectedOutput: nil, expectedIsMatched: false),
                 // Second tap within threshold
-                ScenarioStep(time: 0.2, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Second release (should stay recording)
-                ScenarioStep(time: 0.3, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 0.3, key: nil, modifiers: [.command()], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
             ]
         )
     }
@@ -169,14 +169,14 @@ struct HexTests {
     @Test
     func doubleTapLock_startsRecordingOnDoubleTap_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
                 ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap within threshold
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Second release (should stay recording)
                 ScenarioStep(time: 0.3, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
             ]
@@ -186,17 +186,17 @@ struct HexTests {
     @Test
     func doubleTapLock_startsRecordingOnDoubleTap_multipleModifiers() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option, .command]),
+            hotkey: HotKey(key: nil, modifiers: [.option(), .command()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: false),
-                ScenarioStep(time: 0.05, key: nil, modifiers: [.option, .command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.05, key: nil, modifiers: [.option(), .command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
-                ScenarioStep(time: 0.1, key: nil, modifiers: [.option], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.option()], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap within threshold
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.option, .command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option(), .command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Second release (should stay recording)
-                ScenarioStep(time: 0.3, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 0.3, key: nil, modifiers: [.option()], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
             ]
         )
     }
@@ -205,14 +205,14 @@ struct HexTests {
     @Test
     func doubleTapLock_ignoresSlowDoubleTap_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
-                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command()], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap after threshold
-                ScenarioStep(time: 0.4, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.4, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
             ]
         )
     }
@@ -220,14 +220,14 @@ struct HexTests {
     @Test
     func doubleTapLock_ignoresSlowDoubleTap_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
                 ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap after threshold
-                ScenarioStep(time: 0.4, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.4, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
             ]
         )
     }
@@ -236,18 +236,18 @@ struct HexTests {
     @Test
     func doubleTapLock_stopsRecordingOnNextTap_standard() throws {
         runScenario(
-            hotkey: HotKey(key: .a, modifiers: [.command]),
+            hotkey: HotKey(key: .a, modifiers: [.command()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
-                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command()], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap within threshold
-                ScenarioStep(time: 0.2, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: .a, modifiers: [.command()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Second release (should stay recording)
-                ScenarioStep(time: 0.3, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 0.3, key: nil, modifiers: [.command()], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
                 // Third tap to stop recording
-                ScenarioStep(time: 1.0, key: .a, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 1.0, key: .a, modifiers: [.command()], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
     }
@@ -255,18 +255,18 @@ struct HexTests {
     @Test
     func doubleTapLock_stopsRecordingOnNextTap_modifierOnly() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
                 ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap within threshold
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Second release (should stay recording)
                 ScenarioStep(time: 0.3, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
                 // Third tap to stop recording
-                ScenarioStep(time: 1.0, key: nil, modifiers: [.option], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 1.0, key: nil, modifiers: [.option()], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
     }
@@ -278,14 +278,14 @@ struct HexTests {
     @Test
     func pressAndHold_stopsRecordingOnKeyPressAndStaysDirty() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // Initial hotkey press (option)
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Press a different modifier within cancel threshold
-                ScenarioStep(time: 0.1, key: .c, modifiers: [.option], expectedOutput: .stopRecording, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: .c, modifiers: [.option()], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Release the C
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option()], expectedOutput: nil, expectedIsMatched: false),
             ]
         )
     }
@@ -294,14 +294,14 @@ struct HexTests {
     @Test
     func pressAndHold_staysDirtyAfterTwoSeconds() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // Initial hotkey press (option)
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Press command after two seconds
-                ScenarioStep(time: 2.0, key: nil, modifiers: [.option, .command], expectedOutput: nil, expectedIsMatched: true),
+                ScenarioStep(time: 2.0, key: nil, modifiers: [.option(), .command()], expectedOutput: nil, expectedIsMatched: true),
                 // Release command
-                ScenarioStep(time: 2.1, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: true),
+                ScenarioStep(time: 2.1, key: nil, modifiers: [.option()], expectedOutput: nil, expectedIsMatched: true),
                 // Release option
                 ScenarioStep(time: 2.2, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
@@ -312,14 +312,14 @@ struct HexTests {
     @Test
     func doubleTap_onlyLocksAfterSecondRelease() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
                 ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second tap within threshold - should start a new recording but not lock yet
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true, expectedState: .pressAndHold(startTime: Date(timeIntervalSince1970: 0.2))),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true, expectedState: .pressAndHold(startTime: Date(timeIntervalSince1970: 0.2))),
                 // Second release - NOW it should lock
                 ScenarioStep(time: 0.3, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
             ]
@@ -330,16 +330,16 @@ struct HexTests {
     @Test
     func doubleTap_secondTapHeldTooLongBecomesHold() throws {
         runScenario(
-            hotkey: HotKey(key: nil, modifiers: [.option]),
+            hotkey: HotKey(key: nil, modifiers: [.option()]),
             steps: [
                 // First tap
-                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // First release
                 ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
                 // Second press within threshold
-                ScenarioStep(time: 0.2, key: nil, modifiers: [.option], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option()], expectedOutput: .startRecording, expectedIsMatched: true),
                 // Hold for 2 seconds (should stay in press-and-hold mode)
-                ScenarioStep(time: 2.2, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: true),
+                ScenarioStep(time: 2.2, key: nil, modifiers: [.option()], expectedOutput: nil, expectedIsMatched: true),
                 // Release - should stop recording since it was a hold
                 ScenarioStep(time: 2.3, key: nil, modifiers: [], expectedOutput: .stopRecording, expectedIsMatched: false),
             ]

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -238,6 +238,9 @@
     "Downloading model..." : {
 
     },
+    "Either" : {
+
+    },
     "Enable in Settings" : {
 
     },
@@ -334,12 +337,14 @@
     "Input Device" : {
 
     },
+    "Left" : {
+
+    },
     "Maximum History Entries" : {
 
     },
     "Microphone" : {
       "comment" : "Microphone permission.",
-      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -350,9 +355,6 @@
       }
     },
     "Microphone Selection" : {
-
-    },
-    "Microphone!" : {
 
     },
     "Model" : {
@@ -475,6 +477,9 @@
           }
         }
       }
+    },
+    "Right" : {
+
     },
     "Save Transcription History" : {
 


### PR DESCRIPTION
Adds a left/right modifier key detection feature with user-facing controls to let users choose between "Either", "Left", or "Right" for each modifier key in their hotkey configuration.

Key changes:

- Add ModifierSideControls component with segmented pickers in Settings
- Add updateModifierSide action and reducer to SettingsFeature
- Display L/R prefix on hotkey badges when specific sides are selected
- Controls appear below hotkey display when modifiers are present
- Update HotKeyProcessor to use side-aware matching logic
- Maintain full backward compatibility with existing settings

The system automatically detects which physical modifier key was pressed using IOKit device-specific bit masks, and users can now refine these preferences through the Settings UI. When set to "Either", the hotkey will trigger on either the left or right modifier key (default behavior).

<img width="680" height="680" alt="Screenshot 2025-10-20 at 2 19 09 PM" src="https://github.com/user-attachments/assets/bfcb0a2e-d6e4-4727-87d8-3a2b3e007ff1" />

Also includes:
- Update all tests to use new modifier syntax with associated values
- Add localization keys for "Either", "Left", "Right"
- Minor cleanup: change var to let in RecordingClient deviceNamePtr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hotkey configuration now supports left/right modifier key selection, allowing users to specify which side of modifier keys (left, right, or either) are pressed.
  * Added modifier side controls to Settings for configuring keyboard shortcut preferences.

* **Improvements**
  * Enhanced hotkey matching and detection reliability.

* **Localization**
  * Added support for modifier side option labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->