### PR TITLE
Improve changelog sheet dismissal controls

### DIFF
--- a/.changeset/40f4ab66.md
+++ b/.changeset/40f4ab66.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Improve changelog sheet dismissal by adding a persistent top Close control while keeping the bottom Close button

--- a/Hex/Features/Settings/AboutView.swift
+++ b/Hex/Features/Settings/AboutView.swift
@@ -31,7 +31,9 @@ struct AboutView: View {
                     .sheet(isPresented: $showingChangelog, onDismiss: {
                         showingChangelog = false
                     }) {
-                        ChangelogView()
+                        NavigationStack {
+                            ChangelogView()
+                        }
                     }
                 }
                 HStack {

--- a/Hex/Features/Settings/ChangelogView.swift
+++ b/Hex/Features/Settings/ChangelogView.swift
@@ -9,10 +9,6 @@ struct ChangelogView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
-                Text("Changelog")
-                    .font(.title)
-                    .padding(.bottom, 10)
-
                 if let changelogPath = Bundle.main.path(forResource: "changelog", ofType: "md"),
                     let changelogContent = try? String(
                         contentsOfFile: changelogPath, encoding: .utf8)
@@ -32,6 +28,14 @@ struct ChangelogView: View {
                 .padding(.top, 20)
             }
             .padding()
+        }
+        .navigationTitle("Changelog")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close") {
+                    dismiss()
+                }
+            }
         }
         .enableInjection()
     }


### PR DESCRIPTION
Adds a persistent top Close control to the changelog sheet while keeping the existing bottom Close button, so users can dismiss long changelog content without scrolling to the end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog view navigation by adding a persistent Close button at the top of the sheet, making it easier to dismiss while maintaining the existing bottom Close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->