### PR TITLE
Avoid priming sound effects when disabled

### DIFF
--- a/.changeset/silent-lamps-prove.md
+++ b/.changeset/silent-lamps-prove.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Stop priming the sound-effects audio engine when sound effects are disabled so Hex avoids unnecessary background audio activity and sleep assertions (#200).

--- a/Hex/App/HexAppDelegate.swift
+++ b/Hex/App/HexAppDelegate.swift
@@ -26,6 +26,7 @@ class HexAppDelegate: NSObject, NSApplicationDelegate {
 
 		Task {
 			await soundEffect.preloadSounds()
+			await soundEffect.setEnabled(hexSettings.soundEffectsEnabled)
 		}
 		launchedAtLogin = wasLaunchedAtLogin()
 		appLogger.info("Application did finish launching")

--- a/Hex/Clients/SoundEffect.swift
+++ b/Hex/Clients/SoundEffect.swift
@@ -77,20 +77,19 @@ actor SoundEffectsClientLive {
   private var playerNodes: [SoundEffect: AVAudioPlayerNode] = [:]
   private var audioBuffers: [SoundEffect: AVAudioPCMBuffer] = [:]
   private var isEngineRunning = false
-  private var soundEffectsEnabled = HexSettings().soundEffectsEnabled
 
   func play(_ soundEffect: SoundEffect) {
-	guard soundEffectsEnabled else { return }
-	guard let player = playerNodes[soundEffect], let buffer = audioBuffers[soundEffect] else {
-		logger.error("Requested sound \(soundEffect.rawValue) not preloaded")
-		return
-	}
-	prepareEngineIfNeeded()
-	let clampedVolume = min(max(hexSettings.soundEffectsVolume, 0), baselineVolume)
-	player.volume = Float(clampedVolume)
-	player.stop()
-	player.scheduleBuffer(buffer, at: nil, options: [], completionHandler: nil)
-	player.play()
+    guard hexSettings.soundEffectsEnabled else { return }
+    guard let player = playerNodes[soundEffect], let buffer = audioBuffers[soundEffect] else {
+      logger.error("Requested sound \(soundEffect.rawValue) not preloaded")
+      return
+    }
+    prepareEngineIfNeeded()
+    let clampedVolume = min(max(hexSettings.soundEffectsVolume, 0), baselineVolume)
+    player.volume = Float(clampedVolume)
+    player.stop()
+    player.scheduleBuffer(buffer, at: nil, options: [], completionHandler: nil)
+    player.play()
   }
 
   func stop(_ soundEffect: SoundEffect) {
@@ -111,11 +110,10 @@ actor SoundEffectsClientLive {
     isSetup = true
   }
 
-  func setEnabled(_ enabled: Bool) async {
-    soundEffectsEnabled = enabled
+  func setEnabled(_: Bool) async {
     await preloadSounds()
 
-    if enabled {
+    if hexSettings.soundEffectsEnabled {
       prepareEngineIfNeeded()
     } else {
       stopAll()

--- a/Hex/Clients/SoundEffect.swift
+++ b/Hex/Clients/SoundEffect.swift
@@ -35,6 +35,7 @@ public struct SoundEffectsClient {
   public var stop: @Sendable (SoundEffect) -> Void
   public var stopAll: @Sendable () -> Void
   public var preloadSounds: @Sendable () async -> Void
+  public var setEnabled: @Sendable (Bool) async -> Void
 }
 
 extension SoundEffectsClient: DependencyKey {
@@ -52,6 +53,9 @@ extension SoundEffectsClient: DependencyKey {
       },
       preloadSounds: {
         await live.preloadSounds()
+      },
+      setEnabled: { enabled in
+        await live.setEnabled(enabled)
       }
     )
   }
@@ -73,9 +77,10 @@ actor SoundEffectsClientLive {
   private var playerNodes: [SoundEffect: AVAudioPlayerNode] = [:]
   private var audioBuffers: [SoundEffect: AVAudioPCMBuffer] = [:]
   private var isEngineRunning = false
+  private var soundEffectsEnabled = HexSettings().soundEffectsEnabled
 
   func play(_ soundEffect: SoundEffect) {
-	guard hexSettings.soundEffectsEnabled else { return }
+	guard soundEffectsEnabled else { return }
 	guard let player = playerNodes[soundEffect], let buffer = audioBuffers[soundEffect] else {
 		logger.error("Requested sound \(soundEffect.rawValue) not preloaded")
 		return
@@ -102,9 +107,20 @@ actor SoundEffectsClientLive {
     for soundEffect in SoundEffect.allCases {
       loadSound(soundEffect)
     }
-    prepareEngineIfNeeded()
 
     isSetup = true
+  }
+
+  func setEnabled(_ enabled: Bool) async {
+    soundEffectsEnabled = enabled
+    await preloadSounds()
+
+    if enabled {
+      prepareEngineIfNeeded()
+    } else {
+      stopAll()
+      stopEngineIfNeeded()
+    }
   }
 
   private var isSetup = false
@@ -136,6 +152,7 @@ actor SoundEffectsClientLive {
       logger.error("Failed to load sound \(soundEffect.rawValue): \(error.localizedDescription)")
     }
   }
+
   private func prepareEngineIfNeeded() {
     if !isEngineRunning || !engine.isRunning {
       engine.prepare()
@@ -149,5 +166,19 @@ actor SoundEffectsClientLive {
         logger.error("Failed to start AVAudioEngine: \(error.localizedDescription)")
       }
     }
+  }
+
+  private func stopEngineIfNeeded() {
+    guard isEngineRunning || engine.isRunning else { return }
+    engine.stop()
+    isEngineRunning = false
+  }
+
+  deinit {
+    playerNodes.values.forEach {
+      $0.stop()
+      engine.detach($0)
+    }
+    engine.stop()
   }
 }

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -120,6 +120,7 @@ struct SettingsFeature {
   @Dependency(\.transcription) var transcription
   @Dependency(\.recording) var recording
   @Dependency(\.permissions) var permissions
+  @Dependency(\.soundEffects) var soundEffects
   @Dependency(\.transcriptPersistence) var transcriptPersistence
 
   private func deleteAudioEffect(for transcripts: [Transcript]) -> Effect<Action> {
@@ -499,7 +500,9 @@ struct SettingsFeature {
 
       case let .setSoundEffectsEnabled(enabled):
         state.$hexSettings.withLock { $0.soundEffectsEnabled = enabled }
-        return .none
+        return .run { _ in
+          await soundEffects.setEnabled(enabled)
+        }
 
       case let .setSoundEffectsVolume(volume):
         state.$hexSettings.withLock { $0.soundEffectsVolume = volume }


### PR DESCRIPTION
## Summary
- stop starting the sound-effects AVAudioEngine during preload
- prime the engine only when sound effects are enabled
- stop the engine again if the setting is toggled off

## Why
Hex currently launches its sound-effects AVAudioEngine even when `soundEffectsEnabled` is false. In runtime checks, that keeps an unnecessary Core Audio output sleep assertion alive for the app lifetime.

This keeps the low-latency path for users who want sound effects, while removing the background audio cost for users who have them disabled.

## Validation
- `cd HexCore && swift test`
- `xcodebuild -scheme Hex -configuration Release CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -scheme Hex -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- runtime check: patched debug app launched with sound effects disabled did not create a new audio-out sleep assertion

## Note
- `xcodebuild test -scheme Hex CODE_SIGNING_ALLOWED=NO` still fails in the current repo because `HexTests` resolves `TEST_HOST` to `Hex.app` while Debug builds produce `Hex Debug.app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sound effects engine no longer initializes when sound effects are disabled, preventing unwanted background audio and reducing resource use.
* **Behavior Change**
  * Toggling sound effects in Settings now applies immediately — enabling preloads and starts audio, disabling stops audio right away.
* **Chores**
  * Patch release entry added for the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->