### PR TITLE
Add single-tap toggle recording mode + fix hotkey character leak

### DIFF
--- a/.changeset/50f5fa9e.md
+++ b/.changeset/50f5fa9e.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add single-tap toggle recording mode and fix hotkey character leak on stop

--- a/Hex/Features/Settings/HotKeySectionView.swift
+++ b/Hex/Features/Settings/HotKeySectionView.swift
@@ -40,13 +40,15 @@ struct HotKeySectionView: View {
                 }
             }
 
-            // Double-tap toggle (for key+modifier combinations)
-            if hotKey.key != nil {
-                Label {
-                    Toggle("Use double-tap only", isOn: $store.hexSettings.useDoubleTapOnly)
-                } icon: {
-                    Image(systemName: "hand.tap")
+            // Recording mode picker
+            Label {
+                Picker("Recording mode", selection: $store.hexSettings.recordingMode) {
+                    Text("Single Tap").tag(RecordingMode.singleTap)
+                    Text("Double Tap").tag(RecordingMode.doubleTap)
                 }
+                .pickerStyle(.segmented)
+            } icon: {
+                Image(systemName: "hand.tap")
             }
 
             // Minimum key time (for modifier-only shortcuts)

--- a/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
+++ b/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
@@ -16,7 +16,7 @@ final class HexSettingsMigrationTests: XCTestCase {
 		XCTAssertEqual(decoded.preventSystemSleep, true)
 		XCTAssertEqual(decoded.minimumKeyTime, 0.25)
 		XCTAssertEqual(decoded.copyToClipboard, true)
-		XCTAssertEqual(decoded.useDoubleTapOnly, true)
+		XCTAssertEqual(decoded.recordingMode, .doubleTap)
 		XCTAssertEqual(decoded.outputLanguage, "en")
 		XCTAssertEqual(decoded.selectedMicrophoneID, "builtin:mic")
 		XCTAssertEqual(decoded.saveTranscriptionHistory, false)


### PR DESCRIPTION
## Summary

- Adds a **RecordingMode** enum (`.singleTap` / `.doubleTap`) replacing the `useDoubleTapOnly` boolean
- **Single-tap mode** (new default): tap hotkey once to start recording, tap again to stop — no press-and-hold or double-tap needed
- **Double-tap mode**: preserves existing hold-to-record + double-tap-lock behaviour
- **Fixes hotkey character leak**: when stopping recording with a printable-key hotkey (e.g. `^;`), the character (semicolon) no longer leaks into the active app
- Settings UI: replaces "Use double-tap only" toggle with a "Single Tap / Double Tap" segmented picker, shown for all hotkey types
- Backwards-compatible: old JSON with `useDoubleTapOnly=true` decodes as `.doubleTap`

## Files changed

| File | Change |
|------|--------|
| `HexCore/.../HexSettings.swift` | Add `RecordingMode` enum, replace `useDoubleTapOnly` property, backwards-compat decode |
| `HexCore/.../HotKeyProcessor.swift` | Replace `useDoubleTapOnly` with `recordingMode`, update state machine for toggle mode |
| `Hex/.../TranscriptionFeature.swift` | Sync `recordingMode`, intercept key on `.stopRecording` to prevent character leak |
| `Hex/.../HotKeySectionView.swift` | Replace toggle with segmented picker for all hotkey types |
| `HexCore/.../HotKeyProcessorTests.swift` | 7 new single-tap toggle tests, update existing tests for `recordingMode` param |
| `HexCore/.../HexSettingsMigrationTests.swift` | Update assertion for backwards compat |

## Test plan

- [x] `cd HexCore && swift test` — all 67 tests pass (7 new + 60 existing)
- [ ] Manual: set hotkey to `^;`, verify single-tap starts/stops recording
- [ ] Manual: verify no semicolon leaks into pasted text on stop
- [ ] Manual: ESC cancels toggle recording
- [ ] Manual: switch to "Double Tap" mode → old hold-to-record behaviour works
- [ ] Manual: modifier-only hotkey works in both modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added single-tap toggle option for recording mode; users can now select between Single Tap and Double Tap recording activation methods.

* **Bug Fixes**
  * Fixed hotkey character leak when stopping recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->