### PR TITLE
Add style prompt for Whisper transcription

### DIFF
--- a/Hex/Features/Settings/LanguageSectionView.swift
+++ b/Hex/Features/Settings/LanguageSectionView.swift
@@ -9,21 +9,41 @@ struct LanguageSectionView: View {
 	@Bindable var store: StoreOf<SettingsFeature>
 
 	var body: some View {
-		Label {
-			Picker(
-				"Output Language",
-				selection: Binding(
-					get: { store.hexSettings.outputLanguage },
-					set: { store.send(.setOutputLanguage($0)) }
-				)
-			) {
-				ForEach(store.languages, id: \.id) { language in
-					Text(language.name).tag(language.code as String?)
+		Section {
+			Label {
+				Picker(
+					"Output Language",
+					selection: Binding(
+						get: { store.hexSettings.outputLanguage },
+						set: { store.send(.setOutputLanguage($0)) }
+					)
+				) {
+					ForEach(store.languages, id: \.id) { language in
+						Text(language.name).tag(language.code as String?)
+					}
 				}
+				.pickerStyle(.menu)
+			} icon: {
+				Image(systemName: "globe")
 			}
-			.pickerStyle(.menu)
-		} icon: {
-			Image(systemName: "globe")
+
+			Label {
+				VStack(alignment: .leading, spacing: 4) {
+					TextField(
+						"e.g. use all lowercase, no trailing period",
+						text: Binding(
+							get: { store.hexSettings.whisperPrompt ?? "" },
+							set: { store.send(.setWhisperPrompt($0)) }
+						)
+					)
+					Text("Guides the model's output style. Whisper will try to match the tone and formatting of this prompt.")
+						.settingsCaption()
+				}
+			} icon: {
+				Image(systemName: "text.quote")
+			}
+		} header: {
+			Text("Transcription")
 		}
 		.enableInjection()
 	}

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -104,6 +104,9 @@ struct SettingsFeature {
     // Modifier configuration
     case setModifierSide(Modifier.Kind, Modifier.Side)
 
+    // Whisper prompt
+    case setWhisperPrompt(String?)
+
     // Word remappings
     case setWordRemovalsEnabled(Bool)
     case addWordRemoval
@@ -578,6 +581,10 @@ struct SettingsFeature {
         state.$hexSettings.withLock {
           $0.hotkey.modifiers = $0.hotkey.modifiers.setting(kind: kind, to: side)
         }
+        return .none
+
+      case let .setWhisperPrompt(prompt):
+        state.$hexSettings.withLock { $0.whisperPrompt = prompt?.isEmpty == true ? nil : prompt }
         return .none
 
       case let .setWordRemovalsEnabled(enabled):

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -352,6 +352,7 @@ private extension TranscriptionFeature {
     state.error = nil
     let model = state.hexSettings.selectedModel
     let language = state.hexSettings.outputLanguage
+    let whisperPrompt = state.hexSettings.whisperPrompt
 
     state.isPrewarming = true
 
@@ -372,6 +373,7 @@ private extension TranscriptionFeature {
           language: language,
           detectLanguage: language == nil, // Only auto-detect if no language specified
           chunkingStrategy: .vad,
+          initialPrompt: whisperPrompt,
         )
         
         let result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -47,6 +47,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var wordRemovalsEnabled: Bool
 	public var wordRemovals: [WordRemoval]
 	public var wordRemappings: [WordRemapping]
+	public var whisperPrompt: String?
 
 	private mutating func normalizeDoubleTapSettings() {
 		if !doubleTapLockEnabled {
@@ -78,7 +79,8 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		hasCompletedStorageMigration: Bool = false,
 		wordRemovalsEnabled: Bool = false,
 		wordRemovals: [WordRemoval] = HexSettings.defaultWordRemovals,
-		wordRemappings: [WordRemapping] = []
+		wordRemappings: [WordRemapping] = [],
+		whisperPrompt: String? = nil
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
 		self.soundEffectsVolume = soundEffectsVolume
@@ -104,6 +106,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.wordRemovalsEnabled = wordRemovalsEnabled
 		self.wordRemovals = wordRemovals
 		self.wordRemappings = wordRemappings
+		self.whisperPrompt = whisperPrompt
 		normalizeDoubleTapSettings()
 	}
 
@@ -152,6 +155,7 @@ private enum HexSettingKey: String, CodingKey, CaseIterable {
 	case wordRemovalsEnabled
 	case wordRemovals
 	case wordRemappings
+	case whisperPrompt
 }
 
 private struct SettingsField<Value: Codable & Sendable> {
@@ -284,6 +288,14 @@ private enum HexSettingsSchema {
 			.wordRemappings,
 			keyPath: \.wordRemappings,
 			default: defaults.wordRemappings
+		).eraseToAny(),
+		SettingsField(
+			.whisperPrompt,
+			keyPath: \.whisperPrompt,
+			default: defaults.whisperPrompt,
+			encode: { container, key, value in
+				try container.encodeIfPresent(value, forKey: key)
+			}
 		).eraseToAny()
 	]
 }


### PR DESCRIPTION
Add a free-text "style prompt" field to the Whisper settings section. Whatever you type there gets passed as `initialPrompt` to WhisperKit's `DecodingOptions`, so the model tries to match your formatting — things like lowercase output, skipping trailing punctuation, etc.

The field only shows up when a Whisper model is selected (Parakeet doesn't have an equivalent). Saving an empty string clears the setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Transcription settings section where users can configure a custom Whisper prompt to control the transcription model's output formatting, structure, and tone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->