### PR TITLE
Fix silent recording when video conferencing apps change audio device format

### DIFF
--- a/.changeset/1310b767.md
+++ b/.changeset/1310b767.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Fix recording stopping when video conferencing apps (FaceTime, Zoom, Meet) change the audio device format

--- a/.changeset/1310b767.md
+++ b/.changeset/1310b767.md
@@ -2,4 +2,4 @@
 "hex-app": patch
 ---
 
-Fix recording stopping when video conferencing apps (FaceTime, Zoom, Meet) change the audio device format
+Fix silent recording when video conferencing apps (FaceTime, Zoom, Meet) change the audio device format (#211)

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -493,6 +493,10 @@ actor RecordingClientLive {
       reason: "audio-devices-changed"
     )
 
+    captureController.onConfigurationChange = { [weak self] in
+      Task { await self?.enqueueCaptureEnvironmentChange(reason: "engine-config-changed", forceRestart: true) }
+    }
+
     recordingLogger.notice("Installed recording environment observers")
   }
 

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -110,7 +110,10 @@ final class SuperFastCaptureController {
     interleaved: false
   )!
 
+  var onConfigurationChange: (() -> Void)?
+
   private var engine: AVAudioEngine?
+  private var engineConfigObserver: NSObjectProtocol?
   private var converter: AVAudioConverter?
   private var activeRecording: ActiveRecording?
   private var keepWarmBuffer = false
