### PR TITLE
Update README with Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Press-and-hold a hotkey to transcribe your voice and paste the result wherever y
 > **Note:** Hex is currently only available for **Apple Silicon** Macs.
 
 Or download via homebrew:
-```
+```bash
 brew install --cask kitlangton-hex
 ```
 


### PR DESCRIPTION
Added installation instructions for Homebrew since it's now available as a cask on homebrew.

The PR to add Hex to homebrew got merged: https://github.com/Homebrew/homebrew-cask/pull/243464#event-21890253748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Hex is currently available only for Apple Silicon Macs.
  * Added Homebrew install instructions (brew install --cask kitlangton-hex) for quick setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->