### PR TITLE
Fix: prevent hotkey twitches from cancelling in-progress transcriptions

### DIFF
--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -96,8 +96,8 @@ struct TranscriptionFeature {
       // MARK: - HotKey Flow
 
       case .hotKeyPressed:
-        // If we're transcribing, send a cancel first. Otherwise start recording immediately.
-        // We'll decide later (on release) whether to keep or discard the recording.
+        // If transcribing, ignore this press (protects against finger twitches).
+        // Otherwise start recording — we'll decide on release whether to keep or discard.
         return handleHotKeyPressed(isTranscribing: state.isTranscribing)
 
       case .hotKeyReleased:
@@ -262,10 +262,14 @@ private extension TranscriptionFeature {
 
 private extension TranscriptionFeature {
   func handleHotKeyPressed(isTranscribing: Bool) -> Effect<Action> {
-    // If already transcribing, cancel first. Otherwise start recording immediately.
-    let maybeCancel = isTranscribing ? Effect.send(Action.cancel) : .none
-    let startRecording = Effect.send(Action.startRecording)
-    return .merge(maybeCancel, startRecording)
+    // If already transcribing, ignore the hotkey press entirely.
+    // This prevents finger twitches after releasing the hold-to-record
+    // hotkey from cancelling an in-progress transcription.
+    // The user can still cancel explicitly with ESC if needed.
+    if isTranscribing {
+      return .none
+    }
+    return .send(.startRecording)
   }
 
   func handleHotKeyReleased(isRecording: Bool) -> Effect<Action> {


### PR DESCRIPTION
## Problem

When using hold-to-record mode (e.g. Cmd+Option), releasing the modifier keys stops recording and begins transcription. However, involuntary finger twitches — re-pressing one or both modifier keys within milliseconds of release — trigger `handleHotKeyPressed` while `isTranscribing` is already `true`.

The previous implementation responded by merging `Effect.send(.cancel)` with `Effect.send(.startRecording)`, which killed the active transcription and started a new (empty) recording. This caused users to lose their entire dictation with no warning.

## Root Cause

In `TranscriptionFeature.swift`, `handleHotKeyPressed` always started a new recording, and additionally cancelled any in-progress transcription first:

```swift
// Before
func handleHotKeyPressed(isTranscribing: Bool) -> Effect<Action> {
    let maybeCancel = isTranscribing ? Effect.send(Action.cancel) : .none
    let startRecording = Effect.send(Action.startRecording)
    return .merge(maybeCancel, startRecording)
}
```

The `.merge(.cancel, .startRecording)` path was reachable any time a hotkey press arrived during transcription — including accidental re-presses immediately after releasing the hold-to-record key.

## Fix

When `isTranscribing` is `true`, the hotkey press is now a no-op. The transcription completes uninterrupted regardless of any subsequent modifier key activity. Users can still cancel explicitly via ESC.

```swift
// After
func handleHotKeyPressed(isTranscribing: Bool) -> Effect<Action> {
    if isTranscribing { return .none }
    return .send(.startRecording)
}
```

Also updates the inline comment at the `.hotKeyPressed` case to accurately describe the new behavior.

## Impact

- Eliminates lost transcriptions caused by accidental hotkey re-presses
- No change to intentional workflows — ESC still cancels, and new recordings start normally when no transcription is active
- Minimal, self-contained change (one function + one comment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotkey handling to prevent accidental transcription cancellations when the hotkey is pressed during an active transcription session. Hotkey now only starts recording when not currently transcribing, and stops recording when released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->