### PR TITLE
delete token.cancel in handleInputEvent callback from TransacriptionFeature.swift

### DIFF
--- a/Hex/Features/App/AppFeature.swift
+++ b/Hex/Features/App/AppFeature.swift
@@ -202,10 +202,8 @@ struct AppFeature {
       defer { token.cancel() }
 
       await withTaskCancellationHandler {
-        do {
-          try await Task.sleep(nanoseconds: .max)
-        } catch {
-          // Expected on cancellation
+        while !Task.isCancelled {
+          try? await Task.sleep(for: .seconds(60))
         }
       } onCancel: {
         token.cancel()

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -237,13 +237,11 @@ private extension TranscriptionFeature {
         }
       }
 
-      // defer { token.cancel() }
+      defer { token.cancel() }
 
       await withTaskCancellationHandler {
-        do {
-          try await Task.sleep(nanoseconds: .max)
-        } catch {
-          // Cancellation expected
+        while !Task.isCancelled {
+          try? await Task.sleep(for: .seconds(60))
         }
       } onCancel: {
         token.cancel()


### PR DESCRIPTION
# Problem

With build on my mac with "main" branch [2348e8c](https://github.com/kitlangton/Hex/commit/2348e8ced86063dd8fce2b19bf62e7f21dea2c25), 
hotkey is not working. 

My mac is using osx 15.4.1 (24E263)

It seems related to #122

In issue #122, this symptom seems to started in 2025-11. 
And commit added 'token cancel' was tagged with '0.5.0' so time seems to match.


# Trial and error 

I saw symptom, after commenting out below line, hotkey started to working with debug build on my laptop.
  https://github.com/kitlangton/Hex/blame/main/Hex/Features/Transcription/TranscriptionFeature.swift#L240

And that is content of this PR. 


I am nowhere near "know enough" for OSX or Swift or TCA. This was just long trial and error with log added to random places. After long trial and error, when I am preparing for short PR, I stumbled upon #122.  

At least I can now saying hello to 'Hex' and it is injecting text correctly.  






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated task cancellation handling in transcription and application monitoring features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->