### PR TITLE
Add toggle to disable double-tap lock mode

### DIFF
--- a/.changeset/3fff430c.md
+++ b/.changeset/3fff430c.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Add setting to disable double-tap lock for hands-free recording

--- a/Hex/Features/Settings/HotKeySectionView.swift
+++ b/Hex/Features/Settings/HotKeySectionView.swift
@@ -40,12 +40,19 @@ struct HotKeySectionView: View {
                 }
             }
 
-            // Double-tap toggle (for key+modifier combinations)
+            Label {
+                Toggle("Enable double-tap lock", isOn: $store.hexSettings.doubleTapLockEnabled)
+            } icon: {
+                Image(systemName: "hand.tap")
+            }
+
+            // Double-tap only mode applies to key+modifier combinations.
             if hotKey.key != nil {
                 Label {
                     Toggle("Use double-tap only", isOn: $store.hexSettings.useDoubleTapOnly)
+                        .disabled(!store.hexSettings.doubleTapLockEnabled)
                 } icon: {
-                    Image(systemName: "hand.tap")
+                    Image(systemName: "hand.tap.fill")
                 }
             }
 

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -109,6 +109,12 @@ struct SettingsFeature {
     Reduce { state, action in
       switch action {
       case .binding:
+        if !state.hexSettings.doubleTapLockEnabled, state.hexSettings.useDoubleTapOnly {
+          state.$hexSettings.withLock {
+            $0.useDoubleTapOnly = false
+          }
+        }
+
         return .run { _ in
           await MainActor.run {
             NotificationCenter.default.post(name: .updateAppMode, object: nil)

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -173,7 +173,9 @@ private extension TranscriptionFeature {
 
         // Always keep hotKeyProcessor in sync with current user hotkey preference
         hotKeyProcessor.hotkey = hexSettings.hotkey
-        hotKeyProcessor.useDoubleTapOnly = hexSettings.useDoubleTapOnly
+        let useDoubleTapOnly = hexSettings.doubleTapLockEnabled && hexSettings.useDoubleTapOnly
+        hotKeyProcessor.doubleTapLockEnabled = hexSettings.doubleTapLockEnabled
+        hotKeyProcessor.useDoubleTapOnly = useDoubleTapOnly
         hotKeyProcessor.minimumKeyTime = hexSettings.minimumKeyTime
 
         switch inputEvent {
@@ -197,7 +199,7 @@ private extension TranscriptionFeature {
             }
             // If the hotkey is purely modifiers, return false to keep it from interfering with normal usage
             // But if useDoubleTapOnly is true, always intercept the key
-            return hexSettings.useDoubleTapOnly || keyEvent.key != nil
+            return useDoubleTapOnly || keyEvent.key != nil
 
           case .stopRecording:
             Task { await send(.hotKeyReleased) }

--- a/HexCore/Sources/HexCore/Logic/HotKeyProcessor.swift
+++ b/HexCore/Sources/HexCore/Logic/HotKeyProcessor.swift
@@ -97,6 +97,10 @@ public struct HotKeyProcessor {
     /// If true, only double-tap activates recording (press-and-hold disabled)
     /// Only applies to key+modifier hotkeys; modifier-only always allows press-and-hold
     public var useDoubleTapOnly: Bool = false
+
+    /// If false, the quick double-tap lock gesture is disabled.
+    /// Press-and-hold still works normally.
+    public var doubleTapLockEnabled: Bool = true
     
     /// Minimum duration before very quick taps are considered valid
     /// For modifier-only hotkeys, this is overridden to 0.3s minimum
@@ -130,10 +134,17 @@ public struct HotKeyProcessor {
     /// - Parameters:
     ///   - hotkey: The key combination to detect
     ///   - useDoubleTapOnly: If true, disables press-and-hold for key+modifier hotkeys
+    ///   - doubleTapLockEnabled: If false, disables double-tap lock behavior
     ///   - minimumKeyTime: Minimum duration for valid key press (overridden to modifierOnlyMinimumDuration for modifier-only)
-    public init(hotkey: HotKey, useDoubleTapOnly: Bool = false, minimumKeyTime: TimeInterval = HexCoreConstants.defaultMinimumKeyTime) {
+    public init(
+        hotkey: HotKey,
+        useDoubleTapOnly: Bool = false,
+        doubleTapLockEnabled: Bool = true,
+        minimumKeyTime: TimeInterval = HexCoreConstants.defaultMinimumKeyTime
+    ) {
         self.hotkey = hotkey
         self.useDoubleTapOnly = useDoubleTapOnly
+        self.doubleTapLockEnabled = doubleTapLockEnabled
         self.minimumKeyTime = minimumKeyTime
     }
 
@@ -278,6 +289,10 @@ public extension HotKeyProcessor {
 // MARK: - Core Logic
 
 extension HotKeyProcessor {
+    private var isDoubleTapOnlyEnabledForCurrentHotkey: Bool {
+        useDoubleTapOnly && doubleTapLockEnabled && hotkey.key != nil
+    }
+
     /// Handles keyboard events that match the configured hotkey.
     ///
     /// # State Transitions
@@ -296,7 +311,7 @@ extension HotKeyProcessor {
         case .idle:
             // If doubleTapOnly mode is enabled and the hotkey has a key component,
             // we want to delay starting recording until we see the double-tap
-            if useDoubleTapOnly && hotkey.key != nil {
+            if isDoubleTapOnlyEnabledForCurrentHotkey {
                 // Record the timestamp but don't start recording
                 lastTapAt = now
                 return nil
@@ -341,8 +356,8 @@ extension HotKeyProcessor {
         switch state {
         case .idle:
             // Handle double-tap detection for key+modifier combinations
-            if useDoubleTapOnly && hotkey.key != nil && 
-               chordIsFullyReleased(e) && 
+            if isDoubleTapOnlyEnabledForCurrentHotkey &&
+               chordIsFullyReleased(e) &&
                lastTapAt != nil {
                 // If we've seen a tap recently, and now we see a full release, and we're in idle state
                 // Check if the time between taps is within the threshold
@@ -362,7 +377,8 @@ extension HotKeyProcessor {
             // If user truly "released" the chord => either normal stop or doubleTapLock
             if isReleaseForActiveHotkey(e) {
                 // Check if this release is close to the prior release => double-tap lock
-                if let prevReleaseTime = lastTapAt,
+                if doubleTapLockEnabled,
+                   let prevReleaseTime = lastTapAt,
                    now.timeIntervalSince(prevReleaseTime) < Self.doubleTapThreshold
                 {
                     // => Switch to doubleTapLock, remain matched, no new output
@@ -371,7 +387,7 @@ extension HotKeyProcessor {
                 } else {
                     // Normal stop => idle => record the release time
                     state = .idle
-                    lastTapAt = now
+                    lastTapAt = doubleTapLockEnabled ? now : nil
                     return .stopRecording
                 }
             } else {
@@ -408,7 +424,7 @@ extension HotKeyProcessor {
 
         case .doubleTapLock:
             // For key+modifier combinations in doubleTapLock mode, require full key release to stop
-            if useDoubleTapOnly && hotkey.key != nil && chordIsFullyReleased(e) {
+            if isDoubleTapOnlyEnabledForCurrentHotkey && chordIsFullyReleased(e) {
                 resetToIdle()
                 return .stopRecording
             }

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -35,6 +35,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var minimumKeyTime: Double
 	public var copyToClipboard: Bool
 	public var useDoubleTapOnly: Bool
+	public var doubleTapLockEnabled: Bool
 	public var outputLanguage: String?
 	public var selectedMicrophoneID: String?
 	public var saveTranscriptionHistory: Bool
@@ -45,6 +46,12 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var wordRemovalsEnabled: Bool
 	public var wordRemovals: [WordRemoval]
 	public var wordRemappings: [WordRemapping]
+
+	private mutating func normalizeDoubleTapSettings() {
+		if !doubleTapLockEnabled {
+			useDoubleTapOnly = false
+		}
+	}
 
 	public init(
 		soundEffectsEnabled: Bool = true,
@@ -59,6 +66,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		minimumKeyTime: Double = HexCoreConstants.defaultMinimumKeyTime,
 		copyToClipboard: Bool = false,
 		useDoubleTapOnly: Bool = false,
+		doubleTapLockEnabled: Bool = true,
 		outputLanguage: String? = nil,
 		selectedMicrophoneID: String? = nil,
 		saveTranscriptionHistory: Bool = true,
@@ -82,6 +90,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.minimumKeyTime = minimumKeyTime
 		self.copyToClipboard = copyToClipboard
 		self.useDoubleTapOnly = useDoubleTapOnly
+		self.doubleTapLockEnabled = doubleTapLockEnabled
 		self.outputLanguage = outputLanguage
 		self.selectedMicrophoneID = selectedMicrophoneID
 		self.saveTranscriptionHistory = saveTranscriptionHistory
@@ -92,6 +101,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.wordRemovalsEnabled = wordRemovalsEnabled
 		self.wordRemovals = wordRemovals
 		self.wordRemappings = wordRemappings
+		normalizeDoubleTapSettings()
 	}
 
 	public init(from decoder: Decoder) throws {
@@ -100,6 +110,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		for field in HexSettingsSchema.fields {
 			try field.decode(into: &self, from: container)
 		}
+		normalizeDoubleTapSettings()
 	}
 
 	public func encode(to encoder: Encoder) throws {
@@ -126,6 +137,7 @@ private enum HexSettingKey: String, CodingKey, CaseIterable {
 	case minimumKeyTime
 	case copyToClipboard
 	case useDoubleTapOnly
+	case doubleTapLockEnabled
 	case outputLanguage
 	case selectedMicrophoneID
 	case saveTranscriptionHistory
@@ -221,6 +233,7 @@ private enum HexSettingsSchema {
 		SettingsField(.minimumKeyTime, keyPath: \.minimumKeyTime, default: defaults.minimumKeyTime).eraseToAny(),
 		SettingsField(.copyToClipboard, keyPath: \.copyToClipboard, default: defaults.copyToClipboard).eraseToAny(),
 		SettingsField(.useDoubleTapOnly, keyPath: \.useDoubleTapOnly, default: defaults.useDoubleTapOnly).eraseToAny(),
+		SettingsField(.doubleTapLockEnabled, keyPath: \.doubleTapLockEnabled, default: defaults.doubleTapLockEnabled).eraseToAny(),
 		SettingsField(
 			.outputLanguage,
 			keyPath: \.outputLanguage,

--- a/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
+++ b/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
@@ -17,6 +17,7 @@ final class HexSettingsMigrationTests: XCTestCase {
 		XCTAssertEqual(decoded.minimumKeyTime, 0.25)
 		XCTAssertEqual(decoded.copyToClipboard, true)
 		XCTAssertEqual(decoded.useDoubleTapOnly, true)
+		XCTAssertEqual(decoded.doubleTapLockEnabled, true)
 		XCTAssertEqual(decoded.outputLanguage, "en")
 		XCTAssertEqual(decoded.selectedMicrophoneID, "builtin:mic")
 		XCTAssertEqual(decoded.saveTranscriptionHistory, false)
@@ -29,6 +30,36 @@ final class HexSettingsMigrationTests: XCTestCase {
 		let settings = HexSettings()
 		let data = try JSONEncoder().encode(settings)
 		let decoded = try JSONDecoder().decode(HexSettings.self, from: data)
+		XCTAssertEqual(decoded, settings)
+	}
+
+	func testInitNormalizesDoubleTapOnlyWhenLockDisabled() {
+		let settings = HexSettings(useDoubleTapOnly: true, doubleTapLockEnabled: false)
+
+		XCTAssertFalse(settings.useDoubleTapOnly)
+		XCTAssertFalse(settings.doubleTapLockEnabled)
+	}
+
+	func testDecodeNormalizesDoubleTapOnlyWhenLockDisabled() throws {
+		let payload = "{\"useDoubleTapOnly\":true,\"doubleTapLockEnabled\":false}"
+		guard let data = payload.data(using: .utf8) else {
+			XCTFail("Failed to encode JSON payload")
+			return
+		}
+
+		let decoded = try JSONDecoder().decode(HexSettings.self, from: data)
+
+		XCTAssertFalse(decoded.useDoubleTapOnly)
+		XCTAssertFalse(decoded.doubleTapLockEnabled)
+	}
+
+	func testEncodeDecodeRoundTripPreservesNormalizedDoubleTapValues() throws {
+		let settings = HexSettings(useDoubleTapOnly: true, doubleTapLockEnabled: false)
+		let data = try JSONEncoder().encode(settings)
+		let decoded = try JSONDecoder().decode(HexSettings.self, from: data)
+
+		XCTAssertFalse(settings.useDoubleTapOnly)
+		XCTAssertFalse(decoded.useDoubleTapOnly)
 		XCTAssertEqual(decoded, settings)
 	}
 

--- a/HexCore/Tests/HexCoreTests/HotKeyProcessorTests.swift
+++ b/HexCore/Tests/HexCoreTests/HotKeyProcessorTests.swift
@@ -288,6 +288,41 @@ struct HotKeyProcessorTests {
         )
     }
 
+    @Test
+    func doubleTapLock_disabled_staysPressAndHold_standard() throws {
+        runScenario(
+            hotkey: HotKey(key: .a, modifiers: [.command]),
+            doubleTapLockEnabled: false,
+            steps: [
+                // First tap
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                // First release
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+                // Release all modifiers
+                ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
+                // Press modifier again
+                ScenarioStep(time: 0.15, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                // Second tap within threshold
+                ScenarioStep(time: 0.2, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                // Second release should stop normally (no lock)
+                ScenarioStep(time: 0.3, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false, expectedState: .idle),
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_ignoredWhenDoubleTapLockDisabled() throws {
+        runScenario(
+            hotkey: HotKey(key: .a, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            doubleTapLockEnabled: false,
+            steps: [
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false),
+            ]
+        )
+    }
+
     // MARK: - Edge Cases
 
     // Tests that after pressing a key with option, releasing the key but keeping option pressed
@@ -603,6 +638,8 @@ struct ScenarioStep {
 
 func runScenario(
     hotkey: HotKey,
+    useDoubleTapOnly: Bool = false,
+    doubleTapLockEnabled: Bool = true,
     steps: [ScenarioStep]
 ) {
     // Sort steps by time, just in case they're not in ascending order
@@ -615,7 +652,11 @@ func runScenario(
     var processor = withDependencies {
         $0.date.now = Date(timeIntervalSince1970: currentTime)
     } operation: {
-        HotKeyProcessor(hotkey: hotkey)
+        HotKeyProcessor(
+            hotkey: hotkey,
+            useDoubleTapOnly: useDoubleTapOnly,
+            doubleTapLockEnabled: doubleTapLockEnabled
+        )
     }
 
     // We'll step through each event


### PR DESCRIPTION
## Summary
- add a Hot Key setting to enable or disable double-tap lock
- wire the new setting through transcription hotkey handling and `HotKeyProcessor` so disabled lock keeps press-and-hold behavior
- normalize decoded/initialized settings so `useDoubleTapOnly` cannot persist while lock is disabled
- add regression tests for lock-disabled behavior and settings normalization, and include a patch changeset

## Testing
- `cd HexCore && swift test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **New Settings**: Added "Enable double-tap lock" toggle to control the double-tap gesture for hands-free recording.
* **Related Setting**: Added "Use double-tap only" toggle that works conditionally with the double-tap lock feature.
* **Settings Validation**: Automatically disables "Use double-tap only" when double-tap lock is disabled to maintain consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->