@@ -195,6 +198,17 @@ final class SuperFastCaptureController {
     engine.prepare()
     try engine.start()
     self.engine = engine
+
+    // AVAudioEngine stops itself when the I/O format changes (e.g. a video call app
+    // renegotiates the device sample rate). Observe the notification so we can restart.
+    engineConfigObserver = NotificationCenter.default.addObserver(
+      forName: .AVAudioEngineConfigurationChange,
+      object: engine,
+      queue: .main
+    ) { [weak self] _ in
+      self?.onConfigurationChange?()
+    }
+
     logger.notice(
       "Capture engine armed reason=\(reason) sampleRate=\(String(format: "%.0f", inputFormat.sampleRate))Hz ringBuffer=\(String(format: "%.2f", SuperFastCaptureConstants.ringBufferDuration))s defaultPreRoll=\(String(format: "%.2f", SuperFastCaptureConstants.defaultPreRollDuration))s"
     )
@@ -203,6 +217,10 @@ final class SuperFastCaptureController {
   func stop(reason: String = "unknown") {
     if engine != nil {
       logger.notice("Capture engine stopped reason=\(reason)")
+    }
+    if let observer = engineConfigObserver {
+      NotificationCenter.default.removeObserver(observer)
+      engineConfigObserver = nil
     }
     if let inputNode = engine?.inputNode {
       inputNode.removeTap(onBus: 0)

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -110,7 +110,10 @@ final class SuperFastCaptureController {
     interleaved: false
   )!
 
-  var onConfigurationChange: (() -> Void)?
+  // Written once from RecordingClientLive.startObservingSystemChanges() before any notification
+  // can fire; read only on the main queue inside the NotificationCenter callback. No real-world
+  // race, but marked nonisolated(unsafe) to make the threading contract explicit.
+  nonisolated(unsafe) var onConfigurationChange: (() -> Void)?
 
   private var engine: AVAudioEngine?
   private var engineConfigObserver: NSObjectProtocol?
@@ -191,6 +194,8 @@ final class SuperFastCaptureController {
     // When another app (e.g. FaceTime) changes the input device to multi-channel (e.g. 3-channel),
     // AVAudioConverter has no layout info to downmix to mono and silently produces silence.
     // Explicitly take channel 0 (the primary mic capsule) to avoid this.
+    // Trade-off: for stereo built-in mics, Apple's default mix (L*0.707 + R*0.707) gives slightly
+    // better off-axis pickup than channel 0 alone. Acceptable given that the alternative is silence.
     if inputFormat.channelCount > 1 {
       converter.channelMap = [0]
     }
@@ -222,7 +227,7 @@ final class SuperFastCaptureController {
 
   func stop(reason: String = "unknown") {
     if engine != nil {
-      logger.notice("Capture engine stopped reason=\(reason)")
+      logger.notice("Capture engine stopped reason=\(reason, privacy: .public)")
     }
     if let observer = engineConfigObserver {
       NotificationCenter.default.removeObserver(observer)
@@ -324,7 +329,8 @@ final class SuperFastCaptureController {
           let samples = converted.floatChannelData?[0]
     else {
       if activeRecording != nil {
-        logger.warning("Buffer dropped during active recording — convert returned nil or empty frames")
+        // Transient drops are expected during an engine format change / restart; use debug not warning.
+        logger.debug("Buffer dropped during active recording — convert returned nil or empty frames")
       }
       return
     }

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -188,6 +188,12 @@ final class SuperFastCaptureController {
       )
     }
 
+    // When another app (e.g. FaceTime) changes the input device to multi-channel (e.g. 3-channel),
+    // AVAudioConverter has no layout info to downmix to mono and silently produces silence.
+    // Explicitly take channel 0 (the primary mic capsule) to avoid this.
+    if inputFormat.channelCount > 1 {
+      converter.channelMap = [0]
+    }
     self.converter = converter
 
     inputNode.installTap(onBus: 0, bufferSize: SuperFastCaptureConstants.tapBufferSize, format: inputFormat) {
@@ -210,7 +216,7 @@ final class SuperFastCaptureController {
     }
 
     logger.notice(
-      "Capture engine armed reason=\(reason) sampleRate=\(String(format: "%.0f", inputFormat.sampleRate))Hz ringBuffer=\(String(format: "%.2f", SuperFastCaptureConstants.ringBufferDuration))s defaultPreRoll=\(String(format: "%.2f", SuperFastCaptureConstants.defaultPreRollDuration))s"
+      "Capture engine armed reason=\(reason, privacy: .public) sampleRate=\(String(format: "%.0f", inputFormat.sampleRate), privacy: .public)Hz channelCount=\(inputFormat.channelCount, privacy: .public) ringBuffer=\(String(format: "%.2f", SuperFastCaptureConstants.ringBufferDuration), privacy: .public)s defaultPreRoll=\(String(format: "%.2f", SuperFastCaptureConstants.defaultPreRollDuration), privacy: .public)s"
     )
   }
 
@@ -317,6 +323,9 @@ final class SuperFastCaptureController {
           converted.frameLength > 0,
           let samples = converted.floatChannelData?[0]
     else {
+      if activeRecording != nil {
+        logger.warning("Buffer dropped during active recording — convert returned nil or empty frames")
+      }
       return
     }
 
@@ -332,8 +341,10 @@ final class SuperFastCaptureController {
     guard var recording = activeRecording else { return }
     if !recording.didLogFirstBuffer {
       let timeToFirstBuffer = Date().timeIntervalSince(recording.requestedAt)
+      var peak: Float = 0
+      for i in 0 ..< sampleCount { peak = max(peak, abs(samples[i])) }
       logger.notice(
-        "Capture engine first buffer latency=\(String(format: "%.3f", timeToFirstBuffer))s prepended=\(String(format: "%.3f", recording.prependedDuration))s frames=\(sampleCount)"
+        "Capture engine first buffer latency=\(String(format: "%.3f", timeToFirstBuffer), privacy: .public)s prepended=\(String(format: "%.3f", recording.prependedDuration), privacy: .public)s frames=\(sampleCount, privacy: .public) peakAmplitude=\(String(format: "%.6f", peak), privacy: .public)"
       )
       recording.didLogFirstBuffer = true
       activeRecording = recording


### PR DESCRIPTION
## Problem

When FaceTime, Zoom, Google Meet, or any video conferencing app is in an active call, Hex records successfully (the indicator appears, the engine runs, buffers arrive) but transcription always produces an empty result. This is the same root cause as the Scarlett 2i2 silence reported in #204 — both are multichannel input devices.

## Root cause

Two distinct failure modes were found via diagnostic logging:

**1. Multichannel input device active when Hex starts or restarts** (fixes #204)

FaceTime switches the system default input device to a **3-channel 48 kHz format** for its echo-cancellation pipeline. Multichannel USB interfaces like the Scarlett 2i2 also present as multi-channel. When `AVAudioEngine` reads `inputNode.inputFormat(forBus: 0)` and creates an `AVAudioConverter` from that multi-channel format to 1-channel 16 kHz, the converter has no channel layout information to guide the downmix and silently produces all-zero samples. Every buffer is written correctly, but every sample is `0.0`.

Confirmed via log: `sampleRate=48000Hz channelCount=3` → `peakAmplitude=0.000000`.

**2. Video call starts after Hex is already armed**

`AVAudioEngine` detects the format change and stops itself, posting `AVAudioEngineConfigurationChangeNotification`. Hex was not observing this notification, so the engine stayed dead for the rest of the session with no error surfaced.

## Fix

**For issue 1** (`SuperFastCaptureController.swift`): when the input device has more than one channel, set `converter.channelMap = [0]` to explicitly route the primary mic capsule (channel 0) to the mono output. This bypasses the broken implicit downmix and works regardless of how many channels the device presents.

Note: for stereo built-in mics, Apple's default coefficient mix (L×0.707 + R×0.707) gives slightly better off-axis pickup than channel 0 alone — this is an accepted tradeoff given that the alternative is silence.

**For issue 2** (`SuperFastCaptureController.swift` + `RecordingClient.swift`): subscribe to `AVAudioEngineConfigurationChangeNotification` scoped to the specific engine instance. On notification, fire an `onConfigurationChange` callback wired into `RecordingClient`'s existing `enqueueCaptureEnvironmentChange` pipeline — which already handles safe restart, mid-recording deferral, and device re-selection.

## Scope

The channel map fix applies to any app or device that presents the system input as multi-channel — not just FaceTime. Confirmed affected: FaceTime (3-channel virtual device), Scarlett 2i2 (multichannel USB interface, reported in #204), and likely Zoom/Meet/Teams which do the same HAL-level format negotiation.

## Testing

- Reproduced on macOS 15 (Apple Silicon) with FaceTime active
- Confirmed fix: `peakAmplitude` goes from `0.000000` → `0.000282`, transcription produces correct text
- Normal operation (no video call, single-channel mic) unaffected — `channelMap` is only set when `channelCount > 1`

Closes #204