### PR TITLE
Preserve modifier side when capturing modifier-only hotkeys

### DIFF
--- a/.changeset/846641b1.md
+++ b/.changeset/846641b1.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Pressing a specific modifier side (e.g. right ctrl) when setting a modifier-only hotkey now pre-selects that side in the side picker instead of defaulting to Either

--- a/.changeset/846641b1.md
+++ b/.changeset/846641b1.md
@@ -2,4 +2,4 @@
 "hex-app": patch
 ---
 
-Pressing a specific modifier side (e.g. right ctrl) when setting a modifier-only hotkey now pre-selects that side in the side picker instead of defaulting to Either
+Pressing a specific modifier side (e.g. right ctrl) when setting a modifier-only hotkey now pre-selects that side in the side picker instead of defaulting to Either (#212)

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -176,7 +176,10 @@ struct SettingsFeature {
     case .recording:
       state.$hexSettings.withLock {
         $0.hotkey.key = key
-        $0.hotkey.modifiers = modifiers.erasingSides()
+        // For modifier-only hotkeys, preserve the captured side (left/right) so the
+        // side picker pre-selects the physical key that was pressed. For key+modifier
+        // combos, erase sides — no picker exists and either side should trigger.
+        $0.hotkey.modifiers = key == nil ? modifiers : modifiers.erasingSides()
       }
     case .pasteLastTranscript:
       guard let key else { return }


### PR DESCRIPTION
## Problem

When setting a modifier-only hotkey (e.g. right ctrl), the physical side pressed is correctly detected via `Modifiers.from(carbonFlags:)` using device-level flags. But `applyCapturedHotKey` immediately calls `erasingSides()` before saving, discarding that information.

The result: the side picker (`ModifierSideControls`) always defaults to "Either" — even if you physically pressed right ctrl. Both left and right trigger the hotkey.

## Root cause

```swift
// SettingsFeature.swift — applyCapturedHotKey
$0.hotkey.modifiers = modifiers.erasingSides()  // strips left/right info
```

The `ModifierSideControls` UI already exists for users to adjust this after setting the hotkey, but it never had the right default to start from.

## Fix

For modifier-only hotkeys, preserve the captured side instead of erasing it:

```swift
$0.hotkey.modifiers = key == nil ? modifiers : modifiers.erasingSides()
```

Key+modifier hotkeys (e.g. Cmd+A) still erase sides — no side picker exists for those and either side should trigger.

## Behaviour after fix

| Action | Before | After |
|--------|--------|-------|
| Press right ctrl to set hotkey | Saved as `control(.either)` | Saved as `control(.right)` |
| Side picker default | "Either" | "Right" |
| Left ctrl triggers hotkey | Yes | No |
| Right ctrl triggers hotkey | Yes | Yes |
| User can override via picker | Yes | Yes |

## No regressions

- Existing saved hotkeys are unaffected (only new captures change)
- Key+modifier hotkeys unchanged
- The side picker still works for manual overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * When configuring modifier-only hotkeys, the side picker now pre-selects the specific modifier side you pressed instead of defaulting to "Either".
  * During hotkey recording, modifier-only captures retain the detected physical side so the UI reflects the exact side you used; key+modifier captures continue to ignore side selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->