### PR TITLE
Fix text insertion on Dvorak-QWERTY hybrid keyboard layout

### DIFF
--- a/.changeset/2910283a.md
+++ b/.changeset/2910283a.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Fix text insertion on Dvorak-QWERTY hybrid keyboard layouts (#162)


### PR DESCRIPTION
## Summary

Fixes #162 - Text insertion was broken on the "Dvorak — QWERTY ⌘" keyboard layout.

The `Cmd+V` paste operation was using `Sauce.shared.keyCode(for: .v)` which returns the layout's V key position. On hybrid layouts like "Dvorak — QWERTY ⌘", this returned the Dvorak V position, but when Command is held, the layout switches to QWERTY positions—causing a mismatch and error beep.

**Fix:** Added detection for hybrid layouts that use QWERTY positions for Command shortcuts. For these layouts, we use the hardcoded QWERTY V key code (9). All other layouts continue using Sauce's layout-aware key code.

## Test plan

- [ ] Test with "Dvorak — QWERTY ⌘" layout: transcription should paste correctly
- [ ] Test with regular Dvorak layout: transcription should still paste correctly
- [ ] Test with QWERTY layout: no regression

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text insertion on Dvorak–QWERTY hybrid keyboard layouts.
  * Improved paste (Cmd+V) handling so paste operations respect the active keyboard layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->