### PR TITLE
Fix Option key special characters leaking through on hotkey events

### DIFF
--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -203,7 +203,7 @@ private extension TranscriptionFeature {
 
           case .stopRecording:
             Task { await send(.hotKeyReleased) }
-            return false // or `true` if you want to intercept
+            return true // Intercept to prevent Option key from printing special characters
 
           case .cancel:
             Task { await send(.cancel) }
@@ -217,7 +217,7 @@ private extension TranscriptionFeature {
             // If we detect repeated same chord, maybe intercept.
             if let pressedKey = keyEvent.key,
                pressedKey == hotKeyProcessor.hotkey.key,
-               keyEvent.modifiers == hotKeyProcessor.hotkey.modifiers
+               keyEvent.modifiers.matchesExactly(hotKeyProcessor.hotkey.modifiers)
             {
               return true
             }


### PR DESCRIPTION
### Problem
When using an Option-based hotkey (e.g. ⌥A), macOS would print special
characters like å or © in two scenarios:

1. **Key repeat (autorepeat):** While holding the hotkey, repeated keyDown
   events were compared using == on Modifiers instead of matchesExactly.
   Since the hotkey stores side: .either but the incoming event has side: .left,
   the sets were not equal — the event wasn't consumed and the special
   character leaked through.

2. **Double-tap lock stop:** When pressing the hotkey to stop a double-tap
   lock recording session, the handler returned false, not consuming the
   event — causing one extra special character to be printed.

### Fix
- In TranscriptionFeature.swift, the .none case: replace
  `keyEvent.modifiers == hotKeyProcessor.hotkey.modifiers` with
  `keyEvent.modifiers.matchesExactly(hotKeyProcessor.hotkey.modifiers)`
  to correctly handle side (.either vs .left/.right) comparison during key repeat.

- In TranscriptionFeature.swift, the .stopRecording case: return true
  instead of false to consume the event when stopping double-tap lock recording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hotkey handling during recording to prevent unintended character input from modifier keys.
  * Improved modifier key detection for more precise hotkey recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->