### PR TITLE
Allow double-tap-only mode for modifier hotkeys

### DIFF
--- a/.changeset/72ce3372.md
+++ b/.changeset/72ce3372.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Allow modifier-only hotkeys to use double-tap-only mode and hide inactive hold controls (#78)

--- a/Hex/Features/Settings/HotKeySectionView.swift
+++ b/Hex/Features/Settings/HotKeySectionView.swift
@@ -52,8 +52,7 @@ struct HotKeySectionView: View {
                 Image(systemName: "hand.tap")
             }
 
-            // Double-tap only mode applies to key+modifier combinations.
-            if hotKey.key != nil {
+            if store.hexSettings.doubleTapLockEnabled {
                 Label {
                     Toggle(
                         "Use double-tap only",
@@ -62,14 +61,14 @@ struct HotKeySectionView: View {
                             set: { store.send(.setUseDoubleTapOnly($0)) }
                         )
                     )
-                        .disabled(!store.hexSettings.doubleTapLockEnabled)
                 } icon: {
                     Image(systemName: "hand.tap.fill")
                 }
             }
 
             // Minimum key time (for modifier-only shortcuts)
-            if store.hexSettings.hotkey.key == nil {
+            if store.hexSettings.hotkey.key == nil,
+               !(store.hexSettings.doubleTapLockEnabled && store.hexSettings.useDoubleTapOnly) {
                 Label {
                     Slider(
                         value: Binding(

--- a/HexCore/Sources/HexCore/Logic/HotKeyProcessor.swift
+++ b/HexCore/Sources/HexCore/Logic/HotKeyProcessor.swift
@@ -95,7 +95,6 @@ public struct HotKeyProcessor {
     public var hotkey: HotKey
     
     /// If true, only double-tap activates recording (press-and-hold disabled)
-    /// Only applies to key+modifier hotkeys; modifier-only always allows press-and-hold
     public var useDoubleTapOnly: Bool = false
 
     /// If false, the quick double-tap lock gesture is disabled.
@@ -113,6 +112,9 @@ public struct HotKeyProcessor {
     
     /// Timestamp of the most recent hotkey release (for double-tap detection)
     private var lastTapAt: Date?
+
+    /// Start time for a pending tap while press-and-hold is disabled.
+    private var doubleTapOnlyPressStartedAt: Date?
     
     /// When true, all input is ignored until full keyboard release
     /// Prevents accidental re-triggering after cancellation or during complex key combos
@@ -133,7 +135,7 @@ public struct HotKeyProcessor {
     /// Creates a new hotkey processor
     /// - Parameters:
     ///   - hotkey: The key combination to detect
-    ///   - useDoubleTapOnly: If true, disables press-and-hold for key+modifier hotkeys
+    ///   - useDoubleTapOnly: If true, disables press-and-hold and requires double-tap lock
     ///   - doubleTapLockEnabled: If false, disables double-tap lock behavior
     ///   - minimumKeyTime: Minimum duration for valid key press (overridden to modifierOnlyMinimumDuration for modifier-only)
     public init(
@@ -198,6 +200,9 @@ public struct HotKeyProcessor {
             // Potentially become dirty if chord has extra mods or different key
             if chordIsDirty(keyEvent) {
                 isDirty = true
+                if isDoubleTapOnlyEnabledForCurrentHotkey {
+                    clearDoubleTapTracking()
+                }
             }
             return handleNonmatchingChord(keyEvent)
         }
@@ -290,7 +295,7 @@ public extension HotKeyProcessor {
 
 extension HotKeyProcessor {
     private var isDoubleTapOnlyEnabledForCurrentHotkey: Bool {
-        useDoubleTapOnly && doubleTapLockEnabled && hotkey.key != nil
+        useDoubleTapOnly && doubleTapLockEnabled
     }
 
     /// Handles keyboard events that match the configured hotkey.
@@ -301,20 +306,26 @@ extension HotKeyProcessor {
     /// - `.doubleTapLock` → `.idle`: User pressed hotkey to stop locked recording
     ///
     /// # Double-Tap Only Mode
-    /// For key+modifier hotkeys with useDoubleTapOnly enabled:
+    /// When useDoubleTapOnly is enabled:
     /// - First press: Record timestamp but don't start recording
-    /// - Wait for quick release and second press to actually start
+    /// - First release: Record release timestamp
+    /// - Second press within threshold: Enter double-tap lock and start recording
     ///
     /// - Returns: `.startRecording` when entering press-and-hold, `.stopRecording` when exiting lock
     private mutating func handleMatchingChord() -> Output? {
         switch state {
         case .idle:
-            // If doubleTapOnly mode is enabled and the hotkey has a key component,
-            // we want to delay starting recording until we see the double-tap
             if isDoubleTapOnlyEnabledForCurrentHotkey {
-                // Record the timestamp but don't start recording
-                lastTapAt = now
-                return nil
+                if let prevTapTime = lastTapAt,
+                   now.timeIntervalSince(prevTapTime) < Self.doubleTapThreshold {
+                    state = .doubleTapLock
+                    clearDoubleTapTracking()
+                    return .startRecording
+                } else {
+                    doubleTapOnlyPressStartedAt = now
+                    lastTapAt = nil
+                    return nil
+                }
             } else {
                 // Normal press => .pressAndHold => .startRecording
                 state = .pressAndHold(startTime: now)
@@ -355,21 +366,16 @@ extension HotKeyProcessor {
     private mutating func handleNonmatchingChord(_ e: KeyEvent) -> Output? {
         switch state {
         case .idle:
-            // Handle double-tap detection for key+modifier combinations
             if isDoubleTapOnlyEnabledForCurrentHotkey &&
-               chordIsFullyReleased(e) &&
-               lastTapAt != nil {
-                // If we've seen a tap recently, and now we see a full release, and we're in idle state
-                // Check if the time between taps is within the threshold
-                if let prevTapTime = lastTapAt,
-                   now.timeIntervalSince(prevTapTime) < Self.doubleTapThreshold {
-                    // This is the second tap - activate recording in double-tap lock mode
-                    state = .doubleTapLock
-                    return .startRecording
+               isReleaseForActiveHotkey(e),
+               let pressStartedAt = doubleTapOnlyPressStartedAt {
+                let elapsed = now.timeIntervalSince(pressStartedAt)
+                if elapsed < Self.doubleTapThreshold {
+                    lastTapAt = now
+                } else {
+                    lastTapAt = nil
                 }
-                
-                // Reset the tap timer as we've fully released
-                lastTapAt = nil
+                doubleTapOnlyPressStartedAt = nil
             }
             return nil
 
@@ -423,12 +429,7 @@ extension HotKeyProcessor {
             }
 
         case .doubleTapLock:
-            // For key+modifier combinations in doubleTapLock mode, require full key release to stop
-            if isDoubleTapOnlyEnabledForCurrentHotkey && chordIsFullyReleased(e) {
-                resetToIdle()
-                return .stopRecording
-            }
-            // Otherwise, if locked, ignore everything except chord == hotkey => stop
+            // If locked, ignore everything except chord == hotkey => stop.
             return nil
         }
     }
@@ -532,6 +533,11 @@ extension HotKeyProcessor {
     /// - `lastTapAt` → nil (double-tap timing reset)
     private mutating func resetToIdle() {
         state = .idle
+        clearDoubleTapTracking()
+    }
+
+    private mutating func clearDoubleTapTracking() {
         lastTapAt = nil
+        doubleTapOnlyPressStartedAt = nil
     }
 }

--- a/HexCore/Tests/HexCoreTests/HotKeyProcessorTests.swift
+++ b/HexCore/Tests/HexCoreTests/HotKeyProcessorTests.swift
@@ -323,6 +323,145 @@ struct HotKeyProcessorTests {
         )
     }
 
+    // MARK: - Double-Tap Only (Key + Modifier)
+
+    @Test
+    func doubleTapOnly_standard_singlePressIgnored() throws {
+        runScenario(
+            hotkey: HotKey(key: .a, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_standard_requiresSecondPress() throws {
+        runScenario(
+            hotkey: HotKey(key: .a, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.2, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true, expectedState: .doubleTapLock)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_standard_releaseAfterLockDoesNotStop() throws {
+        runScenario(
+            hotkey: HotKey(key: .a, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                ScenarioStep(time: 0.0, key: .a, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.2, key: .a, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 0.3, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 0.4, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 1.0, key: .a, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false)
+            ]
+        )
+    }
+
+    // MARK: - Double-Tap Only (Modifier-Only)
+
+    @Test
+    func doubleTapOnly_modifierOnly_requiresSecondPress() throws {
+        runScenario(
+            hotkey: HotKey(key: nil, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                // First press — no recording yet
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                // First release — still no recording, just records release time
+                ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
+                // Second press within threshold — starts recording in lock mode
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_modifierOnly_stopsOnThirdPress() throws {
+        runScenario(
+            hotkey: HotKey(key: nil, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.command], expectedOutput: .startRecording, expectedIsMatched: true),
+                // Release after lock — should NOT stop (modifier-only lock persists)
+                ScenarioStep(time: 0.3, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: true),
+                // Third press — stops recording
+                ScenarioStep(time: 0.5, key: nil, modifiers: [.command], expectedOutput: .stopRecording, expectedIsMatched: false)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_modifierOnly_slowDoubleTapIgnored() throws {
+        runScenario(
+            hotkey: HotKey(key: nil, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                // First press
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                // First release
+                ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
+                // Second press too slow (> 0.3s after release)
+                ScenarioStep(time: 0.5, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                // Release — nothing happens
+                ScenarioStep(time: 0.6, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_modifierOnly_singlePressIgnored() throws {
+        runScenario(
+            hotkey: HotKey(key: nil, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                // Single press — no recording
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                // Release — no recording
+                ScenarioStep(time: 0.1, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_modifierOnly_slowFirstHoldDoesNotArm() throws {
+        runScenario(
+            hotkey: HotKey(key: nil, modifiers: [.command]),
+            useDoubleTapOnly: true,
+            steps: [
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.5, key: nil, modifiers: [], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.6, key: nil, modifiers: [.command], expectedOutput: nil, expectedIsMatched: false)
+            ]
+        )
+    }
+
+    @Test
+    func doubleTapOnly_modifierOnly_multipleModifiersPartialReleaseArmsSecondPress() throws {
+        runScenario(
+            hotkey: HotKey(key: nil, modifiers: [.option, .command]),
+            useDoubleTapOnly: true,
+            steps: [
+                ScenarioStep(time: 0.0, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.1, key: nil, modifiers: [.option, .command], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.2, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: false),
+                ScenarioStep(time: 0.3, key: nil, modifiers: [.option, .command], expectedOutput: .startRecording, expectedIsMatched: true, expectedState: .doubleTapLock),
+                ScenarioStep(time: 0.4, key: nil, modifiers: [.option], expectedOutput: nil, expectedIsMatched: true, expectedState: .doubleTapLock)
+            ]
+        )
+    }
+
     // MARK: - Edge Cases
 
     // Tests that after pressing a key with option, releasing the key but keeping option pressed


### PR DESCRIPTION
This removes the key+modifier-only restriction from double-tap-only mode, so modifier-only hotkeys like Cmd or Option can use it too.

It also tightens the Settings UI:
- Hide Use double-tap only unless double-tap lock is enabled.
- Hide the hold threshold slider while double-tap-only mode is active.

Refs #78. Related: #120.

Verified:
- Manually tested Cmd as a modifier-only double-tap-only hotkey in the debug app.
- `swift test --build-path /private/tmp/hexcore-swift-test-build`
- `xcodebuild -scheme Hex -configuration Debug -derivedDataPath /private/tmp/HexDerivedData -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`

<img width="537" height="256" alt="image" src="https://github.com/user-attachments/assets/18fc84ab-dc24-4424-adcc-870da7cdc07c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modifier-only shortcuts can now use double-tap-only mode.

* **Bug Fixes**
  * Double-tap-only reliably ignores single taps and preserves correct timing.
  * The double-tap-only toggle and minimum-key-time control are shown only when appropriate, hiding inactive hold controls.

* **Tests**
  * Added tests covering double-tap-only behavior for standard and modifier-only shortcuts.

* **Chore**
  * Patch release entry added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitlangton/Hex/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->