### PR TITLE
Add drag-and-drop audio transcription

### DIFF
--- a/.changeset/d2cc062c.md
+++ b/.changeset/d2cc062c.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add a Transcribe tab for drag-and-drop audio transcription.

--- a/.changeset/d2cc062c.md
+++ b/.changeset/d2cc062c.md
@@ -2,4 +2,4 @@
 "hex-app": minor
 ---
 
-Add a Transcribe tab for drag-and-drop audio transcription.
+Add a Transcribe tab for drag-and-drop audio transcription (`#232`).

--- a/Hex/Features/App/AppFeature.swift
+++ b/Hex/Features/App/AppFeature.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct AppFeature {
   enum ActiveTab: Equatable {
     case settings
+    case fileTranscription
     case remappings
     case history
     case about
@@ -23,6 +24,7 @@ struct AppFeature {
 	@ObservableState
 	struct State {
 		var transcription: TranscriptionFeature.State = .init()
+    var fileTranscription: FileTranscriptionFeature.State = .init()
 		var settings: SettingsFeature.State = .init()
 		var history: HistoryFeature.State = .init()
 		var activeTab: ActiveTab = .settings
@@ -38,6 +40,7 @@ struct AppFeature {
   enum Action: BindableAction {
     case binding(BindingAction<State>)
     case transcription(TranscriptionFeature.Action)
+    case fileTranscription(FileTranscriptionFeature.Action)
     case settings(SettingsFeature.Action)
     case history(HistoryFeature.Action)
     case setActiveTab(ActiveTab)
@@ -64,6 +67,10 @@ struct AppFeature {
 
     Scope(state: \.transcription, action: \.transcription) {
       TranscriptionFeature()
+    }
+
+    Scope(state: \.fileTranscription, action: \.fileTranscription) {
+      FileTranscriptionFeature()
     }
 
     Scope(state: \.settings, action: \.settings) {
@@ -109,6 +116,9 @@ struct AppFeature {
         }
 
       case .transcription:
+        return .none
+
+      case .fileTranscription:
         return .none
 
       case .settings:
@@ -271,6 +281,14 @@ struct AppView: View {
         .tag(AppFeature.ActiveTab.settings)
 
         Button {
+          store.send(.setActiveTab(.fileTranscription))
+        } label: {
+          Label("Transcribe", systemImage: "waveform")
+        }
+        .buttonStyle(.plain)
+        .tag(AppFeature.ActiveTab.fileTranscription)
+
+        Button {
           store.send(.setActiveTab(.remappings))
         } label: {
           Label("Transforms", systemImage: "text.badge.plus")
@@ -304,6 +322,9 @@ struct AppView: View {
           inputMonitoringPermission: store.inputMonitoringPermission
         )
         .navigationTitle("Settings")
+      case .fileTranscription:
+        FileTranscriptionView(store: store.scope(state: \.fileTranscription, action: \.fileTranscription))
+          .navigationTitle("Transcribe")
       case .remappings:
         WordRemappingsView(store: store.scope(state: \.settings, action: \.settings))
           .navigationTitle("Transforms")

--- a/Hex/Features/FileTranscription/FileTranscriptionFeature.swift
+++ b/Hex/Features/FileTranscription/FileTranscriptionFeature.swift
@@ -1,0 +1,346 @@
+import AVFoundation
+import ComposableArchitecture
+import Foundation
+import HexCore
+import WhisperKit
+
+private let fileTranscriptionLogger = HexLog.transcription
+
+@Reducer
+struct FileTranscriptionFeature {
+  @ObservableState
+  struct State: Equatable {
+    @Shared(.hexSettings) var hexSettings: HexSettings
+    @Shared(.modelBootstrapState) var modelBootstrapState: ModelBootstrapState
+    @Shared(.transcriptionHistory) var transcriptionHistory: TranscriptionHistory
+
+    var jobs: [FileTranscriptionJob] = []
+    var isDropTargeted = false
+    var dropError: String?
+    var dropNotice: String?
+  }
+
+  enum Action: BindableAction {
+    case binding(BindingAction<State>)
+    case addFiles([URL])
+    case importFailed(String)
+    case jobStarted(UUID)
+    case jobSaving(UUID, String)
+    case jobCompleted(UUID, String, Transcript?)
+    case jobFailed(UUID, String)
+    case copyTranscript(UUID)
+    case removeJob(UUID)
+    case clearFinished
+  }
+
+  @Dependency(\.pasteboard) var pasteboard
+  @Dependency(\.transcriptPersistence) var transcriptPersistence
+  @Dependency(\.transcription) var transcription
+
+  static let supportedFormatsDescription = "MP3, M4A/M4B, MP4/MOV/M4V with audio, WAV, FLAC, AAC, AIFF, and CAF"
+
+  private static let supportedFileExtensions: Set<String> = [
+    "aac",
+    "aif",
+    "aiff",
+    "caf",
+    "flac",
+    "m4a",
+    "m4b",
+    "m4v",
+    "mov",
+    "mp3",
+    "mp4",
+    "wav",
+  ]
+
+  var body: some ReducerOf<Self> {
+    BindingReducer()
+
+    Reduce<State, Action> { state, action -> Effect<Action> in
+      switch action {
+      case .binding:
+        return .none
+
+      case let .addFiles(urls):
+        let (audioURLs, skippedURLs) = partitionSupportedAudioURLs(urls)
+        guard !audioURLs.isEmpty else {
+          state.dropError = unsupportedFileMessage(for: skippedURLs)
+          state.dropNotice = nil
+          return .none
+        }
+
+        guard state.modelBootstrapState.isModelReady else {
+          state.dropError = "Download a transcription model before importing audio files."
+          state.dropNotice = nil
+          return .none
+        }
+
+        state.dropError = nil
+        state.dropNotice = skippedURLs.isEmpty ? nil : skippedUnsupportedFileMessage(for: skippedURLs)
+        let jobs = audioURLs.map { FileTranscriptionJob(url: $0) }
+        state.jobs.insert(contentsOf: jobs, at: 0)
+
+        let model = state.hexSettings.selectedModel
+        let language = state.hexSettings.outputLanguage
+        let saveHistory = state.hexSettings.saveTranscriptionHistory
+
+        let effects = jobs.map { job in
+          transcribeFileEffect(
+            id: job.id,
+            url: job.url,
+            model: model,
+            language: language,
+            saveHistory: saveHistory
+          )
+        }
+
+        return effects.reduce(.none) { mergedEffect, effect in
+          .merge(mergedEffect, effect)
+        }
+
+      case let .importFailed(message):
+        state.dropError = message
+        state.dropNotice = nil
+        return .none
+
+      case let .jobStarted(id):
+        updateJob(id, in: &state) {
+          $0.status = .transcribing
+          $0.errorMessage = nil
+        }
+        return .none
+
+      case let .jobSaving(id, text):
+        updateJob(id, in: &state) {
+          $0.status = .saving
+          $0.transcriptText = text
+        }
+        return .none
+
+      case let .jobCompleted(id, text, transcript):
+        updateJob(id, in: &state) {
+          $0.status = .completed
+          $0.transcriptText = text
+          $0.transcriptID = transcript?.id
+          $0.errorMessage = nil
+        }
+
+        guard let transcript else { return .none }
+
+        let maxEntries = state.hexSettings.maxHistoryEntries
+        var removedTranscripts: [Transcript] = []
+        state.$transcriptionHistory.withLock { history in
+          history.history.insert(transcript, at: 0)
+          if let maxEntries, maxEntries > 0 {
+            while history.history.count > maxEntries {
+              removedTranscripts.append(history.history.removeLast())
+            }
+          }
+        }
+
+        return deleteAudioEffect(for: removedTranscripts)
+
+      case let .jobFailed(id, message):
+        updateJob(id, in: &state) {
+          $0.status = .failed
+          $0.errorMessage = message
+        }
+        return .none
+
+      case let .copyTranscript(id):
+        guard let text = state.jobs.first(where: { $0.id == id })?.transcriptText else {
+          return .none
+        }
+        return .run { [pasteboard] _ in
+          await pasteboard.copy(text)
+        }
+
+      case let .removeJob(id):
+        state.jobs.removeAll { $0.id == id }
+        return .none
+
+      case .clearFinished:
+        state.jobs.removeAll { $0.status.isFinished }
+        return .none
+      }
+    }
+  }
+
+  private func transcribeFileEffect(
+    id: UUID,
+    url: URL,
+    model: String,
+    language: String?,
+    saveHistory: Bool
+  ) -> Effect<Action> {
+    .run { [transcription, transcriptPersistence] send in
+      await send(.jobStarted(id))
+
+      let didAccessSecurityScope = url.startAccessingSecurityScopedResource()
+      defer {
+        if didAccessSecurityScope {
+          url.stopAccessingSecurityScopedResource()
+        }
+      }
+
+        do {
+          fileTranscriptionLogger.notice("Transcribing imported audio file=\(url.lastPathComponent)")
+        let duration = try await Self.audioDuration(for: url)
+        let decodeOptions = DecodingOptions(
+          language: language,
+          detectLanguage: language == nil,
+          chunkingStrategy: .vad
+        )
+        let result = try await transcription.transcribe(url, model, decodeOptions) { _ in }
+        let text = result.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !text.isEmpty else {
+          throw FileTranscriptionError.emptyTranscript
+        }
+
+        await send(.jobSaving(id, text))
+
+        let transcript: Transcript?
+        if saveHistory {
+          let temporaryCopy = try Self.copyToTemporaryImportLocation(url)
+          do {
+            transcript = try await transcriptPersistence.save(
+              text,
+              temporaryCopy,
+              duration,
+              nil,
+              url.lastPathComponent
+            )
+          } catch {
+            try? FileManager.default.removeItem(at: temporaryCopy)
+            throw error
+          }
+        } else {
+          transcript = nil
+        }
+
+        await send(.jobCompleted(id, text, transcript))
+      } catch {
+        fileTranscriptionLogger.error("Imported audio transcription failed: \(error.localizedDescription)")
+        await send(.jobFailed(id, error.localizedDescription))
+      }
+    }
+  }
+
+  private func deleteAudioEffect(for transcripts: [Transcript]) -> Effect<Action> {
+    .run { [transcriptPersistence] _ in
+      for transcript in transcripts {
+        try? await transcriptPersistence.deleteAudio(transcript)
+      }
+    }
+  }
+
+  private func updateJob(_ id: UUID, in state: inout State, update: (inout FileTranscriptionJob) -> Void) {
+    guard let index = state.jobs.firstIndex(where: { $0.id == id }) else { return }
+    update(&state.jobs[index])
+  }
+
+  private func partitionSupportedAudioURLs(_ urls: [URL]) -> (supported: [URL], skipped: [URL]) {
+    var seen: Set<URL> = []
+    var supported: [URL] = []
+    var skipped: [URL] = []
+
+    for url in urls {
+      let standardized = url.standardizedFileURL
+      guard seen.insert(standardized).inserted else {
+        continue
+      }
+
+      guard Self.isSupportedAudioURL(standardized) else {
+        skipped.append(standardized)
+        continue
+      }
+
+      supported.append(standardized)
+    }
+
+    return (supported, skipped)
+  }
+
+  private static func isSupportedAudioURL(_ url: URL) -> Bool {
+    guard url.isFileURL else { return false }
+    return supportedFileExtensions.contains(url.pathExtension.lowercased())
+  }
+
+  private static func audioDuration(for url: URL) async throws -> TimeInterval {
+    do {
+      let audioFile = try AVAudioFile(forReading: url, commonFormat: .pcmFormatFloat32, interleaved: false)
+      let seconds = Double(audioFile.length) / audioFile.fileFormat.sampleRate
+      guard seconds.isFinite && seconds > 0 else {
+        throw FileTranscriptionError.noReadableAudioTrack
+      }
+      return seconds
+    } catch let error as FileTranscriptionError {
+      throw error
+    } catch {
+      if !(await hasAudioTrack(url)) {
+        throw FileTranscriptionError.noReadableAudioTrack
+      }
+      throw FileTranscriptionError.unreadableAudio
+    }
+  }
+
+  private static func hasAudioTrack(_ url: URL) async -> Bool {
+    let asset = AVURLAsset(url: url)
+    guard let tracks = try? await asset.loadTracks(withMediaType: .audio) else {
+      return false
+    }
+    return !tracks.isEmpty
+  }
+
+  private func unsupportedFileMessage(for urls: [URL]) -> String {
+    guard !urls.isEmpty else {
+      return "Drop a supported audio or video file to transcribe. Supported: \(Self.supportedFormatsDescription)."
+    }
+    return "\(Self.fileList(urls)) not supported. Supported: \(Self.supportedFormatsDescription)."
+  }
+
+  private func skippedUnsupportedFileMessage(for urls: [URL]) -> String {
+    "Skipped unsupported files: \(Self.fileList(urls)). Supported: \(Self.supportedFormatsDescription)."
+  }
+
+  private static func fileList(_ urls: [URL]) -> String {
+    let names = urls.prefix(3).map(\.lastPathComponent).joined(separator: ", ")
+    let remainingCount = urls.count - 3
+    return remainingCount > 0 ? "\(names), and \(remainingCount) more" : names
+  }
+
+  private static func copyToTemporaryImportLocation(_ url: URL) throws -> URL {
+    let fm = FileManager.default
+    let importDirectory = fm.temporaryDirectory.appendingPathComponent("HexImportedAudio", isDirectory: true)
+    try fm.createDirectory(at: importDirectory, withIntermediateDirectories: true)
+
+    let destination = importDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension(url.pathExtension.isEmpty ? "audio" : url.pathExtension)
+
+    if fm.fileExists(atPath: destination.path) {
+      try fm.removeItem(at: destination)
+    }
+    try fm.copyItem(at: url, to: destination)
+    return destination
+  }
+}
+
+private enum FileTranscriptionError: LocalizedError {
+  case emptyTranscript
+  case noReadableAudioTrack
+  case unreadableAudio
+
+  var errorDescription: String? {
+    switch self {
+    case .emptyTranscript:
+      return "The selected file did not produce any transcript text."
+    case .noReadableAudioTrack:
+      return "The selected file does not contain a readable audio track."
+    case .unreadableAudio:
+      return "Hex could not decode this file's audio. Try MP3, M4A, WAV, or FLAC."
+    }
+  }
+}

--- a/Hex/Features/FileTranscription/FileTranscriptionFeature.swift
+++ b/Hex/Features/FileTranscription/FileTranscriptionFeature.swift
@@ -51,7 +51,7 @@ struct FileTranscriptionFeature {
     "mov",
     "mp3",
     "mp4",
-    "wav",
+    "wav"
   ]
 
   var body: some ReducerOf<Self> {
@@ -184,8 +184,8 @@ struct FileTranscriptionFeature {
         }
       }
 
-        do {
-          fileTranscriptionLogger.notice("Transcribing imported audio file=\(url.lastPathComponent)")
+      do {
+        fileTranscriptionLogger.notice("Transcribing imported audio file=\(url.lastPathComponent, privacy: .private)")
         let duration = try await Self.audioDuration(for: url)
         let decodeOptions = DecodingOptions(
           language: language,
@@ -222,7 +222,7 @@ struct FileTranscriptionFeature {
 
         await send(.jobCompleted(id, text, transcript))
       } catch {
-        fileTranscriptionLogger.error("Imported audio transcription failed: \(error.localizedDescription)")
+        fileTranscriptionLogger.error("Imported audio transcription failed: \(error.localizedDescription, privacy: .private)")
         await send(.jobFailed(id, error.localizedDescription))
       }
     }

--- a/Hex/Features/FileTranscription/FileTranscriptionJob.swift
+++ b/Hex/Features/FileTranscription/FileTranscriptionJob.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SwiftUI
+
+struct FileTranscriptionJob: Equatable, Identifiable {
+  let id: UUID
+  let url: URL
+  let fileName: String
+  var status: FileTranscriptionStatus = .queued
+  var transcriptText: String?
+  var transcriptID: UUID?
+  var errorMessage: String?
+
+  init(id: UUID = UUID(), url: URL) {
+    self.id = id
+    self.url = url
+    self.fileName = url.lastPathComponent
+  }
+}
+
+enum FileTranscriptionStatus: Equatable {
+  case queued
+  case transcribing
+  case saving
+  case completed
+  case failed
+
+  var title: String {
+    switch self {
+    case .queued:
+      return "Queued"
+    case .transcribing:
+      return "Transcribing"
+    case .saving:
+      return "Saving"
+    case .completed:
+      return "Complete"
+    case .failed:
+      return "Failed"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .queued:
+      return "clock"
+    case .transcribing:
+      return "waveform"
+    case .saving:
+      return "tray.and.arrow.down"
+    case .completed:
+      return "checkmark.circle.fill"
+    case .failed:
+      return "exclamationmark.triangle.fill"
+    }
+  }
+
+  var tint: Color {
+    switch self {
+    case .queued, .saving:
+      return .secondary
+    case .transcribing:
+      return .blue
+    case .completed:
+      return .green
+    case .failed:
+      return .red
+    }
+  }
+
+  var isFinished: Bool {
+    switch self {
+    case .completed, .failed:
+      return true
+    case .queued, .transcribing, .saving:
+      return false
+    }
+  }
+}

--- a/Hex/Features/FileTranscription/FileTranscriptionJobRow.swift
+++ b/Hex/Features/FileTranscription/FileTranscriptionJobRow.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct FileTranscriptionJobRow: View {
+  let job: FileTranscriptionJob
+  let copy: () -> Void
+  let remove: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      content
+
+      Divider()
+
+      HStack {
+        HStack(spacing: 6) {
+          Image(systemName: job.status.systemImage)
+            .foregroundStyle(job.status.tint)
+          Text(job.fileName)
+            .lineLimit(1)
+          Text("•")
+          Text(job.status.title)
+        }
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+
+        Spacer()
+
+        HStack(spacing: 10) {
+          if job.status == .completed {
+            Button {
+              copy()
+              showCopyAnimation()
+            } label: {
+              HStack(spacing: 4) {
+                Image(systemName: showCopied ? "checkmark" : "doc.on.doc.fill")
+                if showCopied {
+                  Text("Copied").font(.caption)
+                }
+              }
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(showCopied ? .green : .secondary)
+            .help("Copy to clipboard")
+          }
+
+          Button(action: remove) {
+            Image(systemName: "xmark")
+          }
+          .buttonStyle(.plain)
+          .foregroundStyle(.secondary)
+          .help("Remove from this list")
+        }
+        .font(.subheadline)
+      }
+      .frame(height: 20)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+    }
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(Color(.windowBackgroundColor).opacity(0.5))
+        .overlay(
+          RoundedRectangle(cornerRadius: 8)
+            .strokeBorder(Color.secondary.opacity(0.2), lineWidth: 1)
+        )
+    )
+    .onDisappear {
+      copyTask?.cancel()
+    }
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      if job.status == .transcribing || job.status == .saving {
+        HStack(spacing: 8) {
+          ProgressView()
+            .controlSize(.small)
+          Text(job.status == .saving ? "Saving transcript..." : "Transcribing audio...")
+            .foregroundStyle(.secondary)
+        }
+        .font(.callout)
+      }
+
+      if let error = job.errorMessage {
+        Text(error)
+          .font(.callout)
+          .foregroundStyle(.red)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      if let transcript = job.transcriptText {
+        Text(transcript)
+          .font(.body)
+          .foregroundStyle(.primary)
+          .lineLimit(nil)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.trailing, 40)
+    .padding(12)
+  }
+
+  @State private var showCopied = false
+  @State private var copyTask: Task<Void, Error>?
+
+  private func showCopyAnimation() {
+    copyTask?.cancel()
+
+    copyTask = Task {
+      withAnimation {
+        showCopied = true
+      }
+
+      try await Task.sleep(for: .seconds(1.5))
+
+      withAnimation {
+        showCopied = false
+      }
+    }
+  }
+}

--- a/Hex/Features/FileTranscription/FileTranscriptionView.swift
+++ b/Hex/Features/FileTranscription/FileTranscriptionView.swift
@@ -1,0 +1,181 @@
+import ComposableArchitecture
+import Foundation
+import Inject
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct FileTranscriptionView: View {
+  @ObserveInjection var inject
+  @Bindable var store: StoreOf<FileTranscriptionFeature>
+  @State private var isImporterPresented = false
+
+  var body: some View {
+    VStack(spacing: 16) {
+      dropZone
+
+      if let error = store.dropError {
+        Label(error, systemImage: "exclamationmark.triangle")
+          .font(.callout)
+          .foregroundStyle(.red)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      if let notice = store.dropNotice {
+        Label(notice, systemImage: "info.circle")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      if !store.jobs.isEmpty {
+        ScrollView {
+          LazyVStack(spacing: 10) {
+            ForEach(store.jobs) { job in
+              FileTranscriptionJobRow(
+                job: job,
+                copy: { store.send(.copyTranscript(job.id)) },
+                remove: { store.send(.removeJob(job.id)) }
+              )
+            }
+          }
+          .padding(.bottom)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .padding()
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .toolbar {
+      ToolbarItemGroup {
+        if store.jobs.contains(where: { $0.status.isFinished }) {
+          Button {
+            store.send(.clearFinished)
+          } label: {
+            Label("Clear Finished", systemImage: "xmark.circle")
+          }
+        }
+
+        Button {
+          isImporterPresented = true
+        } label: {
+          Label("Choose Audio", systemImage: "plus")
+        }
+      }
+    }
+    .fileImporter(
+      isPresented: $isImporterPresented,
+      allowedContentTypes: [.audio, .movie],
+      allowsMultipleSelection: true
+    ) { result in
+      switch result {
+      case let .success(urls):
+        store.send(.addFiles(urls))
+      case let .failure(error):
+        store.send(.importFailed(error.localizedDescription))
+      }
+    }
+    .enableInjection()
+  }
+
+  private var dropZone: some View {
+    VStack(spacing: 10) {
+      Image(systemName: "waveform.badge.plus")
+        .font(.system(size: 30, weight: .medium))
+        .foregroundStyle(store.isDropTargeted ? .blue : .secondary)
+
+      Text("Drop audio files to transcribe")
+        .font(.headline)
+
+      Text("Uses the selected transcription model and saves results to History when history is enabled.")
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Text("Supported: \(FileTranscriptionFeature.supportedFormatsDescription)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .frame(maxWidth: .infinity)
+    .frame(minHeight: store.jobs.isEmpty ? 320 : 150)
+    .frame(maxHeight: store.jobs.isEmpty ? .infinity : nil)
+    .padding()
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(store.isDropTargeted ? Color.accentColor.opacity(0.12) : Color(.controlBackgroundColor))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .strokeBorder(
+          store.isDropTargeted ? Color.accentColor : Color.secondary.opacity(0.25),
+          style: StrokeStyle(lineWidth: 1.5, dash: [7, 5])
+        )
+    )
+    .onDrop(of: [UTType.fileURL.identifier], isTargeted: $store.isDropTargeted) { providers in
+      loadDroppedFileURLs(from: providers)
+      return true
+    }
+  }
+
+  private func loadDroppedFileURLs(from providers: [NSItemProvider]) {
+    let group = DispatchGroup()
+    let lock = NSLock()
+    var droppedURLs: [URL] = []
+    var firstError: String?
+
+    for provider in providers {
+      group.enter()
+      provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
+        defer { group.leave() }
+
+        lock.withLock {
+          if let error {
+            firstError = firstError ?? error.localizedDescription
+            return
+          }
+
+          guard let url = Self.fileURL(from: item) else {
+            firstError = firstError ?? "Could not read the dropped file URL."
+            return
+          }
+
+          droppedURLs.append(url)
+        }
+      }
+    }
+
+    group.notify(queue: .main) {
+      if !droppedURLs.isEmpty {
+        store.send(.addFiles(droppedURLs))
+      } else if let firstError {
+        store.send(.importFailed(firstError))
+      }
+    }
+  }
+
+  private static func fileURL(from item: NSSecureCoding?) -> URL? {
+    if let url = item as? URL {
+      return url
+    }
+    if let url = item as? NSURL {
+      return url as URL
+    }
+    if let data = item as? Data {
+      return URL(dataRepresentation: data, relativeTo: nil)
+    }
+    if let string = item as? String {
+      return URL(string: string)
+    }
+    return nil
+  }
+}
+
+#Preview {
+  FileTranscriptionView(
+    store: Store(initialState: FileTranscriptionFeature.State()) {
+      FileTranscriptionFeature()
+    }
+  )
+}

--- a/Hex/Features/FileTranscription/FileTranscriptionView.swift
+++ b/Hex/Features/FileTranscription/FileTranscriptionView.swift
@@ -5,6 +5,11 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct FileTranscriptionView: View {
+  private enum DroppedFileURLResult {
+    case success(URL)
+    case failure(String)
+  }
+
   @ObserveInjection var inject
   @Bindable var store: StoreOf<FileTranscriptionFeature>
   @State private var isImporterPresented = false
@@ -120,37 +125,48 @@ struct FileTranscriptionView: View {
   }
 
   private func loadDroppedFileURLs(from providers: [NSItemProvider]) {
-    let group = DispatchGroup()
-    let lock = NSLock()
-    var droppedURLs: [URL] = []
+    Task { @MainActor in
+      let result = await Self.droppedFileURLs(from: providers)
+      if !result.urls.isEmpty {
+        store.send(.addFiles(result.urls))
+      } else if let firstError = result.firstError {
+        store.send(.importFailed(firstError))
+      }
+    }
+  }
+
+  private static func droppedFileURLs(from providers: [NSItemProvider]) async -> (urls: [URL], firstError: String?) {
+    var urls: [URL] = []
     var firstError: String?
 
     for provider in providers {
-      group.enter()
-      provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
-        defer { group.leave() }
-
-        lock.withLock {
-          if let error {
-            firstError = firstError ?? error.localizedDescription
-            return
-          }
-
-          guard let url = Self.fileURL(from: item) else {
-            firstError = firstError ?? "Could not read the dropped file URL."
-            return
-          }
-
-          droppedURLs.append(url)
+      switch await loadDroppedFileURL(from: provider) {
+      case let .success(url):
+        urls.append(url)
+      case let .failure(message):
+        if firstError == nil {
+          firstError = message
         }
       }
     }
 
-    group.notify(queue: .main) {
-      if !droppedURLs.isEmpty {
-        store.send(.addFiles(droppedURLs))
-      } else if let firstError {
-        store.send(.importFailed(firstError))
+    return (urls, firstError)
+  }
+
+  private static func loadDroppedFileURL(from provider: NSItemProvider) async -> DroppedFileURLResult {
+    await withCheckedContinuation { continuation in
+      provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
+        if let error {
+          continuation.resume(returning: .failure(error.localizedDescription))
+          return
+        }
+
+        guard let url = fileURL(from: item) else {
+          continuation.resume(returning: .failure("Could not read the dropped file URL."))
+          return
+        }
+
+        continuation.resume(returning: .success(url))
       }
     }
   }

--- a/Hex/Features/History/HistoryFeature.swift
+++ b/Hex/Features/History/HistoryFeature.swift
@@ -243,6 +243,10 @@ struct TranscriptView: View {
 							Text(appName)
 						}
 						Text("•")
+					} else if let sourceName = transcript.sourceAppName {
+						Image(systemName: "doc")
+						Text(sourceName)
+						Text("•")
 					}
 					
 					Image(systemName: "clock")

--- a/Hex/Features/Settings/GeneralSectionView.swift
+++ b/Hex/Features/Settings/GeneralSectionView.swift
@@ -82,25 +82,26 @@ struct GeneralSectionView: View {
 				Image(systemName: "bolt.circle")
 			}
 
-			Label {
-				HStack(alignment: .center) {
-					Text("Audio Behavior while Recording")
-				Spacer()
-					Picker("", selection: Binding(
-						get: { store.hexSettings.recordingAudioBehavior },
-						set: { store.send(.setRecordingAudioBehavior($0)) }
-					)) {
-						Label("Pause Media", systemImage: "pause")
-							.tag(RecordingAudioBehavior.pauseMedia)
-						Label("Mute Volume", systemImage: "speaker.slash")
-							.tag(RecordingAudioBehavior.mute)
-						Label("Do Nothing", systemImage: "hand.raised.slash")
-							.tag(RecordingAudioBehavior.doNothing)
-					}
-					.pickerStyle(.menu)
-				}
-			} icon: {
+			HStack(alignment: .center, spacing: 10) {
 				Image(systemName: "speaker.wave.2")
+					.foregroundStyle(.secondary)
+					.frame(width: 18)
+				Text("Audio Behavior while Recording")
+					.lineLimit(1)
+				Spacer()
+				Picker("", selection: Binding(
+					get: { store.hexSettings.recordingAudioBehavior },
+					set: { store.send(.setRecordingAudioBehavior($0)) }
+				)) {
+					Label("Pause Media", systemImage: "pause")
+						.tag(RecordingAudioBehavior.pauseMedia)
+					Label("Mute Volume", systemImage: "speaker.slash")
+						.tag(RecordingAudioBehavior.mute)
+					Label("Do Nothing", systemImage: "hand.raised.slash")
+						.tag(RecordingAudioBehavior.doNothing)
+				}
+				.labelsHidden()
+				.pickerStyle(.menu)
 			}
 		} header: {
 			Text("General")

--- a/HexCore/Sources/HexCore/TranscriptPersistenceClient/TranscriptPersistenceClient.swift
+++ b/HexCore/Sources/HexCore/TranscriptPersistenceClient/TranscriptPersistenceClient.swift
@@ -21,7 +21,8 @@ extension TranscriptPersistenceClient: DependencyKey {
                 let recordingsFolder = try URL.hexApplicationSupport.appendingPathComponent("Recordings", isDirectory: true)
                 try fm.createDirectory(at: recordingsFolder, withIntermediateDirectories: true)
                 
-                let filename = "\(Date().timeIntervalSince1970).wav"
+                let fileExtension = audioURL.pathExtension.isEmpty ? "wav" : audioURL.pathExtension
+                let filename = "\(Date().timeIntervalSince1970).\(fileExtension)"
                 let finalURL = recordingsFolder.appendingPathComponent(filename)
                 try fm.moveItem(at: audioURL, to: finalURL)
                 

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -143,6 +143,12 @@
         }
       }
     },
+    "Choose Audio" : {
+
+    },
+    "Clear Finished" : {
+
+    },
     "Clear shortcut" : {
 
     },
@@ -274,6 +280,9 @@
       }
     },
     "Downloading… %lld%%" : {
+
+    },
+    "Drop audio files to transcribe" : {
 
     },
     "Enable double-tap lock" : {
@@ -551,6 +560,9 @@
     "Remove filler words using case-insensitive regex patterns." : {
 
     },
+    "Remove from this list" : {
+
+    },
     "Remove or replace words in every transcript. Removals use regex patterns and match whole words." : {
 
     },
@@ -576,6 +588,9 @@
 
     },
     "Save transcriptions and audio recordings for later access" : {
+
+    },
+    "Saving transcript..." : {
 
     },
     "Say something…" : {
@@ -693,7 +708,16 @@
     "Support the developer" : {
 
     },
+    "Supported: %@" : {
+
+    },
     "Transcript Modifications" : {
+
+    },
+    "Transcribe" : {
+
+    },
+    "Transcribing audio..." : {
 
     },
     "Transcription history is currently disabled." : {
@@ -742,6 +766,9 @@
       }
     },
     "Use double-tap only" : {
+
+    },
+    "Uses the selected transcription model and saves results to History when history is enabled." : {
 
     },
     "Version" : {


### PR DESCRIPTION
## Summary

- Add a Transcribe tab for drag-and-drop and picker-based audio/video transcription.
- Support common audio formats plus MP4/MOV/M4V files with readable audio tracks, with clearer errors for unsupported or silent video files.
- Save imported transcripts into History when history is enabled, preserving the imported file name and audio extension.
- Polish the transcript result card to match the History card pattern and align the Audio Behavior settings row.

## Testing

- `xcodebuild -scheme Hex -configuration Debug -skipMacroValidation CODE_SIGNING_ALLOWED=NO -quiet build`
- `cd HexCore && swift test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Transcribe" tab with drag-and-drop and file-import audio/video transcription
  * Real-time job list with statuses, per-job copy-to-clipboard and remove actions
  * "Clear Finished" toolbar action and multi-file import support

* **Improvements**
  * Better drop/import error messages and user notices
  * Saved recordings preserve original audio extensions
  * Improved fallback when identifying a transcript's source app

* **Localization**
  * New UI strings for transcription workflow and controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kitlangton/Hex/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->