### PR TITLE
Fix speakers staying muted after double-tap lock recording

### DIFF
--- a/.changeset/9782fb11.md
+++ b/.changeset/9782fb11.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Fix speakers staying muted after double-tap lock transcription ends

--- a/.changeset/9782fb11.md
+++ b/.changeset/9782fb11.md
@@ -2,4 +2,4 @@
 "hex-app": patch
 ---
 
-Fix speakers staying muted after double-tap lock transcription ends
+Fix speakers staying muted after double-tap lock transcription ends (issue #220)

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -1095,7 +1095,7 @@ actor RecordingClientLive {
         // overwrite previousVolume. This fixes a double-tap race: the second
         // recording starts during the first session's async stop grace period,
         // so the system is already at volume 0. Snapshotting 0 as previousVolume
-        // would lose the real original level and leave speakers muted after transcription.
+        // would lose the real original level and leave speakers muted after transcription. (#220)
         guard self.previousVolume == nil else {
           recordingLogger.notice("Skipping mute – previousVolume already captured from overlapping session; preserving original level")
           return

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -1096,7 +1096,10 @@ actor RecordingClientLive {
         // recording starts during the first session's async stop grace period,
         // so the system is already at volume 0. Snapshotting 0 as previousVolume
         // would lose the real original level and leave speakers muted after transcription.
-        guard self.previousVolume == nil else { return }
+        guard self.previousVolume == nil else {
+          recordingLogger.notice("Skipping mute – previousVolume already captured from overlapping session; preserving original level")
+          return
+        }
         let volume = await self.muteSystemVolume()
         await self.setPreviousVolume(volume, sessionID: sessionID)
       }

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -1091,6 +1091,12 @@ actor RecordingClientLive {
       // Mute system volume in background
       mediaControlTask = Task { [sessionID] in
         guard await self.isCurrentSession(sessionID) else { return }
+        // If a prior session already muted and hasn't been restored yet, don't
+        // overwrite previousVolume. This fixes a double-tap race: the second
+        // recording starts during the first session's async stop grace period,
+        // so the system is already at volume 0. Snapshotting 0 as previousVolume
+        // would lose the real original level and leave speakers muted after transcription.
+        guard self.previousVolume == nil else { return }
         let volume = await self.muteSystemVolume()
         await self.setPreviousVolume(volume, sessionID: sessionID)
       }


### PR DESCRIPTION
Fixes #220

## What was happening

When using double-tap lock with the "Mute" audio behavior, the speakers would stay muted after transcription ended. The bug is a race condition that plays out like this:

- The first tap mutes the speakers and saves the original volume (e.g. 0.7)
- The first release triggers an async stop with a short grace period (~100–300ms)
- The second tap fires during that grace period, starting a new recording session
- At this point the speakers are still at 0, so the new session snapshots 0 as the "original" volume — overwriting the real 0.7
- The first session's stop detects a newer session is running and skips the restore entirely
- When the user finally stops the lock recording, it tries to restore to 0 — a no-op — and the speakers stay muted

## The fix

A single guard in the mute task inside `startRecording()`. Before snapshotting the current volume as the "original", it checks whether one has already been saved. If it has, that means a prior session muted the speakers and hasn't had a chance to restore them yet — so we leave that saved value alone. The real original volume survives through to the final restore and the speakers come back as expected.

## Testing

1. Set audio behavior to "Mute" in Settings
2. Play audio so speakers are active
3. Double-tap the hotkey quickly to enter lock mode
4. Say something
5. Tap hotkey once to stop
6. Speakers should restore ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where speakers could remain muted after a double-tap lock transcription session ends, ensuring system audio is restored reliably even when sessions overlap.

* **Chores**
  * Included as a patch release entry to deliver the fix promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->