### PR TITLE
Fix #122 - 

### DIFF
--- a/Hex/Features/App/AppFeature.swift
+++ b/Hex/Features/App/AppFeature.swift
@@ -202,10 +202,8 @@ struct AppFeature {
       defer { token.cancel() }
 
       await withTaskCancellationHandler {
-        do {
-          try await Task.sleep(nanoseconds: .max)
-        } catch {
-          // Expected on cancellation
+        while !Task.isCancelled {
+          try? await Task.sleep(for: .seconds(60))
         }
       } onCancel: {
         token.cancel()

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -237,13 +237,11 @@ private extension TranscriptionFeature {
         }
       }
 
-      // defer { token.cancel() }
+      defer { token.cancel() }
 
       await withTaskCancellationHandler {
-        do {
-          try await Task.sleep(nanoseconds: .max)
-        } catch {
-          // Cancellation expected
+        while !Task.isCancelled {
+          try? await Task.sleep(for: .seconds(60))
         }
       } onCancel: {
         token.cancel()


### PR DESCRIPTION
#122  stems from a Swift: `Task.sleep(nanoseconds: .max)` **returns immediately instead of sleeping indefinitely**.

### Proof of Issue

```bash
swift -e '
import Foundation

func timestamp() -> String {
  let formatter = DateFormatter()
  formatter.timeStyle = .full
  return formatter.string(from: Date())
}

Task {
  // Task.sleep(for: .seconds(5)) — sleeps normally
  print("=== Task.sleep(for: .seconds(5)) ===")
  print("Before: \(timestamp())")
  try await Task.sleep(for: .seconds(5))
  print("After:  \(timestamp())")

  // Task.sleep(nanoseconds: .max) — returns immediately
  print("\n=== Task.sleep(nanoseconds: .max) ===")
  print("Before: \(timestamp())")
  try await Task.sleep(nanoseconds: .max)
  print("After:  \(timestamp())")
}

RunLoop.main.run()
'
```

**Output:**
=== Task.sleep(for: .seconds(5)) ===
Before: 9:55:53 PM Korean Standard Time
After: 9:55:59 PM Korean Standard Time

=== Task.sleep(nanoseconds: .max) ===
Before: 9:55:59 PM Korean Standard Time
After: 9:55:59 PM Korean Standard Time ← Returns immediately!

**Reference:** https://github.com/swiftlang/swift/issues/80791


### The Problem

Because the sleep returns immediately, the `withTaskCancellationHandler` block exits without waiting for cancellation. Then `defer` block also executed immediately.

### The Solution

Replace the immediate-returning sleep with a polling loop that checks `Task.isCancelled` every 60 seconds, ensuring the cancellation handler is properly invoked when hotkeys are released:

**Before (broken):**
```swift
try await Task.sleep(nanoseconds: .max)
```
After (works):

```swift
while !Task.isCancelled {
  try? await Task.sleep(for: .seconds(60))
}
```
Applied to both AppFeature.swift and TranscriptionFeature.swift.

