### PR TITLE
feat(transcription): show live dictation preview while recording

### DIFF
--- a/.changeset/403811d5.md
+++ b/.changeset/403811d5.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Show live dictation preview while recording (#237)

--- a/Hex.xcodeproj/project.pbxproj
+++ b/Hex.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4F0D6A012F1A000100000001 /* HexCore in Frameworks */ = {isa = PBXBuildFile; productRef = 476316262E5FB31400913CDE /* HexCore */; };
-		4F0D6A022F1A000100000001 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E012D444EE900D26DA6 /* ComposableArchitecture */; };
 		47512ABF2E14D8C9000E25BA /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 47512ABE2E14D8C9000E25BA /* WhisperKit */; };
 		476316272E5FB31400913CDE /* HexCore in Frameworks */ = {isa = PBXBuildFile; productRef = 476316262E5FB31400913CDE /* HexCore */; };
 		4765045E2D45900200C7EA60 /* Pow in Frameworks */ = {isa = PBXBuildFile; productRef = 4765045D2D45900200C7EA60 /* Pow */; };
@@ -19,6 +17,8 @@
 		47E05E0A2D44525B00D26DA6 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E092D44525B00D26DA6 /* Dependencies */; };
 		47E05E0C2D44525B00D26DA6 /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E0B2D44525B00D26DA6 /* DependenciesMacros */; };
 		47E16A622EC6C9D300885CF7 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 47E16A612EC6C9D300885CF7 /* FluidAudio */; };
+		4F0D6A012F1A000100000001 /* HexCore in Frameworks */ = {isa = PBXBuildFile; productRef = 476316262E5FB31400913CDE /* HexCore */; };
+		4F0D6A022F1A000100000001 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E012D444EE900D26DA6 /* ComposableArchitecture */; };
 		B5045C972D78DED500D0A119 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = B5045C962D78DED500D0A119 /* MarkdownUI */; };
 		B53356002D7B8D4900E5F542 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B53355FF2D7B8D4900E5F542 /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
@@ -53,17 +53,17 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		4F0D6A032F1A000100000001 /* HexTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = HexTests;
-			sourceTree = "<group>";
-		};
 		47E05DF02D444EC600D26DA6 /* Hex */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				476BAD402D47E8500088C61F /* Exceptions for "Hex" folder in "Hex" target */,
 			);
 			path = Hex;
+			sourceTree = "<group>";
+		};
+		4F0D6A032F1A000100000001 /* HexTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = HexTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -446,8 +446,8 @@
 		47E05DFE2D444EC700D26DA6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = Hex/Hex.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -456,7 +456,7 @@
 				CURRENT_PROJECT_VERSION = 86;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Hex/Preview Content\"";
-				DEVELOPMENT_TEAM = QC99C9JE59;
+				DEVELOPMENT_TEAM = SK85S6YZP9;
 				EMIT_FRONTEND_COMMAND_LINES = YES;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -501,8 +501,8 @@
 		47E05DFF2D444EC700D26DA6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = Hex/Hex.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -511,7 +511,7 @@
 				CURRENT_PROJECT_VERSION = 86;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Hex/Preview Content\"";
-				DEVELOPMENT_TEAM = QC99C9JE59;
+				DEVELOPMENT_TEAM = SK85S6YZP9;
 				EMIT_FRONTEND_COMMAND_LINES = NO;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;

--- a/Hex/Clients/KeyEventMonitorClient.swift
+++ b/Hex/Clients/KeyEventMonitorClient.swift
@@ -30,9 +30,8 @@ struct KeyEventMonitorToken: Sendable {
 public extension KeyEvent {
   init(cgEvent: CGEvent, type: CGEventType, isFnPressed: Bool) {
     let keyCode = Int(cgEvent.getIntegerValueField(.keyboardEventKeycode))
-    // Accessing keyboard layout / input source via Sauce must be on main thread.
     let key: Key?
-    if cgEvent.type == .keyDown {
+    if type == .keyDown, !Self.isModifierKeyCode(keyCode) {
       if Thread.isMainThread {
         key = Sauce.shared.key(for: keyCode)
       } else {
@@ -47,6 +46,18 @@ public extension KeyEvent {
       modifiers = modifiers.removing(kind: .fn)
     }
     self.init(key: key, modifiers: modifiers)
+  }
+
+  /// Modifier keys can emit keyDown/keyUp in addition to flagsChanged; treat them as modifier-only.
+  private static func isModifierKeyCode(_ keyCode: Int) -> Bool {
+    switch keyCode {
+    case Int(kVK_Command), Int(kVK_Shift), Int(kVK_CapsLock), Int(kVK_Option), Int(kVK_Control),
+      Int(kVK_RightCommand), Int(kVK_RightShift), Int(kVK_RightOption), Int(kVK_RightControl),
+      Int(kVK_Function):
+      return true
+    default:
+      return false
+    }
   }
 }
 
@@ -394,6 +405,10 @@ class KeyEventMonitorClientLive {
           }
 
           guard hotKeyClientLive.hasRequiredPermissions else {
+            return Unmanaged.passUnretained(cgEvent)
+          }
+
+          if SyntheticKeyboardEvent.isTagged(cgEvent) {
             return Unmanaged.passUnretained(cgEvent)
           }
 

--- a/Hex/Clients/LiveTextInsertionClient.swift
+++ b/Hex/Clients/LiveTextInsertionClient.swift
@@ -1,0 +1,630 @@
+import ApplicationServices
+import AppKit
+import ComposableArchitecture
+import Dependencies
+import DependenciesMacros
+import Foundation
+import HexCore
+
+private let liveTextInsertionLogger = HexLog.pasteboard
+
+@DependencyClient
+struct LiveTextInsertionClient {
+  /// Capture focus synchronously on the hotkey event path, before async work runs.
+  var prepareNow: @Sendable () -> Bool = { false }
+  var prepare: @Sendable () async -> Bool = { false }
+  var begin: @Sendable () async -> Bool = { false }
+  var update: @Sendable (String) async -> Bool = { _ in false }
+  var finalize: @Sendable (String) async -> Bool = { _ in false }
+  var revert: @Sendable () async -> Void = {}
+  var isActive: @Sendable () async -> Bool = { false }
+  var isKeystrokeUpdateInFlight: @Sendable () -> Bool = { false }
+}
+
+extension LiveTextInsertionClient: DependencyKey {
+  static var liveValue: Self {
+    let live = LiveTextInsertionClientLive()
+    return .init(
+      prepareNow: {
+        if Thread.isMainThread {
+          return MainActor.assumeIsolated { live.prepareNow() }
+        }
+        return DispatchQueue.main.sync { live.prepareNow() }
+      },
+      prepare: { await live.prepare() },
+      begin: { await live.begin() },
+      update: { text in await live.update(text) },
+      finalize: { text in await live.finalize(text) },
+      revert: { await live.revert() },
+      isActive: { await live.isActive() },
+      isKeystrokeUpdateInFlight: {
+        if Thread.isMainThread {
+          return MainActor.assumeIsolated { live.isKeystrokeUpdateInFlight }
+        }
+        return DispatchQueue.main.sync { live.isKeystrokeUpdateInFlight }
+      }
+    )
+  }
+}
+
+extension DependencyValues {
+  var liveTextInsertion: LiveTextInsertionClient {
+    get { self[LiveTextInsertionClient.self] }
+    set { self[LiveTextInsertionClient.self] = newValue }
+  }
+}
+
+final class LiveTextInsertionClientLive {
+  private enum Session {
+    case accessibility(element: AXUIElement, bundleID: String?, state: LiveTextInsertionState)
+    case keystroke(bundleID: String?)
+  }
+
+  @MainActor private var session: Session?
+  @MainActor private var insertedText = ""
+  @MainActor private var keystrokeUpdateChain: Task<Bool, Never>?
+  @MainActor private var keystrokeUpdateGeneration = 0
+  @MainActor private var pendingKeystrokeText: String?
+  @MainActor private(set) var isKeystrokeUpdateInFlight = false
+  private let pasteboard = PasteboardClientLive()
+
+  private static let hexBundleIdentifiers: Set<String> = [
+    "com.kitlangton.Hex",
+    "com.kitlangton.Hex.debug",
+  ]
+
+  @MainActor
+  func prepareNow() -> Bool {
+    prepare()
+  }
+
+  @MainActor
+  func prepare() -> Bool {
+    resetSession()
+
+    if let captured = FocusedTextFieldEditor.captureFromFrontmostApp(
+      excludingBundleIdentifiers: Self.hexBundleIdentifiers
+    ) {
+      session = .accessibility(
+        element: captured.element,
+        bundleID: captured.bundleID,
+        state: captured.state
+      )
+      liveTextInsertionLogger.notice(
+        "Live text insertion prepared mode=accessibility app=\(captured.bundleID ?? "unknown") prefixChars=\(captured.state.prefix.count) suffixChars=\(captured.state.suffix.count)"
+      )
+      return true
+    }
+
+    let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    guard let bundleID, !Self.hexBundleIdentifiers.contains(bundleID) else {
+      liveTextInsertionLogger.notice(
+        "Live text insertion prepare failed: frontmost app is Hex or missing"
+      )
+      return false
+    }
+
+    if let selectedTextElement = FocusedTextFieldEditor.captureSelectedTextElement(
+      excludingBundleIdentifiers: Self.hexBundleIdentifiers
+    ) {
+      session = .accessibility(
+        element: selectedTextElement.element,
+        bundleID: selectedTextElement.bundleID,
+        state: selectedTextElement.state
+      )
+      liveTextInsertionLogger.notice(
+        "Live text insertion prepared mode=accessibility-selected-text app=\(selectedTextElement.bundleID ?? "unknown")"
+      )
+      return true
+    }
+
+    session = .keystroke(bundleID: bundleID)
+    liveTextInsertionLogger.notice(
+      "Live text insertion prepared mode=keystroke app=\(bundleID)"
+    )
+    return true
+  }
+
+  @MainActor
+  func begin() -> Bool {
+    if session != nil { return true }
+    return prepare()
+  }
+
+  @MainActor
+  func update(_ text: String) async -> Bool {
+    guard let session else { return false }
+
+    switch session {
+    case let .accessibility(element, bundleID, state):
+      var mutableState = state
+      let previousInsertedLength = mutableState.insertedText.count
+      let newValue = mutableState.update(with: text)
+      guard FocusedTextFieldEditor.apply(
+        to: element,
+        state: mutableState,
+        value: newValue,
+        previousInsertedLength: previousInsertedLength
+      ) else {
+        liveTextInsertionLogger.debug(
+          "Live text insertion accessibility update failed app=\(bundleID ?? "unknown") chars=\(text.count)"
+        )
+        return false
+      }
+
+      self.session = .accessibility(element: element, bundleID: bundleID, state: mutableState)
+      insertedText = text
+      liveTextInsertionLogger.notice("Live text insertion updated mode=accessibility chars=\(text.count)")
+      return true
+
+    case let .keystroke(bundleID):
+      pendingKeystrokeText = text
+      keystrokeUpdateGeneration &+= 1
+      let generation = keystrokeUpdateGeneration
+      isKeystrokeUpdateInFlight = true
+      let priorChain = keystrokeUpdateChain
+      let updateTask = Task { @MainActor in
+        if let priorChain {
+          _ = await priorChain.value
+        }
+
+        defer {
+          if self.keystrokeUpdateGeneration == generation {
+            self.isKeystrokeUpdateInFlight = false
+          }
+        }
+
+        var lastSucceeded = false
+        while let targetText = self.pendingKeystrokeText {
+          self.pendingKeystrokeText = nil
+          let previousText = self.insertedText
+          lastSucceeded = await self.pasteboard.replaceLiveText(
+            targetBundleID: bundleID,
+            previousText: previousText,
+            newText: targetText
+          )
+          if lastSucceeded {
+            self.insertedText = targetText
+          } else if !previousText.isEmpty {
+            liveTextInsertionLogger.debug(
+              "Live text insertion keystroke replace failed; keeping previous snapshot chars=\(previousText.count)"
+            )
+          }
+        }
+        return lastSucceeded
+      }
+      keystrokeUpdateChain = updateTask
+      guard await updateTask.value else {
+        liveTextInsertionLogger.debug(
+          "Live text insertion keystroke update failed app=\(bundleID ?? "unknown") chars=\(text.count)"
+        )
+        return false
+      }
+      liveTextInsertionLogger.notice("Live text insertion updated mode=keystroke chars=\(text.count)")
+      return true
+    }
+  }
+
+  @MainActor
+  func finalize(_ text: String) async -> Bool {
+    guard session != nil else { return false }
+    let succeeded = await update(text)
+    if succeeded {
+      resetSession()
+      liveTextInsertionLogger.notice("Live text insertion finalized chars=\(text.count)")
+    }
+    return succeeded
+  }
+
+  @MainActor
+  func revert() async {
+    guard let session, !insertedText.isEmpty else {
+      resetSession()
+      return
+    }
+
+    switch session {
+    case let .accessibility(element, _, state):
+      let restored = state.revertedValue()
+      _ = FocusedTextFieldEditor.apply(
+        to: element,
+        state: LiveTextInsertionState(
+          prefix: state.prefix,
+          suffix: state.suffix,
+          insertedText: ""
+        ),
+        value: restored,
+        cursorLocation: state.revertedCursorLocation
+      )
+      liveTextInsertionLogger.notice("Live text insertion reverted mode=accessibility")
+
+    case .keystroke(let bundleID):
+      let revertCount = insertedText.count
+      pasteboard.activateApplication(bundleIdentifier: bundleID)
+      if revertCount > 0 {
+        await pasteboard.selectBackwardAndDeleteForRevert(count: revertCount)
+      }
+      liveTextInsertionLogger.notice("Live text insertion reverted mode=keystroke")
+    }
+
+    resetSession()
+  }
+
+  @MainActor
+  func isActive() -> Bool {
+    session != nil
+  }
+
+  @MainActor
+  private func resetSession() {
+    keystrokeUpdateChain?.cancel()
+    keystrokeUpdateChain = nil
+    keystrokeUpdateGeneration &+= 1
+    isKeystrokeUpdateInFlight = false
+    session = nil
+    insertedText = ""
+    pendingKeystrokeText = nil
+  }
+}
+
+private struct CapturedTextField {
+  let element: AXUIElement
+  let bundleID: String?
+  let state: LiveTextInsertionState
+}
+
+@MainActor
+private enum FocusedTextFieldEditor {
+  private static let editableRoles: Set<String> = [
+    kAXTextFieldRole as String,
+    kAXTextAreaRole as String,
+    kAXComboBoxRole as String,
+    "AXSearchField",
+    "AXWebArea",
+  ]
+
+  static func captureFromFrontmostApp(
+    excludingBundleIdentifiers: Set<String>
+  ) -> CapturedTextField? {
+    if let systemWide = captureSystemWideFocusedElement(excludingBundleIdentifiers: excludingBundleIdentifiers) {
+      return systemWide
+    }
+
+    if let frontmost = NSWorkspace.shared.frontmostApplication,
+       let bundleID = frontmost.bundleIdentifier,
+       !excludingBundleIdentifiers.contains(bundleID),
+       let captured = capture(in: frontmost.processIdentifier, bundleID: bundleID)
+    {
+      return captured
+    }
+
+    for app in NSWorkspace.shared.runningApplications where app.isActive {
+      guard let bundleID = app.bundleIdentifier,
+            !excludingBundleIdentifiers.contains(bundleID),
+            let captured = capture(in: app.processIdentifier, bundleID: bundleID)
+      else { continue }
+      return captured
+    }
+
+    return nil
+  }
+
+  static func captureSelectedTextElement(
+    excludingBundleIdentifiers: Set<String>
+  ) -> CapturedTextField? {
+    let systemWideElement = AXUIElementCreateSystemWide()
+    var focusedElementRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+      systemWideElement,
+      kAXFocusedUIElementAttribute as CFString,
+      &focusedElementRef
+    ) == .success,
+      let focusedElementRef
+    else {
+      return nil
+    }
+
+    let element = focusedElementRef as! AXUIElement
+    guard let pid = processID(of: element),
+          let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
+          !excludingBundleIdentifiers.contains(bundleID),
+          canSetSelectedText(on: element)
+    else {
+      return nil
+    }
+
+    return CapturedTextField(
+      element: element,
+      bundleID: bundleID,
+      state: LiveTextInsertionState(prefix: "", suffix: "")
+    )
+  }
+
+  private static func captureSystemWideFocusedElement(
+    excludingBundleIdentifiers: Set<String>
+  ) -> CapturedTextField? {
+    let systemWideElement = AXUIElementCreateSystemWide()
+    var focusedElementRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+      systemWideElement,
+      kAXFocusedUIElementAttribute as CFString,
+      &focusedElementRef
+    ) == .success,
+      let focusedElementRef
+    else {
+      return nil
+    }
+
+    let element = focusedElementRef as! AXUIElement
+    guard let pid = processID(of: element),
+          let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
+          !excludingBundleIdentifiers.contains(bundleID),
+          let state = captureState(from: element)
+    else {
+      return nil
+    }
+
+    return CapturedTextField(element: element, bundleID: bundleID, state: state)
+  }
+
+  private static func capture(in processID: pid_t, bundleID: String) -> CapturedTextField? {
+    let appElement = AXUIElementCreateApplication(processID)
+
+    if let focused = focusedElement(in: appElement),
+       let state = captureState(from: focused)
+    {
+      return CapturedTextField(element: focused, bundleID: bundleID, state: state)
+    }
+
+    if let window = focusedWindow(in: appElement),
+       let editable = findEditableElement(in: window),
+       let state = captureState(from: editable)
+    {
+      return CapturedTextField(element: editable, bundleID: bundleID, state: state)
+    }
+
+    return nil
+  }
+
+  private static func captureState(from element: AXUIElement) -> LiveTextInsertionState? {
+    guard elementSupportsTextEditing(element) else { return nil }
+
+    if let fullValue = readValue(from: element),
+       let selection = readSelectedRange(from: element),
+       let initialState = LiveTextInsertionLogic.snapshot(
+         fullValue: fullValue,
+         selectionLocation: selection.location,
+         selectionLength: selection.length
+       )
+    {
+      return initialState
+    }
+
+    if readSelectedRange(from: element) != nil || canSetSelectedText(on: element) {
+      return LiveTextInsertionState(prefix: "", suffix: "")
+    }
+
+    return nil
+  }
+
+  static func apply(
+    to element: AXUIElement,
+    state: LiveTextInsertionState,
+    value: String,
+    cursorLocation: Int? = nil,
+    previousInsertedLength: Int = 0
+  ) -> Bool {
+    guard elementSupportsTextEditing(element) else { return false }
+
+    let targetCursor = cursorLocation ?? state.cursorLocation
+    let insertionStart = max(0, targetCursor - state.insertedText.count)
+
+    if previousInsertedLength > 0 {
+      let replaceRange = CFRange(location: insertionStart, length: previousInsertedLength)
+      guard setSelectedRange(replaceRange, on: element) else { return false }
+      guard AXUIElementSetAttributeValue(
+        element,
+        kAXSelectedTextAttribute as CFString,
+        state.insertedText as CFString
+      ) == .success else {
+        return false
+      }
+      return setSelectedRange(CFRange(location: targetCursor, length: 0), on: element)
+    }
+
+    if let selection = readSelectedRange(from: element) {
+      let replaceRange = CFRange(location: selection.location, length: selection.length)
+      if setSelectedRange(replaceRange, on: element),
+         AXUIElementSetAttributeValue(
+           element,
+           kAXSelectedTextAttribute as CFString,
+           state.insertedText as CFString
+         ) == .success
+      {
+        return setSelectedRange(
+          CFRange(location: selection.location + state.insertedText.count, length: 0),
+          on: element
+        )
+      }
+    }
+
+    if setValue(value, on: element) {
+      return setSelectedRange(CFRange(location: targetCursor, length: 0), on: element)
+    }
+
+    let fallbackRange = CFRange(
+      location: readSelectedRange(from: element)?.location ?? 0,
+      length: 0
+    )
+    guard setSelectedRange(fallbackRange, on: element) else { return false }
+    return AXUIElementSetAttributeValue(
+      element,
+      kAXSelectedTextAttribute as CFString,
+      state.insertedText as CFString
+    ) == .success
+  }
+
+  private static func focusedElement(in appElement: AXUIElement) -> AXUIElement? {
+    var focusedElementRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+      appElement,
+      kAXFocusedUIElementAttribute as CFString,
+      &focusedElementRef
+    ) == .success,
+      let focusedElementRef
+    else {
+      return nil
+    }
+    return (focusedElementRef as! AXUIElement)
+  }
+
+  private static func focusedWindow(in appElement: AXUIElement) -> AXUIElement? {
+    var windowRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(
+      appElement,
+      kAXFocusedWindowAttribute as CFString,
+      &windowRef
+    ) == .success,
+      let windowRef
+    else {
+      return nil
+    }
+    return (windowRef as! AXUIElement)
+  }
+
+  private static func findEditableElement(in root: AXUIElement, depth: Int = 0) -> AXUIElement? {
+    guard depth <= 12 else { return nil }
+
+    if elementSupportsTextEditing(root), captureState(from: root) != nil {
+      return root
+    }
+
+    guard let children = childElements(of: root) else { return nil }
+
+    for child in children {
+      if editableRoles.contains(role(of: child) ?? ""),
+         elementSupportsTextEditing(child),
+         captureState(from: child) != nil
+      {
+        return child
+      }
+    }
+
+    for child in children {
+      if let match = findEditableElement(in: child, depth: depth + 1) {
+        return match
+      }
+    }
+
+    return nil
+  }
+
+  private static func childElements(of element: AXUIElement) -> [AXUIElement]? {
+    var childrenRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+          let children = childrenRef as? [AXUIElement]
+    else {
+      return nil
+    }
+    return children
+  }
+
+  private static func role(of element: AXUIElement) -> String? {
+    var roleRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef) == .success else {
+      return nil
+    }
+    return roleRef as? String
+  }
+
+  private static func processID(of element: AXUIElement) -> pid_t? {
+    var pid = pid_t(0)
+    guard AXUIElementGetPid(element, &pid) == .success else { return nil }
+    return pid
+  }
+
+  private static func canSetSelectedText(on element: AXUIElement) -> Bool {
+    var settable = DarwinBoolean(false)
+    return AXUIElementIsAttributeSettable(element, kAXSelectedTextAttribute as CFString, &settable) == .success
+      && settable.boolValue
+  }
+
+  private static func elementSupportsTextEditing(_ element: AXUIElement) -> Bool {
+    if copyBoolAttribute(element, "AXEditableText" as CFString) == true {
+      return true
+    }
+
+    if canSetSelectedText(on: element) {
+      return true
+    }
+
+    var value: CFTypeRef?
+    let supportsText = AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &value) == .success
+    let supportsSelectedText = AXUIElementCopyAttributeValue(element, kAXSelectedTextAttribute as CFString, &value) == .success
+    if supportsText || supportsSelectedText {
+      return true
+    }
+
+    if let role = role(of: element), editableRoles.contains(role) {
+      return true
+    }
+
+    return false
+  }
+
+  private static func copyBoolAttribute(_ element: AXUIElement, _ attribute: CFString) -> Bool? {
+    var valueRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute, &valueRef) == .success else {
+      return nil
+    }
+    if let boolValue = valueRef as? Bool {
+      return boolValue
+    }
+    if let number = valueRef as? NSNumber {
+      return number.boolValue
+    }
+    return nil
+  }
+
+  private static func readValue(from element: AXUIElement) -> String? {
+    var valueRef: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success else {
+      return nil
+    }
+
+    if let string = valueRef as? String {
+      return string
+    }
+    if let attributed = valueRef as? NSAttributedString {
+      return attributed.string
+    }
+    return nil
+  }
+
+  private static func readSelectedRange(from element: AXUIElement) -> CFRange? {
+    var rangeValue: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXSelectedTextRangeAttribute as CFString, &rangeValue) == .success,
+          let rangeValue,
+          CFGetTypeID(rangeValue) == AXValueGetTypeID()
+    else {
+      return nil
+    }
+
+    let axValue = rangeValue as! AXValue
+    guard AXValueGetType(axValue) == .cfRange else { return nil }
+
+    var range = CFRange()
+    guard AXValueGetValue(axValue, .cfRange, &range) else { return nil }
+    return range
+  }
+
+  private static func setValue(_ value: String, on element: AXUIElement) -> Bool {
+    AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFString) == .success
+  }
+
+  private static func setSelectedRange(_ range: CFRange, on element: AXUIElement) -> Bool {
+    var mutableRange = range
+    guard let axRange = AXValueCreate(AXValueType.cfRange, &mutableRange) else { return false }
+    return AXUIElementSetAttributeValue(element, kAXSelectedTextRangeAttribute as CFString, axRange) == .success
+  }
+}

--- a/Hex/Clients/LiveTextInsertionClient.swift
+++ b/Hex/Clients/LiveTextInsertionClient.swift
@@ -119,6 +119,7 @@ final class LiveTextInsertionClientLive {
     }
 
     session = .keystroke(bundleID: bundleID)
+    pasteboard.beginLiveKeystrokePasteboardSession()
     liveTextInsertionLogger.notice(
       "Live text insertion prepared mode=keystroke app=\(bundleID)"
     )
@@ -210,7 +211,8 @@ final class LiveTextInsertionClientLive {
     guard session != nil else { return false }
     let succeeded = await update(text)
     if succeeded {
-      resetSession()
+      let finalKeystrokeText: String? = if case .keystroke = session { text } else { nil }
+      resetSession(finalKeystrokeText: finalKeystrokeText)
       liveTextInsertionLogger.notice("Live text insertion finalized chars=\(text.count)")
     }
     return succeeded
@@ -256,7 +258,10 @@ final class LiveTextInsertionClientLive {
   }
 
   @MainActor
-  private func resetSession() {
+  private func resetSession(finalKeystrokeText: String? = nil) {
+    if case .keystroke = session {
+      pasteboard.endLiveKeystrokePasteboardSession(finalText: finalKeystrokeText)
+    }
     keystrokeUpdateChain?.cancel()
     keystrokeUpdateChain = nil
     keystrokeUpdateGeneration &+= 1

--- a/Hex/Clients/LiveTextInsertionClient.swift
+++ b/Hex/Clients/LiveTextInsertionClient.swift
@@ -168,6 +168,9 @@ final class LiveTextInsertionClientLive {
       return true
 
     case let .keystroke(bundleID, preferFullReplace):
+      if text == insertedText {
+        return true
+      }
       pendingKeystrokeText = text
       keystrokeUpdateGeneration &+= 1
       let generation = keystrokeUpdateGeneration
@@ -236,36 +239,70 @@ final class LiveTextInsertionClientLive {
 
   @MainActor
   func finalize(_ text: String) async -> Bool {
-    guard session != nil else { return false }
-    if await update(text) {
-      let finalKeystrokeText: String? = if case .keystroke = session { text } else { nil }
-      await resetSession(finalKeystrokeText: finalKeystrokeText)
-      liveTextInsertionLogger.notice("Live text insertion finalized chars=\(text.count)")
-      return true
-    }
+    guard let session else { return false }
 
-    if case let .keystroke(bundleID, preferFullReplace) = session {
-      let previousText = insertedText
-      guard previousText != text else {
-        await resetSession(finalKeystrokeText: text)
-        return true
+    pendingKeystrokeText = nil
+    keystrokeUpdateGeneration &+= 1
+    if let chain = keystrokeUpdateChain {
+      _ = await chain.value
+    }
+    keystrokeUpdateChain = nil
+    isKeystrokeUpdateInFlight = false
+
+    switch session {
+    case let .accessibility(element, bundleID, state):
+      var mutableState = state
+      let previousInsertedLength = mutableState.insertedText.count
+      let newValue = mutableState.update(with: text)
+      guard FocusedTextFieldEditor.apply(
+        to: element,
+        state: mutableState,
+        value: newValue,
+        previousInsertedLength: previousInsertedLength
+      ) else {
+        return false
       }
-      let replaced = await pasteboard.replaceLiveText(
-        targetBundleID: bundleID,
-        previousText: previousText,
-        newText: text,
-        preferFullReplace: true
-      )
-      if replaced {
+      await resetSession()
+      liveTextInsertionLogger.notice("Live text insertion finalized mode=accessibility chars=\(text.count)")
+      return true
+
+    case let .keystroke(bundleID, _):
+      let previewText = insertedText
+
+      if previewText == text, !previewText.isEmpty {
         await resetSession(finalKeystrokeText: text)
         liveTextInsertionLogger.notice(
-          "Live text insertion finalized via full-replace fallback chars=\(text.count) fullReplace=\(preferFullReplace)"
+          "Live text insertion finalized without re-paste chars=\(text.count)"
         )
         return true
       }
-    }
 
-    return false
+      pasteboard.activateApplication(bundleIdentifier: bundleID)
+      if !previewText.isEmpty {
+        await pasteboard.deleteKeystrokeInsertedText(count: previewText.count)
+      }
+
+      let pasted: Bool
+      if text.isEmpty {
+        pasted = true
+      } else {
+        pasted = await pasteboard.pasteKeystrokeTextAtCursor(text, targetBundleID: bundleID)
+      }
+
+      guard pasted else { return false }
+
+      await resetSession(finalKeystrokeText: text)
+      if previewText.isEmpty {
+        liveTextInsertionLogger.notice(
+          "Live text insertion finalized via single-paste chars=\(text.count)"
+        )
+      } else {
+        liveTextInsertionLogger.notice(
+          "Live text insertion finalized via revert-and-paste chars=\(text.count) previewChars=\(previewText.count)"
+        )
+      }
+      return true
+    }
   }
 
   @MainActor
@@ -300,7 +337,7 @@ final class LiveTextInsertionClientLive {
       let revertCount = insertedText.count
       pasteboard.activateApplication(bundleIdentifier: bundleID)
       if revertCount > 0 {
-        await pasteboard.selectBackwardAndDeleteForRevert(count: revertCount)
+        await pasteboard.deleteKeystrokeInsertedText(count: revertCount)
       }
       liveTextInsertionLogger.notice("Live text insertion reverted mode=keystroke")
     }

--- a/Hex/Clients/LiveTextInsertionClient.swift
+++ b/Hex/Clients/LiveTextInsertionClient.swift
@@ -18,6 +18,7 @@ struct LiveTextInsertionClient {
   var finalize: @Sendable (String) async -> Bool = { _ in false }
   var revert: @Sendable () async -> Void = {}
   var isActive: @Sendable () async -> Bool = { false }
+  var isKeystrokeSession: @Sendable () async -> Bool = { false }
   var isKeystrokeUpdateInFlight: @Sendable () -> Bool = { false }
 }
 
@@ -37,6 +38,7 @@ extension LiveTextInsertionClient: DependencyKey {
       finalize: { text in await live.finalize(text) },
       revert: { await live.revert() },
       isActive: { await live.isActive() },
+      isKeystrokeSession: { await live.isKeystrokeSession() },
       isKeystrokeUpdateInFlight: {
         if Thread.isMainThread {
           return MainActor.assumeIsolated { live.isKeystrokeUpdateInFlight }
@@ -57,7 +59,7 @@ extension DependencyValues {
 final class LiveTextInsertionClientLive {
   private enum Session {
     case accessibility(element: AXUIElement, bundleID: String?, state: LiveTextInsertionState)
-    case keystroke(bundleID: String?)
+    case keystroke(bundleID: String?, preferFullReplace: Bool)
   }
 
   @MainActor private var session: Session?
@@ -73,6 +75,16 @@ final class LiveTextInsertionClientLive {
     "com.kitlangton.Hex.debug",
   ]
 
+  /// Electron and web-wrapper chat apps often drop incremental backspaces; full replace is safer.
+  private static let fullKeystrokeReplaceBundleIdentifiers: Set<String> = [
+    "net.whatsapp.WhatsApp",
+    "net.whatsapp.WhatsApp.Service",
+    "com.tinyspeck.slackmacgap",
+    "com.microsoft.teams2",
+    "com.hnc.Discord",
+    "org.telegram.desktop",
+  ]
+
   @MainActor
   func prepareNow() -> Bool {
     prepare()
@@ -80,7 +92,7 @@ final class LiveTextInsertionClientLive {
 
   @MainActor
   func prepare() -> Bool {
-    resetSession()
+    resetSessionImmediately()
 
     if let captured = FocusedTextFieldEditor.captureFromFrontmostApp(
       excludingBundleIdentifiers: Self.hexBundleIdentifiers
@@ -118,10 +130,13 @@ final class LiveTextInsertionClientLive {
       return true
     }
 
-    session = .keystroke(bundleID: bundleID)
+    session = .keystroke(
+      bundleID: bundleID,
+      preferFullReplace: Self.fullKeystrokeReplaceBundleIdentifiers.contains(bundleID)
+    )
     pasteboard.beginLiveKeystrokePasteboardSession()
     liveTextInsertionLogger.notice(
-      "Live text insertion prepared mode=keystroke app=\(bundleID)"
+      "Live text insertion prepared mode=keystroke app=\(bundleID) fullReplace=\(Self.fullKeystrokeReplaceBundleIdentifiers.contains(bundleID))"
     )
     return true
   }
@@ -158,7 +173,7 @@ final class LiveTextInsertionClientLive {
       liveTextInsertionLogger.notice("Live text insertion updated mode=accessibility chars=\(text.count)")
       return true
 
-    case let .keystroke(bundleID):
+    case let .keystroke(bundleID, preferFullReplace):
       pendingKeystrokeText = text
       keystrokeUpdateGeneration &+= 1
       let generation = keystrokeUpdateGeneration
@@ -176,20 +191,39 @@ final class LiveTextInsertionClientLive {
         }
 
         var lastSucceeded = false
+        var useFullReplace = preferFullReplace
         while let targetText = self.pendingKeystrokeText {
           self.pendingKeystrokeText = nil
           let previousText = self.insertedText
           lastSucceeded = await self.pasteboard.replaceLiveText(
             targetBundleID: bundleID,
             previousText: previousText,
-            newText: targetText
+            newText: targetText,
+            preferFullReplace: useFullReplace
           )
           if lastSucceeded {
             self.insertedText = targetText
           } else if !previousText.isEmpty {
-            liveTextInsertionLogger.debug(
-              "Live text insertion keystroke replace failed; keeping previous snapshot chars=\(previousText.count)"
+            useFullReplace = true
+            if case .keystroke(let bundleID, _) = self.session {
+              self.session = .keystroke(bundleID: bundleID, preferFullReplace: true)
+            }
+            lastSucceeded = await self.pasteboard.replaceLiveText(
+              targetBundleID: bundleID,
+              previousText: previousText,
+              newText: targetText,
+              preferFullReplace: true
             )
+            if lastSucceeded {
+              self.insertedText = targetText
+              liveTextInsertionLogger.notice(
+                "Live text insertion keystroke full-replace retry succeeded chars=\(targetText.count)"
+              )
+            } else {
+              liveTextInsertionLogger.debug(
+                "Live text insertion keystroke replace failed; keeping previous snapshot chars=\(previousText.count)"
+              )
+            }
           }
         }
         return lastSucceeded
@@ -209,19 +243,47 @@ final class LiveTextInsertionClientLive {
   @MainActor
   func finalize(_ text: String) async -> Bool {
     guard session != nil else { return false }
-    let succeeded = await update(text)
-    if succeeded {
+    if await update(text) {
       let finalKeystrokeText: String? = if case .keystroke = session { text } else { nil }
-      resetSession(finalKeystrokeText: finalKeystrokeText)
+      await resetSession(finalKeystrokeText: finalKeystrokeText)
       liveTextInsertionLogger.notice("Live text insertion finalized chars=\(text.count)")
+      return true
     }
-    return succeeded
+
+    if case let .keystroke(bundleID, preferFullReplace) = session {
+      let previousText = insertedText
+      guard previousText != text else {
+        await resetSession(finalKeystrokeText: text)
+        return true
+      }
+      let replaced = await pasteboard.replaceLiveText(
+        targetBundleID: bundleID,
+        previousText: previousText,
+        newText: text,
+        preferFullReplace: true
+      )
+      if replaced {
+        await resetSession(finalKeystrokeText: text)
+        liveTextInsertionLogger.notice(
+          "Live text insertion finalized via full-replace fallback chars=\(text.count) fullReplace=\(preferFullReplace)"
+        )
+        return true
+      }
+    }
+
+    return false
   }
 
   @MainActor
   func revert() async {
+    pendingKeystrokeText = nil
+    keystrokeUpdateGeneration &+= 1
+    if let chain = keystrokeUpdateChain {
+      _ = await chain.value
+    }
+
     guard let session, !insertedText.isEmpty else {
-      resetSession()
+      await resetSession()
       return
     }
 
@@ -240,7 +302,7 @@ final class LiveTextInsertionClientLive {
       )
       liveTextInsertionLogger.notice("Live text insertion reverted mode=accessibility")
 
-    case .keystroke(let bundleID):
+    case .keystroke(let bundleID, _):
       let revertCount = insertedText.count
       pasteboard.activateApplication(bundleIdentifier: bundleID)
       if revertCount > 0 {
@@ -249,7 +311,7 @@ final class LiveTextInsertionClientLive {
       liveTextInsertionLogger.notice("Live text insertion reverted mode=keystroke")
     }
 
-    resetSession()
+    await resetSession()
   }
 
   @MainActor
@@ -258,9 +320,15 @@ final class LiveTextInsertionClientLive {
   }
 
   @MainActor
-  private func resetSession(finalKeystrokeText: String? = nil) {
+  func isKeystrokeSession() -> Bool {
+    if case .keystroke = session { return true }
+    return false
+  }
+
+  @MainActor
+  private func resetSessionImmediately() {
     if case .keystroke = session {
-      pasteboard.endLiveKeystrokePasteboardSession(finalText: finalKeystrokeText)
+      pasteboard.endLiveKeystrokePasteboardSession(finalText: nil)
     }
     keystrokeUpdateChain?.cancel()
     keystrokeUpdateChain = nil
@@ -269,6 +337,23 @@ final class LiveTextInsertionClientLive {
     session = nil
     insertedText = ""
     pendingKeystrokeText = nil
+  }
+
+  @MainActor
+  private func resetSession(finalKeystrokeText: String? = nil) async {
+    pendingKeystrokeText = nil
+    keystrokeUpdateGeneration &+= 1
+    keystrokeUpdateChain?.cancel()
+    if let chain = keystrokeUpdateChain {
+      _ = await chain.value
+    }
+    keystrokeUpdateChain = nil
+    isKeystrokeUpdateInFlight = false
+    if case .keystroke = session {
+      pasteboard.endLiveKeystrokePasteboardSession(finalText: finalKeystrokeText)
+    }
+    session = nil
+    insertedText = ""
   }
 }
 
@@ -336,6 +421,21 @@ private enum FocusedTextFieldEditor {
           canSetSelectedText(on: element)
     else {
       return nil
+    }
+
+    if let fullValue = readValue(from: element),
+       let selection = readSelectedRange(from: element),
+       let initialState = LiveTextInsertionLogic.snapshot(
+         fullValue: fullValue,
+         selectionLocation: selection.location,
+         selectionLength: selection.length
+       )
+    {
+      return CapturedTextField(
+        element: element,
+        bundleID: bundleID,
+        state: initialState
+      )
     }
 
     return CapturedTextField(

--- a/Hex/Clients/LiveTextInsertionClient.swift
+++ b/Hex/Clients/LiveTextInsertionClient.swift
@@ -63,6 +63,7 @@ final class LiveTextInsertionClientLive {
   }
 
   @MainActor private var session: Session?
+  @MainActor private var sessionID = UUID()
   @MainActor private var insertedText = ""
   @MainActor private var keystrokeUpdateChain: Task<Bool, Never>?
   @MainActor private var keystrokeUpdateGeneration = 0
@@ -75,9 +76,8 @@ final class LiveTextInsertionClientLive {
     "com.kitlangton.Hex.debug",
   ]
 
-  /// Keystroke fallback means Accessibility insertion failed; incremental edits are
-  /// unreliable in Electron/web-wrapper apps (WhatsApp, Slack, Cursor, etc.).
-  private static let prefersFullKeystrokeReplace: Bool = true
+  /// Prefer incremental append/revision during live preview; escalate to full replace on failure.
+  private static let prefersFullKeystrokeReplace: Bool = false
 
   @MainActor
   func prepareNow() -> Bool {
@@ -87,6 +87,7 @@ final class LiveTextInsertionClientLive {
   @MainActor
   func prepare() -> Bool {
     resetSessionImmediately()
+    sessionID = UUID()
 
     if let captured = FocusedTextFieldEditor.captureFromFrontmostApp(
       excludingBundleIdentifiers: Self.hexBundleIdentifiers
@@ -240,6 +241,7 @@ final class LiveTextInsertionClientLive {
   @MainActor
   func finalize(_ text: String) async -> Bool {
     guard let session else { return false }
+    let expectedSessionID = sessionID
 
     pendingKeystrokeText = nil
     keystrokeUpdateGeneration &+= 1
@@ -249,8 +251,15 @@ final class LiveTextInsertionClientLive {
     keystrokeUpdateChain = nil
     isKeystrokeUpdateInFlight = false
 
+    guard sessionID == expectedSessionID else {
+      liveTextInsertionLogger.notice(
+        "Live text insertion finalize skipped — session superseded by a newer recording"
+      )
+      return false
+    }
+
     switch session {
-    case let .accessibility(element, bundleID, state):
+    case let .accessibility(element, _, state):
       var mutableState = state
       let previousInsertedLength = mutableState.insertedText.count
       let newValue = mutableState.update(with: text)

--- a/Hex/Clients/LiveTextInsertionClient.swift
+++ b/Hex/Clients/LiveTextInsertionClient.swift
@@ -75,15 +75,9 @@ final class LiveTextInsertionClientLive {
     "com.kitlangton.Hex.debug",
   ]
 
-  /// Electron and web-wrapper chat apps often drop incremental backspaces; full replace is safer.
-  private static let fullKeystrokeReplaceBundleIdentifiers: Set<String> = [
-    "net.whatsapp.WhatsApp",
-    "net.whatsapp.WhatsApp.Service",
-    "com.tinyspeck.slackmacgap",
-    "com.microsoft.teams2",
-    "com.hnc.Discord",
-    "org.telegram.desktop",
-  ]
+  /// Keystroke fallback means Accessibility insertion failed; incremental edits are
+  /// unreliable in Electron/web-wrapper apps (WhatsApp, Slack, Cursor, etc.).
+  private static let prefersFullKeystrokeReplace: Bool = true
 
   @MainActor
   func prepareNow() -> Bool {
@@ -132,11 +126,11 @@ final class LiveTextInsertionClientLive {
 
     session = .keystroke(
       bundleID: bundleID,
-      preferFullReplace: Self.fullKeystrokeReplaceBundleIdentifiers.contains(bundleID)
+      preferFullReplace: Self.prefersFullKeystrokeReplace
     )
     pasteboard.beginLiveKeystrokePasteboardSession()
     liveTextInsertionLogger.notice(
-      "Live text insertion prepared mode=keystroke app=\(bundleID) fullReplace=\(Self.fullKeystrokeReplaceBundleIdentifiers.contains(bundleID))"
+      "Live text insertion prepared mode=keystroke app=\(bundleID) fullReplace=\(Self.prefersFullKeystrokeReplace)"
     )
     return true
   }

--- a/Hex/Clients/LiveTranscriptionClient.swift
+++ b/Hex/Clients/LiveTranscriptionClient.swift
@@ -66,7 +66,9 @@ actor LiveTranscriptionClientLive {
   private var fedBufferCount = 0
 
   init() {
-    resetUpdateStream()
+    let (stream, continuation) = AsyncStream<LiveTranscriptionUpdate>.makeStream()
+    updateStream = stream
+    updateContinuation = continuation
   }
 
   private func resetUpdateStream() {

--- a/Hex/Clients/LiveTranscriptionClient.swift
+++ b/Hex/Clients/LiveTranscriptionClient.swift
@@ -1,0 +1,212 @@
+//
+//  LiveTranscriptionClient.swift
+//  Hex
+//
+
+import AVFoundation
+import Dependencies
+import DependenciesMacros
+import Foundation
+import HexCore
+
+#if canImport(FluidAudio)
+import FluidAudio
+#endif
+
+struct LiveTranscriptionUpdate: Equatable, Sendable {
+  let text: String
+  let isConfirmed: Bool
+}
+
+@DependencyClient
+struct LiveTranscriptionClient {
+  var isSupported: @Sendable (String) async -> Bool = { _ in false }
+  var prepare: @Sendable (String) async throws -> Void = { _ in }
+  var start: @Sendable (String) async throws -> Void = { _ in }
+  var feedAudio: @Sendable (AVAudioPCMBuffer) async -> Void = { _ in }
+  var observeUpdates: @Sendable () async -> AsyncStream<LiveTranscriptionUpdate> = { AsyncStream { _ in } }
+  var finish: @Sendable () async throws -> String = { "" }
+  var cancel: @Sendable () async -> Void = {}
+}
+
+extension LiveTranscriptionClient: DependencyKey {
+  static var liveValue: Self {
+    let live = LiveTranscriptionClientLive()
+    return Self(
+      isSupported: { await live.isSupported($0) },
+      prepare: { try await live.prepare(modelName: $0) },
+      start: { try await live.start(modelName: $0) },
+      feedAudio: { await live.feedAudio($0) },
+      observeUpdates: { await live.observeUpdates() },
+      finish: { try await live.finish() },
+      cancel: { await live.cancel() }
+    )
+  }
+
+  static let testValue = Self()
+}
+
+extension DependencyValues {
+  var liveTranscription: LiveTranscriptionClient {
+    get { self[LiveTranscriptionClient.self] }
+    set { self[LiveTranscriptionClient.self] = newValue }
+  }
+}
+
+#if canImport(FluidAudio)
+
+actor LiveTranscriptionClientLive {
+  private let logger = HexLog.parakeet
+  private var manager: StreamingAsrManager?
+  private var bridgeTask: Task<Void, Never>?
+  private let (updateStream, updateContinuation) = AsyncStream<LiveTranscriptionUpdate>.makeStream()
+  private var cachedModels: AsrModels?
+  private var cachedVariant: ParakeetModel?
+  private var fedBufferCount = 0
+
+  func isSupported(_ modelName: String) -> Bool {
+    ParakeetModel(rawValue: modelName) != nil
+  }
+
+  func observeUpdates() -> AsyncStream<LiveTranscriptionUpdate> {
+    updateStream
+  }
+
+  func prepare(modelName: String) async throws {
+    guard let variant = ParakeetModel(rawValue: modelName) else { return }
+    if cachedVariant == variant, cachedModels != nil { return }
+
+    logger.notice("Preparing live transcription models variant=\(variant.identifier)")
+    let models = try await AsrModels.downloadAndLoad(version: variant.asrVersion)
+    cachedModels = models
+    cachedVariant = variant
+    logger.notice("Live transcription models ready variant=\(variant.identifier)")
+  }
+
+  private func models(for variant: ParakeetModel) async throws -> AsrModels {
+    if cachedVariant == variant, let cachedModels {
+      return cachedModels
+    }
+    let models = try await AsrModels.downloadAndLoad(version: variant.asrVersion)
+    cachedModels = models
+    cachedVariant = variant
+    return models
+  }
+
+  func start(modelName: String) async throws {
+    await cancelSessionOnly()
+
+    guard let variant = ParakeetModel(rawValue: modelName) else {
+      throw NSError(
+        domain: "LiveTranscription",
+        code: -1,
+        userInfo: [NSLocalizedDescriptionKey: "Live transcription is not supported for model \(modelName)"]
+      )
+    }
+
+    let models = try await models(for: variant)
+    let config = streamingConfig(for: variant)
+    let manager = StreamingAsrManager(config: config)
+    try await manager.start(models: models, source: .microphone)
+    self.manager = manager
+    fedBufferCount = 0
+
+    logger.notice("Live transcription started variant=\(variant.identifier)")
+
+    bridgeTask = Task { [updateContinuation, logger] in
+      var updateCount = 0
+      for await update in await manager.transcriptionUpdates {
+        guard !Task.isCancelled else { break }
+
+        let confirmed = await manager.confirmedTranscript
+        let volatile = await manager.volatileTranscript
+        var parts: [String] = []
+        if !confirmed.isEmpty { parts.append(confirmed) }
+        if !volatile.isEmpty { parts.append(volatile) }
+
+        let displayText = parts.isEmpty ? update.text : parts.joined(separator: " ")
+        guard !displayText.isEmpty else { continue }
+
+        updateCount += 1
+        if updateCount == 1 {
+          logger.notice("Live transcription first update chars=\(displayText.count)")
+        }
+
+        updateContinuation.yield(
+          LiveTranscriptionUpdate(text: displayText, isConfirmed: update.isConfirmed)
+        )
+      }
+    }
+  }
+
+  func feedAudio(_ buffer: AVAudioPCMBuffer) async {
+    guard let manager else { return }
+    fedBufferCount += 1
+    if fedBufferCount == 1 {
+      logger.notice("Live transcription feeding first audio buffer frames=\(buffer.frameLength)")
+    }
+    await manager.streamAudio(buffer)
+  }
+
+  func finish() async throws -> String {
+    guard let manager else { return "" }
+
+    let result = try await manager.finish()
+    self.manager = nil
+    bridgeTask?.cancel()
+    bridgeTask = nil
+    logger.notice(
+      "Live transcription finished textLength=\(result.count) fedBuffers=\(self.fedBufferCount)"
+    )
+    return result
+  }
+
+  func cancel() async {
+    await cancelSessionOnly()
+  }
+
+  private func cancelSessionOnly() async {
+    bridgeTask?.cancel()
+    bridgeTask = nil
+    await manager?.cancel()
+    manager = nil
+    fedBufferCount = 0
+  }
+
+  private func streamingConfig(for variant: ParakeetModel) -> StreamingAsrConfig {
+    switch variant {
+    case .englishV2, .multilingualV3:
+      return StreamingAsrConfig(
+        chunkSeconds: 0.35,
+        hypothesisChunkSeconds: 0.35,
+        leftContextSeconds: 0.2,
+        rightContextSeconds: 0.1,
+        minContextForConfirmation: 0.35,
+        confirmationThreshold: 0.45
+      )
+    }
+  }
+}
+
+private extension ParakeetModel {
+  var asrVersion: AsrModelVersion {
+    switch self {
+    case .englishV2: return .v2
+    case .multilingualV3: return .v3
+    }
+  }
+}
+
+#else
+
+actor LiveTranscriptionClientLive {
+  func isSupported(_: String) -> Bool { false }
+  func prepare(modelName _: String) async throws {}
+  func observeUpdates() -> AsyncStream<LiveTranscriptionUpdate> { AsyncStream { _ in } }
+  func start(modelName _: String) async throws {}
+  func feedAudio(_: AVAudioPCMBuffer) async {}
+  func finish() async throws -> String { "" }
+  func cancel() async {}
+}
+
+#endif

--- a/Hex/Clients/LiveTranscriptionClient.swift
+++ b/Hex/Clients/LiveTranscriptionClient.swift
@@ -59,17 +59,29 @@ actor LiveTranscriptionClientLive {
   private let logger = HexLog.parakeet
   private var manager: StreamingAsrManager?
   private var bridgeTask: Task<Void, Never>?
-  private let (updateStream, updateContinuation) = AsyncStream<LiveTranscriptionUpdate>.makeStream()
+  private var updateStream: AsyncStream<LiveTranscriptionUpdate>?
+  private var updateContinuation: AsyncStream<LiveTranscriptionUpdate>.Continuation?
   private var cachedModels: AsrModels?
   private var cachedVariant: ParakeetModel?
   private var fedBufferCount = 0
+
+  init() {
+    resetUpdateStream()
+  }
+
+  private func resetUpdateStream() {
+    updateContinuation?.finish()
+    let (stream, continuation) = AsyncStream<LiveTranscriptionUpdate>.makeStream()
+    updateStream = stream
+    updateContinuation = continuation
+  }
 
   func isSupported(_ modelName: String) -> Bool {
     ParakeetModel(rawValue: modelName) != nil
   }
 
   func observeUpdates() -> AsyncStream<LiveTranscriptionUpdate> {
-    updateStream
+    updateStream ?? AsyncStream { _ in }
   }
 
   func prepare(modelName: String) async throws {
@@ -95,6 +107,7 @@ actor LiveTranscriptionClientLive {
 
   func start(modelName: String) async throws {
     await cancelSessionOnly()
+    resetUpdateStream()
 
     guard let variant = ParakeetModel(rawValue: modelName) else {
       throw NSError(
@@ -114,6 +127,7 @@ actor LiveTranscriptionClientLive {
     logger.notice("Live transcription started variant=\(variant.identifier)")
 
     bridgeTask = Task { [updateContinuation, logger] in
+      guard let updateContinuation else { return }
       var updateCount = 0
       for await update in await manager.transcriptionUpdates {
         guard !Task.isCancelled else { break }
@@ -171,6 +185,7 @@ actor LiveTranscriptionClientLive {
     await manager?.cancel()
     manager = nil
     fedBufferCount = 0
+    resetUpdateStream()
   }
 
   private func streamingConfig(for variant: ParakeetModel) -> StreamingAsrConfig {

--- a/Hex/Clients/ParakeetClient.swift
+++ b/Hex/Clients/ParakeetClient.swift
@@ -109,7 +109,7 @@ actor ParakeetClient {
     return total
   }
 
-  func transcribe(_ url: URL) async throws -> String {
+  func transcribe(_ url: URL, reinitializeOnEmpty: Bool = true) async throws -> String {
     try Task.checkCancellation()
     await acquireTranscribeSlot()
     defer { releaseTranscribeSlot() }
@@ -119,7 +119,7 @@ actor ParakeetClient {
     }
 
     var text = try await transcribeLocked(url)
-    if text.isEmpty {
+    if text.isEmpty, reinitializeOnEmpty {
       let shouldReinitialize: Bool = {
         guard let lastTranscriberReinitializeAt else { return true }
         return Date().timeIntervalSince(lastTranscriberReinitializeAt) >= transcriberReinitializeCooldown

--- a/Hex/Clients/ParakeetClient.swift
+++ b/Hex/Clients/ParakeetClient.swift
@@ -8,6 +8,10 @@ actor ParakeetClient {
   private var asr: AsrManager?
   private var models: AsrModels?
   private var currentVariant: ParakeetModel?
+  private var transcribeWaiters: [CheckedContinuation<Void, Never>] = []
+  private var isTranscribeSlotHeld = false
+  private var lastTranscriberReinitializeAt: Date?
+  private let transcriberReinitializeCooldown: TimeInterval = 2.0
   private let logger = HexLog.parakeet
   private let vendorDirs = [
     // Our app-specific cache path convention (under XDG or com.kitlangton.Hex/cache)
@@ -106,12 +110,93 @@ actor ParakeetClient {
   }
 
   func transcribe(_ url: URL) async throws -> String {
-    guard let asr else { throw NSError(domain: "Parakeet", code: -1, userInfo: [NSLocalizedDescriptionKey: "Parakeet not initialized"]) }
+    try Task.checkCancellation()
+    await acquireTranscribeSlot()
+    defer { releaseTranscribeSlot() }
+
+    guard asr != nil else {
+      throw NSError(domain: "Parakeet", code: -1, userInfo: [NSLocalizedDescriptionKey: "Parakeet not initialized"])
+    }
+
+    var text = try await transcribeLocked(url)
+    if text.isEmpty {
+      let shouldReinitialize: Bool = {
+        guard let lastTranscriberReinitializeAt else { return true }
+        return Date().timeIntervalSince(lastTranscriberReinitializeAt) >= transcriberReinitializeCooldown
+      }()
+      if shouldReinitialize {
+        logger.notice("Parakeet returned empty text for \(url.lastPathComponent); reinitializing transcriber")
+        try await reinitializeTranscriberLocked()
+        lastTranscriberReinitializeAt = Date()
+        text = try await transcribeLocked(url)
+        if text.isEmpty {
+          logger.notice("Parakeet returned empty text after reinitialize for \(url.lastPathComponent)")
+        }
+      } else {
+        logger.debug("Parakeet returned empty text for \(url.lastPathComponent); skipping reinitialize cooldown")
+      }
+    }
+    return text
+  }
+
+  func resetTranscriberState() async throws {
+    await acquireTranscribeSlot()
+    defer { releaseTranscribeSlot() }
+    guard let asr else { return }
+    try await asr.resetDecoderState()
+  }
+
+  /// Rebuilds AsrManager from cached models when decoder state becomes corrupted.
+  func reinitializeTranscriber() async throws {
+    await acquireTranscribeSlot()
+    defer { releaseTranscribeSlot() }
+    try await reinitializeTranscriberLocked()
+  }
+
+  private func transcribeLocked(_ url: URL) async throws -> String {
+    guard let asr else {
+      throw NSError(domain: "Parakeet", code: -1, userInfo: [NSLocalizedDescriptionKey: "Parakeet not initialized"])
+    }
     let t0 = Date()
     logger.notice("Transcribing with Parakeet file=\(url.lastPathComponent)")
-    let result = try await asr.transcribe(url)
+    // File-based batch transcribe uses FluidAudio's default `.system` decoder path.
+    let result = try await asr.transcribe(url, source: .system)
     logger.info("Parakeet transcription finished in \(String(format: "%.2f", Date().timeIntervalSince(t0)))s")
     return result.text
+  }
+
+  private func reinitializeTranscriberLocked() async throws {
+    guard let models, let variant = currentVariant else { return }
+    let manager = AsrManager(config: .init())
+    try await manager.initialize(models: models)
+    self.asr = manager
+    logger.notice("Parakeet transcriber reinitialized variant=\(variant.identifier)")
+  }
+
+  /// FluidAudio's AsrManager is not re-entrant; hold this slot for the entire transcribe await.
+  private func acquireTranscribeSlot() async {
+    if !isTranscribeSlotHeld {
+      isTranscribeSlotHeld = true
+      return
+    }
+    await withCheckedContinuation { continuation in
+      transcribeWaiters.append(continuation)
+    }
+  }
+
+  private func releaseTranscribeSlot() {
+    if transcribeWaiters.isEmpty {
+      isTranscribeSlotHeld = false
+      return
+    }
+    let next = transcribeWaiters.removeFirst()
+    next.resume()
+  }
+
+  /// Waits until no Parakeet transcribe call is in progress.
+  func waitUntilTranscribeIdle() async {
+    await acquireTranscribeSlot()
+    releaseTranscribeSlot()
   }
 
   // Delete cached Parakeet models from known locations and reset state
@@ -191,6 +276,9 @@ actor ParakeetClient {
     )
   }
   func transcribe(_ url: URL) async throws -> String { throw NSError(domain: "Parakeet", code: -3, userInfo: [NSLocalizedDescriptionKey: "Parakeet not available"]) }
+  func waitUntilTranscribeIdle() async {}
+  func resetTranscriberState() async throws {}
+  func reinitializeTranscriber() async throws {}
   func deleteCaches(modelName: String) async throws {}
 }
 

--- a/Hex/Clients/ParakeetClipPreparer.swift
+++ b/Hex/Clients/ParakeetClipPreparer.swift
@@ -37,7 +37,8 @@ enum ParakeetClipPreparer {
   // so pad to at least that window to avoid decoder errors.
   static let defaultMinimumDuration: TimeInterval = 1.5
   /// Shorter padding for live preview snapshots to reduce first-token latency.
-  static let previewMinimumDuration: TimeInterval = 0.5
+  /// Values below ~1s cause Parakeet to hallucinate on zero-padded clips.
+  static let previewMinimumDuration: TimeInterval = 1.0
 
   static func ensureMinimumDuration(
     url: URL,

--- a/Hex/Clients/ParakeetClipPreparer.swift
+++ b/Hex/Clients/ParakeetClipPreparer.swift
@@ -36,6 +36,8 @@ enum ParakeetClipPreparer {
   // FluidAudio's LastChunkHandling guidance recommends chunk_duration 1.5s,
   // so pad to at least that window to avoid decoder errors.
   static let defaultMinimumDuration: TimeInterval = 1.5
+  /// Shorter padding for live preview snapshots to reduce first-token latency.
+  static let previewMinimumDuration: TimeInterval = 0.5
 
   static func ensureMinimumDuration(
     url: URL,

--- a/Hex/Clients/PasteboardClient.swift
+++ b/Hex/Clients/PasteboardClient.swift
@@ -302,9 +302,28 @@ struct PasteboardClientLive {
         event?.post(tap: .cghidEventTap)
     }
 
+    /// Deletes recently inserted preview text when the cursor sits at the end of the insertion.
+    @MainActor
+    func deleteKeystrokeInsertedText(count: Int) async {
+        guard count > 0 else { return }
+        postBackspaces(count)
+        let settleMs = min(200, max(15, count * 2))
+        try? await Task.sleep(for: .milliseconds(settleMs))
+    }
+
+    /// Pastes finalized dictation text at the cursor during a keystroke live session.
+    @MainActor
+    func pasteKeystrokeTextAtCursor(_ text: String, targetBundleID: String?) async -> Bool {
+        if !Self.isTargetAppFrontmost(bundleIdentifier: targetBundleID) {
+            activateApplication(bundleIdentifier: targetBundleID)
+            try? await Task.sleep(for: .milliseconds(12))
+        }
+        return await pasteTextAtCursor(text, delayMs: 3)
+    }
+
     /// Replaces live preview text at the cursor.
-    /// Electron editors (e.g. Cursor) often drop synthetic backspaces; selecting inserted
-    /// text with Shift+Left then pasting is much more reliable.
+    /// Full replace deletes via backspace at the insertion tail (Shift+Left select + paste
+    /// appends in Electron editors like Cursor). Incremental edits still use selection.
     @MainActor
     func replaceLiveText(
         targetBundleID: String?,
@@ -335,12 +354,18 @@ struct PasteboardClientLive {
             return true
         case let .replaceTail(backspaces, insert):
             if backspaces > 0 {
-                await selectBackward(backspaces)
-                let settleMs = min(120, max(10, backspaces / 4))
-                try? await Task.sleep(for: .milliseconds(settleMs))
+                if preferFullReplace {
+                    postBackspaces(backspaces)
+                    let settleMs = min(200, max(15, backspaces * 2))
+                    try? await Task.sleep(for: .milliseconds(settleMs))
+                } else {
+                    await selectBackward(backspaces)
+                    let settleMs = min(120, max(10, backspaces / 4))
+                    try? await Task.sleep(for: .milliseconds(settleMs))
+                }
             }
             guard !insert.isEmpty else {
-                if backspaces > 0 {
+                if backspaces > 0, !preferFullReplace {
                     postBackspaces(1)
                 }
                 return true

--- a/Hex/Clients/PasteboardClient.swift
+++ b/Hex/Clients/PasteboardClient.swift
@@ -350,26 +350,17 @@ struct PasteboardClientLive {
             guard !suffix.isEmpty else { return true }
             return await pasteTextAtCursor(suffix, delayMs: 3)
         case let .shrinkBackspaces(count):
-            await selectBackwardAndDelete(count)
+            postBackspaces(count)
+            let settleMs = min(200, max(15, count * 2))
+            try? await Task.sleep(for: .milliseconds(settleMs))
             return true
         case let .replaceTail(backspaces, insert):
             if backspaces > 0 {
-                if preferFullReplace {
-                    postBackspaces(backspaces)
-                    let settleMs = min(200, max(15, backspaces * 2))
-                    try? await Task.sleep(for: .milliseconds(settleMs))
-                } else {
-                    await selectBackward(backspaces)
-                    let settleMs = min(120, max(10, backspaces / 4))
-                    try? await Task.sleep(for: .milliseconds(settleMs))
-                }
+                postBackspaces(backspaces)
+                let settleMs = min(200, max(15, backspaces * 2))
+                try? await Task.sleep(for: .milliseconds(settleMs))
             }
-            guard !insert.isEmpty else {
-                if backspaces > 0, !preferFullReplace {
-                    postBackspaces(1)
-                }
-                return true
-            }
+            guard !insert.isEmpty else { return true }
             return await pasteTextAtCursor(insert, delayMs: 3)
         }
     }

--- a/Hex/Clients/PasteboardClient.swift
+++ b/Hex/Clients/PasteboardClient.swift
@@ -6,6 +6,7 @@
 //
 
 import ComposableArchitecture
+import Carbon
 import Dependencies
 import DependenciesMacros
 import Foundation
@@ -127,7 +128,7 @@ struct PasteboardClientLive {
         // Press modifiers down
         for keyCode in modifierKeyCodes {
             let modDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
-            modDown?.post(tap: .cghidEventTap)
+            postTagged(modDown)
         }
         
         // Press main key if present
@@ -136,17 +137,18 @@ struct PasteboardClientLive {
             
             let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true)
             keyDown?.flags = flags
-            keyDown?.post(tap: .cghidEventTap)
+            keyDown?.flags = flags
+            postTagged(keyDown)
             
             let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
             keyUp?.flags = flags
-            keyUp?.post(tap: .cghidEventTap)
+            postTagged(keyUp)
         }
         
         // Release modifiers in reverse order
         for keyCode in modifierKeyCodes.reversed() {
             let modUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
-            modUp?.post(tap: .cghidEventTap)
+            postTagged(modUp)
         }
         
         pasteboardLogger.debug("Sent keyboard command: \(command.displayName)")
@@ -265,6 +267,155 @@ struct PasteboardClientLive {
         return false
     }
 
+    @MainActor
+    private func postTagged(_ event: CGEvent?) {
+        SyntheticKeyboardEvent.tag(event)
+        event?.post(tap: .cghidEventTap)
+    }
+
+    /// Replaces live preview text at the cursor.
+    /// Electron editors (e.g. Cursor) often drop synthetic backspaces; selecting inserted
+    /// text with Shift+Left then pasting is much more reliable.
+    @MainActor
+    func replaceLiveText(
+        targetBundleID: String?,
+        previousText: String,
+        newText: String
+    ) async -> Bool {
+        guard previousText != newText else { return true }
+
+        if !Self.isTargetAppFrontmost(bundleIdentifier: targetBundleID) {
+            activateApplication(bundleIdentifier: targetBundleID)
+            try? await Task.sleep(for: .milliseconds(12))
+        }
+
+        let action = LiveTextInsertionLogic.keystrokeUpdateAction(previous: previousText, new: newText)
+        switch action {
+        case .none:
+            return true
+        case let .append(suffix):
+            guard !suffix.isEmpty else { return true }
+            return await pasteTextAtCursor(suffix, delayMs: 3)
+        case let .shrinkBackspaces(count):
+            await selectBackwardAndDelete(count)
+            return true
+        case let .replaceTail(backspaces, insert):
+            if backspaces > 0 {
+                await selectBackward(backspaces)
+                let settleMs = min(120, max(10, backspaces / 4))
+                try? await Task.sleep(for: .milliseconds(settleMs))
+            }
+            guard !insert.isEmpty else {
+                if backspaces > 0 {
+                    postBackspaces(1)
+                }
+                return true
+            }
+            return await pasteTextAtCursor(insert, delayMs: 3)
+        }
+    }
+
+    @MainActor
+    private func selectBackward(_ count: Int) async {
+        guard count > 0 else { return }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let leftArrow = CGKeyCode(kVK_LeftArrow)
+        let shiftKey = CGKeyCode(kVK_Shift)
+
+        CGEvent(keyboardEventSource: source, virtualKey: shiftKey, keyDown: true).map { postTagged($0) }
+
+        var remaining = count
+        let chunkSize = 32
+        while remaining > 0 {
+            let batch = min(chunkSize, remaining)
+            for _ in 0 ..< batch {
+                let keyDown = CGEvent(keyboardEventSource: source, virtualKey: leftArrow, keyDown: true)
+                keyDown?.flags = .maskShift
+                postTagged(keyDown)
+                let keyUp = CGEvent(keyboardEventSource: source, virtualKey: leftArrow, keyDown: false)
+                keyUp?.flags = .maskShift
+                postTagged(keyUp)
+            }
+            remaining -= batch
+            if remaining > 0 {
+                try? await Task.sleep(for: .milliseconds(6))
+            }
+        }
+
+        CGEvent(keyboardEventSource: source, virtualKey: shiftKey, keyDown: false).map { postTagged($0) }
+    }
+
+    @MainActor
+    private func selectBackwardAndDelete(_ count: Int) async {
+        guard count > 0 else { return }
+        await selectBackward(count)
+        let settleMs = min(120, max(10, count / 4))
+        try? await Task.sleep(for: .milliseconds(settleMs))
+        postBackspaces(1)
+    }
+
+    @MainActor
+    func selectBackwardAndDeleteForRevert(count: Int) async {
+        await selectBackwardAndDelete(count)
+    }
+
+    @MainActor
+    private func pasteTextAtCursor(_ text: String, delayMs: Int) async -> Bool {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+
+        if await postCmdV(delayMs: delayMs) { return true }
+        if Self.pasteToFrontmostApp() { return true }
+        return (try? Self.insertTextAtCursor(text)) != nil
+    }
+
+    @MainActor
+    func activateApplication(bundleIdentifier: String?) {
+        guard let bundleIdentifier else { return }
+        NSWorkspace.shared.runningApplications
+            .first { $0.bundleIdentifier == bundleIdentifier }?
+            .activate(options: [.activateAllWindows])
+    }
+
+    @MainActor
+    private static func isTargetAppFrontmost(bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return NSWorkspace.shared.frontmostApplication?.bundleIdentifier == bundleIdentifier
+    }
+
+    @MainActor
+    func postBackspaces(_ count: Int) {
+        guard count > 0 else { return }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let deleteKey = CGKeyCode(kVK_Delete)
+        for _ in 0 ..< count {
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: deleteKey, keyDown: true)
+            postTagged(keyDown)
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: deleteKey, keyDown: false)
+            postTagged(keyUp)
+        }
+    }
+
+    /// Types text at the cursor without touching the pasteboard. Reserved for short inserts
+    /// where paste flicker is undesirable; live dictation uses paste for spacing reliability.
+    @MainActor
+    func postUnicodeText(_ text: String) {
+        guard !text.isEmpty else { return }
+        let source = CGEventSource(stateID: .combinedSessionState)
+        for codeUnit in text.utf16 {
+            var uniChar = codeUnit
+            guard
+                let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+                let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+            else { continue }
+            keyDown.keyboardSetUnicodeString(stringLength: 1, unicodeString: &uniChar)
+            keyUp.keyboardSetUnicodeString(stringLength: 1, unicodeString: &uniChar)
+            postTagged(keyDown)
+            postTagged(keyUp)
+        }
+    }
+
     // MARK: - Paste Orchestration
 
     @MainActor
@@ -311,10 +462,10 @@ struct PasteboardClientLive {
         let vUp = CGEvent(keyboardEventSource: source, virtualKey: vKey, keyDown: false)
         vUp?.flags = .maskCommand
         let cmdUp = CGEvent(keyboardEventSource: source, virtualKey: cmdKey, keyDown: false)
-        cmdDown?.post(tap: .cghidEventTap)
-        vDown?.post(tap: .cghidEventTap)
-        vUp?.post(tap: .cghidEventTap)
-        cmdUp?.post(tap: .cghidEventTap)
+        postTagged(cmdDown)
+        postTagged(vDown)
+        postTagged(vUp)
+        postTagged(cmdUp)
         return true
     }
 

--- a/Hex/Clients/PasteboardClient.swift
+++ b/Hex/Clients/PasteboardClient.swift
@@ -49,6 +49,12 @@ extension DependencyValues {
 
 struct PasteboardClientLive {
     @Shared(.hexSettings) var hexSettings: HexSettings
+
+    private final class LiveKeystrokePasteboardSession {
+        var userSnapshot: PasteboardSnapshot?
+    }
+
+    private let liveKeystrokePasteboardSession = LiveKeystrokePasteboardSession()
     
     private struct PasteboardSnapshot {
         let items: [[String: Any]]
@@ -79,6 +85,27 @@ struct PasteboardClientLive {
                 pasteboard.writeObjects([item])
             }
         }
+    }
+
+    @MainActor
+    func beginLiveKeystrokePasteboardSession() {
+        liveKeystrokePasteboardSession.userSnapshot = PasteboardSnapshot(
+            pasteboard: NSPasteboard.general
+        )
+    }
+
+    @MainActor
+    func endLiveKeystrokePasteboardSession(finalText: String? = nil) {
+        defer { liveKeystrokePasteboardSession.userSnapshot = nil }
+        let pasteboard = NSPasteboard.general
+        if hexSettings.copyToClipboard {
+            if let finalText, !finalText.isEmpty {
+                pasteboard.clearContents()
+                pasteboard.setString(finalText, forType: .string)
+            }
+            return
+        }
+        liveKeystrokePasteboardSession.userSnapshot?.restore(to: pasteboard)
     }
 
     @MainActor
@@ -362,12 +389,25 @@ struct PasteboardClientLive {
     @MainActor
     private func pasteTextAtCursor(_ text: String, delayMs: Int) async -> Bool {
         let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        let targetChangeCount = writeAndTrackChangeCount(pasteboard: pasteboard, text: text)
+        _ = await waitForPasteboardCommit(targetChangeCount: targetChangeCount)
 
-        if await postCmdV(delayMs: delayMs) { return true }
-        if Self.pasteToFrontmostApp() { return true }
-        return (try? Self.insertTextAtCursor(text)) != nil
+        var succeeded = await postCmdV(delayMs: delayMs)
+        if !succeeded {
+            succeeded = Self.pasteToFrontmostApp()
+        }
+        if !succeeded {
+            succeeded = (try? Self.insertTextAtCursor(text)) != nil
+        }
+
+        if !hexSettings.copyToClipboard && succeeded {
+            if let snapshot = liveKeystrokePasteboardSession.userSnapshot {
+                try? await Task.sleep(for: .milliseconds(500))
+                snapshot.restore(to: pasteboard)
+            }
+        }
+
+        return succeeded
     }
 
     @MainActor

--- a/Hex/Clients/PasteboardClient.swift
+++ b/Hex/Clients/PasteboardClient.swift
@@ -102,6 +102,8 @@ struct PasteboardClientLive {
             if let finalText, !finalText.isEmpty {
                 pasteboard.clearContents()
                 pasteboard.setString(finalText, forType: .string)
+            } else {
+                liveKeystrokePasteboardSession.userSnapshot?.restore(to: pasteboard)
             }
             return
         }
@@ -307,7 +309,8 @@ struct PasteboardClientLive {
     func replaceLiveText(
         targetBundleID: String?,
         previousText: String,
-        newText: String
+        newText: String,
+        preferFullReplace: Bool = false
     ) async -> Bool {
         guard previousText != newText else { return true }
 
@@ -316,7 +319,11 @@ struct PasteboardClientLive {
             try? await Task.sleep(for: .milliseconds(12))
         }
 
-        let action = LiveTextInsertionLogic.keystrokeUpdateAction(previous: previousText, new: newText)
+        let action = LiveTextInsertionLogic.keystrokeUpdateAction(
+            previous: previousText,
+            new: newText,
+            preferFullReplace: preferFullReplace
+        )
         switch action {
         case .none:
             return true
@@ -400,12 +407,8 @@ struct PasteboardClientLive {
             succeeded = (try? Self.insertTextAtCursor(text)) != nil
         }
 
-        if !hexSettings.copyToClipboard && succeeded {
-            if let snapshot = liveKeystrokePasteboardSession.userSnapshot {
-                try? await Task.sleep(for: .milliseconds(500))
-                snapshot.restore(to: pasteboard)
-            }
-        }
+        // Clipboard restore is deferred to endLiveKeystrokePasteboardSession so live
+        // preview updates are not blocked by a 500ms wait on every keystroke paste.
 
         return succeeded
     }

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -1183,19 +1183,34 @@ actor RecordingClientLive {
     resumeMediaTask?.cancel()
     resumeMediaTask = nil
 
+    // Assign the session ID before any early return so an in-flight stop from a
+    // prior recording is ignored once the user starts again during the stop grace window.
+    let sessionID = UUID()
+    recordingSessionID = sessionID
+    mediaControlTask?.cancel()
+    mediaControlTask = nil
+
     if isCaptureActive {
-      recordingLogger.notice("Ignoring duplicate startRecording while capture is active")
-      return
+      recordingLogger.notice("Waiting for prior capture to finish before starting new recording")
+      let deadline = Date().addingTimeInterval(
+        captureController.stopTimingEstimate.gracePeriod + 0.05
+      )
+      while isCaptureActive, Date() < deadline {
+        try? await Task.sleep(for: .milliseconds(5))
+        guard isCurrentSession(sessionID) else {
+          recordingLogger.notice("New recording session superseded while waiting for prior capture")
+          return
+        }
+      }
+      if isCaptureActive {
+        recordingLogger.notice("Prior capture still active; cannot start new recording")
+        return
+      }
     }
 
     if hasActiveMediaControlState {
       await resumeMediaImmediately()
     }
-
-    let sessionID = UUID()
-    recordingSessionID = sessionID
-    mediaControlTask?.cancel()
-    mediaControlTask = nil
 
     // Defer pause/mute until the recording survives the minimum hold threshold.
     // This avoids pause/play and volume flicker on accidental or fluttering hotkey presses.

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -37,6 +37,7 @@ struct RecordingClient {
   var setLiveAudioConsumer: @Sendable ((@Sendable (AVAudioPCMBuffer) async -> Void)?) async -> Void = { _ in }
   var snapshotRecordingForPreview: @Sendable () async -> URL? = { nil }
   var previewRecordingDuration: @Sendable () async -> TimeInterval = { 0 }
+  var recordingSpeechMetrics: @Sendable () async -> SpeechActivityMetrics = { .zero }
   var getAvailableInputDevices: @Sendable () async -> [AudioInputDevice] = { [] }
   var getDefaultInputDeviceName: @Sendable () async -> String? = { nil }
   var warmUpRecorder: @Sendable () async -> Void = {}
@@ -61,6 +62,7 @@ extension RecordingClient: DependencyKey {
       setLiveAudioConsumer: { await live.setLiveAudioConsumer($0) },
       snapshotRecordingForPreview: { await live.snapshotRecordingForPreview() },
       previewRecordingDuration: { await live.previewRecordingDuration() },
+      recordingSpeechMetrics: { await live.recordingSpeechMetrics() },
       getAvailableInputDevices: { await live.getAvailableInputDevices() },
       getDefaultInputDeviceName: { await live.getDefaultInputDeviceName() },
       warmUpRecorder: { await live.warmUpRecorder() },
@@ -348,6 +350,7 @@ actor RecordingClientLive {
   private var lastPrimedDeviceID: AudioDeviceID?
   private var recordingSessionID: UUID?
   private var activeRecordingSession: ActiveRecordingSession?
+  private var sessionSpeechMetrics = SpeechActivityMetrics.zero
   private var lastRecordingEndedAt: Date?
   private var deferredCaptureRestartReason: String?
   private var isLiveMonitoringActive = false
@@ -1187,6 +1190,8 @@ actor RecordingClientLive {
     // prior recording is ignored once the user starts again during the stop grace window.
     let sessionID = UUID()
     recordingSessionID = sessionID
+    sessionSpeechMetrics = .zero
+    captureController.resetSessionSpeechMetrics()
     mediaControlTask?.cancel()
     mediaControlTask = nil
 
@@ -1626,7 +1631,13 @@ actor RecordingClientLive {
         let averageNormalized = pow(10, averagePower / 20.0)
         let peakPower = r.peakPower(forChannel: 0)
         let peakNormalized = pow(10, peakPower / 20.0)
-        meterContinuation.yield(Meter(averagePower: Double(averageNormalized), peakPower: Double(peakNormalized)))
+        let meter = Meter(averagePower: Double(averageNormalized), peakPower: Double(peakNormalized))
+        meterContinuation.yield(meter)
+        if activeRecordingSession != nil {
+          sessionSpeechMetrics.merge(
+            SpeechActivityMetrics(peakRMS: meter.averagePower, peakSample: meter.peakPower)
+          )
+        }
         try? await Task.sleep(for: .milliseconds(100))
       }
     }
@@ -1670,6 +1681,12 @@ actor RecordingClientLive {
 
   func previewRecordingDuration() -> TimeInterval {
     captureController.previewCaptureDuration
+  }
+
+  func recordingSpeechMetrics() -> SpeechActivityMetrics {
+    var metrics = sessionSpeechMetrics
+    metrics.merge(captureController.recordingSpeechMetrics())
+    return metrics
   }
 
   func warmUpRecorder() async {

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -27,13 +27,21 @@ struct AudioInputDevice: Identifiable, Equatable {
 
 @DependencyClient
 struct RecordingClient {
-  var startRecording: @Sendable () async -> Void = {}
+  var startRecording: @Sendable (_ requiresLiveAudio: Bool) async -> Void = { _ in }
   var stopRecording: @Sendable () async -> URL = { URL(fileURLWithPath: "") }
   var requestMicrophoneAccess: @Sendable () async -> Bool = { false }
   var observeAudioLevel: @Sendable () async -> AsyncStream<Meter> = { AsyncStream { _ in } }
+  var observeLiveAudio: @Sendable () async -> AsyncStream<AVAudioPCMBuffer> = { AsyncStream { _ in } }
+  /// Registers a per-recording sink for live PCM. Uses a persistent pump so each session
+  /// does not compete for a single AsyncStream iterator (which dropped audio after session 1).
+  var setLiveAudioConsumer: @Sendable ((@Sendable (AVAudioPCMBuffer) async -> Void)?) async -> Void = { _ in }
+  var snapshotRecordingForPreview: @Sendable () async -> URL? = { nil }
+  var previewRecordingDuration: @Sendable () async -> TimeInterval = { 0 }
   var getAvailableInputDevices: @Sendable () async -> [AudioInputDevice] = { [] }
   var getDefaultInputDeviceName: @Sendable () async -> String? = { nil }
   var warmUpRecorder: @Sendable () async -> Void = {}
+  /// Arms the capture engine without starting a recording (call on hotkey press).
+  var prewarmCapture: @Sendable () async -> Void = {}
   var cleanup: @Sendable () async -> Void = {}
 }
 
@@ -42,15 +50,21 @@ extension RecordingClient: DependencyKey {
     let live = RecordingClientLive()
     Task {
       await live.startObservingSystemChanges()
+      await live.startLiveAudioPump()
     }
     return Self(
-      startRecording: { await live.startRecording() },
+      startRecording: { await live.startRecording(requiresLiveAudio: $0) },
       stopRecording: { await live.stopRecording() },
       requestMicrophoneAccess: { await live.requestMicrophoneAccess() },
       observeAudioLevel: { await live.observeAudioLevel() },
+      observeLiveAudio: { await live.observeLiveAudio() },
+      setLiveAudioConsumer: { await live.setLiveAudioConsumer($0) },
+      snapshotRecordingForPreview: { await live.snapshotRecordingForPreview() },
+      previewRecordingDuration: { await live.previewRecordingDuration() },
       getAvailableInputDevices: { await live.getAvailableInputDevices() },
       getDefaultInputDeviceName: { await live.getDefaultInputDeviceName() },
       warmUpRecorder: { await live.warmUpRecorder() },
+      prewarmCapture: { await live.prewarmCapture() },
       cleanup: { await live.cleanup() }
     )
   }
@@ -336,8 +350,11 @@ actor RecordingClientLive {
   private var activeRecordingSession: ActiveRecordingSession?
   private var lastRecordingEndedAt: Date?
   private var deferredCaptureRestartReason: String?
+  private var isLiveMonitoringActive = false
   private var environmentChangeDebounceTask: Task<Void, Never>?
   private var mediaControlTask: Task<Void, Never>?
+  private var resumeMediaTask: Task<Void, Never>?
+  private static let resumeMediaDebounce: Duration = .milliseconds(200)
   private let recorderSettings: [String: Any] = [
     AVFormatIDKey: Int(kAudioFormatLinearPCM),
     AVSampleRateKey: 16000.0,
@@ -348,9 +365,13 @@ actor RecordingClientLive {
     AVLinearPCMIsNonInterleaved: false,
   ]
   private let (meterStream, meterContinuation) = AsyncStream<Meter>.makeStream()
+  private let (liveAudioStream, liveAudioContinuation) = AsyncStream<AVAudioPCMBuffer>.makeStream()
+  private var liveAudioConsumer: (@Sendable (AVAudioPCMBuffer) async -> Void)?
+  private var liveAudioPumpTask: Task<Void, Never>?
   private var meterTask: Task<Void, Never>?
   private lazy var captureController = SuperFastCaptureController(
     meterContinuation: meterContinuation,
+    liveAudioContinuation: liveAudioContinuation,
     onEngineConfigurationChange: { [weak self] in
       Task {
         await self?.enqueueCaptureEnvironmentChange(reason: "capture-engine-configuration-changed")
@@ -359,6 +380,8 @@ actor RecordingClientLive {
   )
   private var captureControllerDeviceID: AudioDeviceID?
   private var captureControllerNeedsRestartReason: String?
+  private var captureEngineLastArmedAt: Date?
+  private static let captureConfigChangeGracePeriod: TimeInterval = 2.0
   private var notificationObservers: [NSObjectProtocol] = []
   private var audioHardwareObservers: [AudioHardwareObserver] = []
   private var isObservingSystemChanges = false
@@ -376,6 +399,22 @@ actor RecordingClientLive {
 
   /// Tracks previous system volume when muted for recording
   private var previousVolume: Float?
+
+  private var hasActiveMediaControlState: Bool {
+    didPauseMedia || didPauseViaMediaRemote || previousVolume != nil || !pausedPlayers.isEmpty
+  }
+
+  private var isCaptureActive: Bool {
+    activeRecordingSession != nil || captureController.isRecording || recorder?.isRecording == true
+  }
+
+  /// Wait until a recording is likely intentional before pausing media or muting output.
+  private func mediaControlActivationDelay() -> TimeInterval {
+    if hexSettings.hotkey.key == nil {
+      return max(hexSettings.minimumKeyTime, RecordingDecisionEngine.modifierOnlyMinimumDuration)
+    }
+    return max(hexSettings.minimumKeyTime, 0.1)
+  }
 
   /// Gets all available input devices on the system
   func getAvailableInputDevices() async -> [AudioInputDevice] {
@@ -504,10 +543,17 @@ actor RecordingClientLive {
   private func enqueueCaptureEnvironmentChange(reason: String) {
     environmentChangeDebounceTask?.cancel()
     environmentChangeDebounceTask = Task { [self] in
-      try? await Task.sleep(for: .milliseconds(250))
+      try? await Task.sleep(for: .milliseconds(500))
       guard !Task.isCancelled else { return }
       await handleCaptureEnvironmentChange(reason: reason)
     }
+  }
+
+  private func shouldIgnoreCaptureEngineConfigChange(_ reason: String) -> Bool {
+    guard reason.contains("capture-engine-configuration-changed") else { return false }
+    guard let captureEngineLastArmedAt else { return false }
+    guard activeRecordingSession == nil, !captureController.isRecording else { return false }
+    return Date().timeIntervalSince(captureEngineLastArmedAt) < Self.captureConfigChangeGracePeriod
   }
 
   private func stopObservingSystemChanges() {
@@ -555,12 +601,38 @@ actor RecordingClientLive {
       return
     }
 
+    if shouldIgnoreCaptureEngineConfigChange(reason) {
+      recordingLogger.debug(
+        "Ignoring capture engine config change within grace period reason=\(reason) armedAgo=\(String(format: "%.3f", Date().timeIntervalSince(self.captureEngineLastArmedAt ?? Date())))s running=\(self.captureController.isRunning)"
+      )
+      captureControllerNeedsRestartReason = nil
+      if !captureController.isRunning {
+        let activeInputDevice = applyPreferredInputDevice()
+        do {
+          try ensureCaptureControllerReady(
+            for: activeInputDevice,
+            reason: "config-change-grace-rearm",
+            forceRestart: false
+          )
+          await waitForCaptureEngineReady(
+            minimumRingDuration: SuperFastCaptureController.Readiness.prewarmRingDuration,
+            timeout: SuperFastCaptureController.Readiness.warmUpTimeout,
+            reason: "config-change-grace-rearm"
+          )
+        } catch {
+          recordingLogger.error("Grace period capture re-arm failed: \(error.localizedDescription)")
+        }
+      }
+      return
+    }
+
     deferredCaptureRestartReason = nil
     if hexSettings.superFastModeEnabled {
       releaseRecorder(reason: "environment-change-\(reason)")
       captureControllerNeedsRestartReason = reason
       captureController.clearWarmBuffer()
-      recordingLogger.notice("Deferring capture engine rebuild until next recording reason=\(reason)")
+      recordingLogger.notice("Scheduling idle capture engine rebuild reason=\(reason)")
+      await applyPendingCaptureRestartIfIdle()
       return
     }
 
@@ -574,6 +646,82 @@ actor RecordingClientLive {
     guard let deferredCaptureRestartReason else { return }
     recordingLogger.notice("Applying deferred capture restart reason=\(deferredCaptureRestartReason)")
     await handleCaptureEnvironmentChange(reason: "deferred-\(deferredCaptureRestartReason)")
+  }
+
+  private func applyPendingCaptureRestartIfIdle() async {
+    guard activeRecordingSession == nil, !captureController.isRecording else { return }
+    guard captureControllerNeedsRestartReason != nil else { return }
+
+    let activeInputDevice = applyPreferredInputDevice()
+    do {
+      try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: "idle-rebuild")
+      recordingLogger.notice("Capture engine rebuilt while idle")
+      await waitForCaptureEngineReady(
+        minimumRingDuration: SuperFastCaptureController.Readiness.minimumRingDuration,
+        timeout: SuperFastCaptureController.Readiness.warmUpTimeout,
+        reason: "idle-rebuild"
+      )
+    } catch {
+      recordingLogger.error("Idle capture engine rebuild failed: \(error.localizedDescription)")
+      guard captureControllerNeedsRestartReason != nil else { return }
+      try? await Task.sleep(for: .milliseconds(250))
+      do {
+        try ensureCaptureControllerReadyAfterDeferredRestart(
+          for: applyPreferredInputDevice(),
+          reason: "idle-rebuild-retry"
+        )
+        recordingLogger.notice("Capture engine rebuilt while idle after retry")
+        await waitForCaptureEngineReady(
+          minimumRingDuration: SuperFastCaptureController.Readiness.minimumRingDuration,
+          timeout: SuperFastCaptureController.Readiness.warmUpTimeout,
+          reason: "idle-rebuild-retry"
+        )
+      } catch {
+        recordingLogger.error("Idle capture engine rebuild retry failed: \(error.localizedDescription)")
+        captureControllerNeedsRestartReason = nil
+      }
+    }
+  }
+
+  private func waitForCaptureEngineReady(
+    minimumRingDuration: TimeInterval,
+    timeout: TimeInterval,
+    reason: String
+  ) async {
+    guard hexSettings.superFastModeEnabled else { return }
+
+    let ringFill = captureController.ringBufferFillDuration
+    if ringFill >= minimumRingDuration {
+      recordingLogger.debug(
+        "Capture engine already ready reason=\(reason) ringFill=\(String(format: "%.3f", ringFill))s"
+      )
+      return
+    }
+
+    let ready = await captureController.waitUntilReady(
+      minimumRingDuration: minimumRingDuration,
+      timeout: timeout
+    )
+    let finalFill = captureController.ringBufferFillDuration
+    if ready {
+      recordingLogger.notice(
+        "Capture engine ready reason=\(reason) ringFill=\(String(format: "%.3f", finalFill))s"
+      )
+    } else {
+      recordingLogger.notice(
+        "Capture engine armed without full ring buffer reason=\(reason) ringFill=\(String(format: "%.3f", finalFill))s"
+      )
+    }
+  }
+
+  private func ensureCaptureReadyForRecording(reason: String) async throws {
+    let activeInputDevice = applyPreferredInputDevice()
+    try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: reason)
+    await waitForCaptureEngineReady(
+      minimumRingDuration: SuperFastCaptureController.Readiness.minimumRingDuration,
+      timeout: SuperFastCaptureController.Readiness.readyTimeout,
+      reason: reason
+    )
   }
 
   /// Get all available audio devices
@@ -867,6 +1015,7 @@ actor RecordingClientLive {
       keepWarmBuffer: currentCaptureMode().keepsWarmBuffer
     )
     captureControllerDeviceID = deviceID
+    captureEngineLastArmedAt = Date()
   }
 
   private func ensureCaptureControllerReadyAfterDeferredRestart(
@@ -1030,61 +1179,38 @@ actor RecordingClientLive {
     }
   }
 
-  func startRecording() async {
+  func startRecording(requiresLiveAudio: Bool = false) async {
+    resumeMediaTask?.cancel()
+    resumeMediaTask = nil
+
+    if isCaptureActive {
+      recordingLogger.notice("Ignoring duplicate startRecording while capture is active")
+      return
+    }
+
+    if hasActiveMediaControlState {
+      await resumeMediaImmediately()
+    }
+
     let sessionID = UUID()
     recordingSessionID = sessionID
     mediaControlTask?.cancel()
     mediaControlTask = nil
 
-    // Handle audio behavior based on user preference
+    // Defer pause/mute until the recording survives the minimum hold threshold.
+    // This avoids pause/play and volume flicker on accidental or fluttering hotkey presses.
     switch hexSettings.recordingAudioBehavior {
     case .pauseMedia:
-      // Pause media in background - don't block recording from starting
-      mediaControlTask = Task { [sessionID] in
-        guard await self.isCurrentSession(sessionID) else { return }
-        if await self.pauseUsingMediaRemoteIfPossible(sessionID: sessionID) {
-          return
-        }
-
-        // First, pause all media applications using their AppleScript interface.
-        let paused = await pauseAllMediaApplications()
-        guard await self.isCurrentSession(sessionID) else {
-          await resumeMediaApplications(paused)
-          return
-        }
-        await self.updatePausedPlayers(paused, sessionID: sessionID)
-
-        // If no specific players were paused, pause generic media using the media key.
-        guard await self.isCurrentSession(sessionID) else { return }
-        if paused.isEmpty {
-          if await isAudioPlayingOnDefaultOutput() {
-            guard await self.isCurrentSession(sessionID) else { return }
-            mediaLogger.notice("Detected active audio on default output; sending media pause")
-            await MainActor.run {
-              sendMediaKey()
-            }
-            await self.setDidPauseMedia(true, sessionID: sessionID)
-            mediaLogger.notice("Paused media via media key fallback")
-          }
-        } else {
-          mediaLogger.notice("Paused media players: \(paused.joined(separator: ", "))")
-        }
+      scheduleMediaControl(sessionID: sessionID) { [sessionID] in
+        await self.applyPauseMedia(sessionID: sessionID)
       }
 
     case .mute:
-      // Mute system volume in background
-      mediaControlTask = Task { [sessionID] in
-        guard await self.isCurrentSession(sessionID) else { return }
-        let volume = await self.muteSystemVolume()
-        guard await self.isCurrentSession(sessionID) else {
-          await self.restoreSystemVolume(volume)
-          return
-        }
-        await self.setPreviousVolume(volume, sessionID: sessionID)
+      scheduleMediaControl(sessionID: sessionID) { [sessionID] in
+        await self.applyMute(sessionID: sessionID)
       }
 
     case .doNothing:
-      // No audio handling
       break
     }
 
@@ -1096,7 +1222,7 @@ actor RecordingClientLive {
     let startRequestAt = Date()
 
     do {
-      try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: "startRecording")
+      try await ensureCaptureReadyForRecording(reason: "startRecording")
       let recordingURL = makeCaptureRecordingURL()
       try captureController.beginRecording(to: recordingURL, requestedAt: startRequestAt, mode: mode)
       let startedAt = Date()
@@ -1112,6 +1238,17 @@ actor RecordingClientLive {
     } catch {
       recordingLogger.error("Failed to start capture engine for mode=\(mode.rawValue): \(error.localizedDescription); falling back to AVAudioRecorder")
       stopCaptureController(reason: "capture-engine-start-failed")
+
+      if requiresLiveAudio {
+        do {
+          try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: "live-audio-fallback")
+          try captureController.beginLiveMonitoring()
+          isLiveMonitoringActive = true
+          recordingLogger.notice("Started capture engine live monitoring alongside recorder fallback")
+        } catch {
+          recordingLogger.error("Failed to start live audio monitoring: \(error.localizedDescription)")
+        }
+      }
     }
 
     do {
@@ -1140,6 +1277,8 @@ actor RecordingClientLive {
   }
 
   func stopRecording() async -> URL {
+    defer { stopLiveMonitoringIfNeeded() }
+
     let stopSessionID = recordingSessionID
     let activeSession = activeRecordingSession
 
@@ -1181,7 +1320,7 @@ actor RecordingClientLive {
       }
 
       await flushDeferredCaptureRestartIfNeeded()
-      await resumeMediaIfNeeded()
+      scheduleResumeMediaIfNeeded()
       return captureURL
     }
 
@@ -1200,7 +1339,7 @@ actor RecordingClientLive {
       clearActiveRecordingMetadata()
       lastRecordingEndedAt = stoppedAt
       await flushDeferredCaptureRestartIfNeeded()
-      await resumeMediaIfNeeded()
+      scheduleResumeMediaIfNeeded()
       return makeIgnoredStopURL()
     }
     recorder?.stop()
@@ -1224,12 +1363,78 @@ actor RecordingClientLive {
     }
 
     await flushDeferredCaptureRestartIfNeeded()
-    await resumeMediaIfNeeded()
+    scheduleResumeMediaIfNeeded()
 
     return exportedURL
   }
 
-  private func resumeMediaIfNeeded() async {
+  private func stopLiveMonitoringIfNeeded() {
+    guard isLiveMonitoringActive else { return }
+    captureController.endLiveMonitoring()
+    isLiveMonitoringActive = false
+  }
+
+  private func scheduleMediaControl(sessionID: UUID, action: @escaping @Sendable () async -> Void) {
+    let activationDelay = mediaControlActivationDelay()
+    mediaControlTask = Task {
+      if activationDelay > 0 {
+        try? await Task.sleep(for: .seconds(activationDelay))
+      }
+      guard await self.isCurrentSession(sessionID), !Task.isCancelled else { return }
+      await action()
+    }
+  }
+
+  private func applyPauseMedia(sessionID: UUID) async {
+    guard isCurrentSession(sessionID) else { return }
+    if await pauseUsingMediaRemoteIfPossible(sessionID: sessionID) {
+      return
+    }
+
+    let paused = await pauseAllMediaApplications()
+    guard isCurrentSession(sessionID) else {
+      await resumeMediaApplications(paused)
+      return
+    }
+    updatePausedPlayers(paused, sessionID: sessionID)
+
+    guard isCurrentSession(sessionID) else { return }
+    if paused.isEmpty {
+      if await isAudioPlayingOnDefaultOutput() {
+        guard isCurrentSession(sessionID) else { return }
+        mediaLogger.notice("Detected active audio on default output; sending media pause")
+        await MainActor.run {
+          sendMediaKey()
+        }
+        setDidPauseMedia(true, sessionID: sessionID)
+        mediaLogger.notice("Paused media via media key fallback")
+      }
+    } else {
+      mediaLogger.notice("Paused media players: \(paused.joined(separator: ", "))")
+    }
+  }
+
+  private func applyMute(sessionID: UUID) async {
+    guard isCurrentSession(sessionID) else { return }
+    let volume = await muteSystemVolume()
+    guard isCurrentSession(sessionID) else {
+      await restoreSystemVolume(volume)
+      return
+    }
+    setPreviousVolume(volume, sessionID: sessionID)
+  }
+
+  private func scheduleResumeMediaIfNeeded() {
+    guard hasActiveMediaControlState else { return }
+    resumeMediaTask?.cancel()
+    resumeMediaTask = Task {
+      try? await Task.sleep(for: Self.resumeMediaDebounce)
+      guard !Task.isCancelled else { return }
+      await self.resumeMediaImmediately()
+    }
+  }
+
+  private func resumeMediaImmediately() async {
     let playersToResume = pausedPlayers
     let shouldResumeMedia = didPauseMedia
     let shouldResumeViaMediaRemote = didPauseViaMediaRemote
@@ -1421,6 +1626,37 @@ actor RecordingClientLive {
     meterStream
   }
 
+  func observeLiveAudio() -> AsyncStream<AVAudioPCMBuffer> {
+    liveAudioStream
+  }
+
+  func startLiveAudioPump() {
+    guard liveAudioPumpTask == nil else { return }
+    liveAudioPumpTask = Task {
+      for await buffer in liveAudioStream {
+        guard !Task.isCancelled else { break }
+        await deliverLiveAudio(buffer)
+      }
+    }
+  }
+
+  func setLiveAudioConsumer(_ consumer: (@Sendable (AVAudioPCMBuffer) async -> Void)?) {
+    liveAudioConsumer = consumer
+  }
+
+  private func deliverLiveAudio(_ buffer: AVAudioPCMBuffer) async {
+    guard let consumer = liveAudioConsumer else { return }
+    await consumer(buffer)
+  }
+
+  func snapshotRecordingForPreview() -> URL? {
+    captureController.makePreviewSnapshotURL()
+  }
+
+  func previewRecordingDuration() -> TimeInterval {
+    captureController.previewCaptureDuration
+  }
+
   func warmUpRecorder() async {
     guard activeRecordingSession == nil, recorder?.isRecording != true, !captureController.isRecording else {
       recordingLogger.notice("Skipping recorder warm-up while recording is active")
@@ -1432,6 +1668,11 @@ actor RecordingClientLive {
       releaseRecorder(reason: "warm-up-super-fast")
       do {
         try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: "warmUpRecorder")
+        await waitForCaptureEngineReady(
+          minimumRingDuration: SuperFastCaptureController.Readiness.minimumRingDuration,
+          timeout: SuperFastCaptureController.Readiness.warmUpTimeout,
+          reason: "warmUpRecorder"
+        )
       } catch {
         recordingLogger.error("Failed to arm capture engine for super fast mode: \(error.localizedDescription)")
       }
@@ -1443,10 +1684,25 @@ actor RecordingClientLive {
     recordingLogger.debug("Standard mode uses on-demand capture engine startup; skipping idle recorder priming")
   }
 
+  func prewarmCapture() async {
+    guard activeRecordingSession == nil, !captureController.isRecording else { return }
+    let activeInputDevice = applyPreferredInputDevice()
+    do {
+      try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: "prewarmCapture")
+      await waitForCaptureEngineReady(
+        minimumRingDuration: SuperFastCaptureController.Readiness.prewarmRingDuration,
+        timeout: SuperFastCaptureController.Readiness.readyTimeout,
+        reason: "prewarmCapture"
+      )
+    } catch {
+      recordingLogger.debug("Capture prewarm skipped: \(error.localizedDescription)")
+    }
+  }
+
   /// Release recorder resources. Call on app termination.
   func cleanup() async {
     endRecordingSession()
-    await resumeMediaIfNeeded()
+    await resumeMediaImmediately()
     stopObservingSystemChanges()
     stopCaptureController(reason: "cleanup")
     releaseRecorder(reason: "cleanup")

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -38,6 +38,7 @@ struct RecordingClient {
   var snapshotRecordingForPreview: @Sendable () async -> URL? = { nil }
   var previewRecordingDuration: @Sendable () async -> TimeInterval = { 0 }
   var recordingSpeechMetrics: @Sendable () async -> SpeechActivityMetrics = { .zero }
+  var previewSpeechMetrics: @Sendable () async -> SpeechActivityMetrics = { .zero }
   var getAvailableInputDevices: @Sendable () async -> [AudioInputDevice] = { [] }
   var getDefaultInputDeviceName: @Sendable () async -> String? = { nil }
   var warmUpRecorder: @Sendable () async -> Void = {}
@@ -1687,6 +1688,10 @@ actor RecordingClientLive {
     var metrics = sessionSpeechMetrics
     metrics.merge(captureController.recordingSpeechMetrics())
     return metrics
+  }
+
+  func previewSpeechMetrics() -> SpeechActivityMetrics {
+    captureController.previewSpeechMetrics()
   }
 
   func warmUpRecorder() async {

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -64,6 +64,7 @@ extension RecordingClient: DependencyKey {
       snapshotRecordingForPreview: { await live.snapshotRecordingForPreview() },
       previewRecordingDuration: { await live.previewRecordingDuration() },
       recordingSpeechMetrics: { await live.recordingSpeechMetrics() },
+      previewSpeechMetrics: { await live.previewSpeechMetrics() },
       getAvailableInputDevices: { await live.getAvailableInputDevices() },
       getDefaultInputDeviceName: { await live.getDefaultInputDeviceName() },
       warmUpRecorder: { await live.warmUpRecorder() },
@@ -524,7 +525,7 @@ actor RecordingClientLive {
     reason: String
   ) {
     let listener: CoreAudioPropertyListenerBlock = { _, _ in
-      Task { await self.enqueueCaptureEnvironmentChange(reason: reason) }
+      Task { self.enqueueCaptureEnvironmentChange(reason: reason) }
     }
 
     var address = audioPropertyAddress(selector)
@@ -1401,7 +1402,7 @@ actor RecordingClientLive {
       if activationDelay > 0 {
         try? await Task.sleep(for: .seconds(activationDelay))
       }
-      guard await self.isCurrentSession(sessionID), !Task.isCancelled else { return }
+      guard self.isCurrentSession(sessionID), !Task.isCancelled else { return }
       await action()
     }
   }

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -39,11 +39,15 @@ struct RecordingClient {
   var previewRecordingDuration: @Sendable () async -> TimeInterval = { 0 }
   var recordingSpeechMetrics: @Sendable () async -> SpeechActivityMetrics = { .zero }
   var previewSpeechMetrics: @Sendable () async -> SpeechActivityMetrics = { .zero }
+  var previewHasSpeechActivity: @Sendable () async -> Bool = { false }
+  var previewSpeechEvaluation: @Sendable () async -> (metrics: SpeechActivityMetrics, hasActivity: Bool) = { (.zero, false) }
   var getAvailableInputDevices: @Sendable () async -> [AudioInputDevice] = { [] }
   var getDefaultInputDeviceName: @Sendable () async -> String? = { nil }
   var warmUpRecorder: @Sendable () async -> Void = {}
   /// Arms the capture engine without starting a recording (call on hotkey press).
   var prewarmCapture: @Sendable () async -> Void = {}
+  /// Restores volume / resumes media paused or muted for the active recording session.
+  var resumeMediaIfNeeded: @Sendable () async -> Void = {}
   var cleanup: @Sendable () async -> Void = {}
 }
 
@@ -65,10 +69,13 @@ extension RecordingClient: DependencyKey {
       previewRecordingDuration: { await live.previewRecordingDuration() },
       recordingSpeechMetrics: { await live.recordingSpeechMetrics() },
       previewSpeechMetrics: { await live.previewSpeechMetrics() },
+      previewHasSpeechActivity: { await live.previewHasSpeechActivity() },
+      previewSpeechEvaluation: { await live.previewSpeechEvaluation() },
       getAvailableInputDevices: { await live.getAvailableInputDevices() },
       getDefaultInputDeviceName: { await live.getDefaultInputDeviceName() },
       warmUpRecorder: { await live.warmUpRecorder() },
       prewarmCapture: { await live.prewarmCapture() },
+      resumeMediaIfNeeded: { await live.resumeMediaIfNeeded() },
       cleanup: { await live.cleanup() }
     )
   }
@@ -1342,7 +1349,6 @@ actor RecordingClientLive {
       }
 
       await flushDeferredCaptureRestartIfNeeded()
-      scheduleResumeMediaIfNeeded()
       return captureURL
     }
 
@@ -1361,7 +1367,6 @@ actor RecordingClientLive {
       clearActiveRecordingMetadata()
       lastRecordingEndedAt = stoppedAt
       await flushDeferredCaptureRestartIfNeeded()
-      scheduleResumeMediaIfNeeded()
       return makeIgnoredStopURL()
     }
     recorder?.stop()
@@ -1385,7 +1390,6 @@ actor RecordingClientLive {
     }
 
     await flushDeferredCaptureRestartIfNeeded()
-    scheduleResumeMediaIfNeeded()
 
     return exportedURL
   }
@@ -1444,6 +1448,10 @@ actor RecordingClientLive {
       return
     }
     setPreviousVolume(volume, sessionID: sessionID)
+  }
+
+  func resumeMediaIfNeeded() {
+    scheduleResumeMediaIfNeeded()
   }
 
   private func scheduleResumeMediaIfNeeded() {
@@ -1693,6 +1701,14 @@ actor RecordingClientLive {
 
   func previewSpeechMetrics() -> SpeechActivityMetrics {
     captureController.previewSpeechMetrics()
+  }
+
+  func previewHasSpeechActivity() -> Bool {
+    captureController.previewHasSpeechActivity()
+  }
+
+  func previewSpeechEvaluation() -> (metrics: SpeechActivityMetrics, hasActivity: Bool) {
+    captureController.previewSpeechEvaluation()
   }
 
   func warmUpRecorder() async {

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -180,7 +180,7 @@ final class SuperFastCaptureController {
 
   var previewCaptureDuration: TimeInterval {
     processingQueue.sync {
-      guard activeRecording != nil else { return 0 }
+      guard activeRecording != nil || isLiveMonitoring else { return 0 }
       return Double(previewSamples.count) / SuperFastCaptureConstants.sampleRate
     }
   }
@@ -190,44 +190,47 @@ final class SuperFastCaptureController {
   func makePreviewSnapshotURL(
     minimumDuration: TimeInterval = SuperFastCaptureConstants.previewMinimumDuration
   ) -> URL? {
-    processingQueue.sync {
-      guard activeRecording != nil else { return nil }
+    let snapshotData = processingQueue.sync { () -> (samples: [Float], duration: TimeInterval)? in
+      guard activeRecording != nil || isLiveMonitoring else { return nil }
 
       let duration = Double(previewSamples.count) / SuperFastCaptureConstants.sampleRate
       guard duration >= minimumDuration else { return nil }
+      return (previewSamples, duration)
+    }
 
-      let snapshotURL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("hex-preview-\(UUID().uuidString).wav")
+    guard let snapshotData else { return nil }
+    let (samples, duration) = snapshotData
 
-      do {
-        if FileManager.default.fileExists(atPath: snapshotURL.path) {
-          try FileManager.default.removeItem(at: snapshotURL)
-        }
+    let snapshotURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("hex-preview-\(UUID().uuidString).wav")
 
-        let file = try AVAudioFile(
-          forWriting: snapshotURL,
-          settings: [
-            AVFormatIDKey: Int(kAudioFormatLinearPCM),
-            AVSampleRateKey: SuperFastCaptureConstants.sampleRate,
-            AVNumberOfChannelsKey: 1,
-            AVLinearPCMBitDepthKey: 32,
-            AVLinearPCMIsFloatKey: true,
-            AVLinearPCMIsBigEndianKey: false,
-            AVLinearPCMIsNonInterleaved: true,
-          ],
-          commonFormat: .pcmFormatFloat32,
-          interleaved: false
-        )
-        try write(samples: previewSamples, to: file)
-        let sampleCount = previewSamples.count
-        logger.debug(
-          "Preview snapshot written duration=\(String(format: "%.3f", duration))s samples=\(sampleCount) file=\(snapshotURL.lastPathComponent)"
-        )
-        return snapshotURL
-      } catch {
-        logger.debug("Failed to write preview snapshot: \(error.localizedDescription)")
-        return nil
+    do {
+      if FileManager.default.fileExists(atPath: snapshotURL.path) {
+        try FileManager.default.removeItem(at: snapshotURL)
       }
+
+      let file = try AVAudioFile(
+        forWriting: snapshotURL,
+        settings: [
+          AVFormatIDKey: Int(kAudioFormatLinearPCM),
+          AVSampleRateKey: SuperFastCaptureConstants.sampleRate,
+          AVNumberOfChannelsKey: 1,
+          AVLinearPCMBitDepthKey: 32,
+          AVLinearPCMIsFloatKey: true,
+          AVLinearPCMIsBigEndianKey: false,
+          AVLinearPCMIsNonInterleaved: true,
+        ],
+        commonFormat: .pcmFormatFloat32,
+        interleaved: false
+      )
+      try write(samples: samples, to: file)
+      logger.debug(
+        "Preview snapshot written duration=\(String(format: "%.3f", duration))s samples=\(samples.count) file=\(snapshotURL.lastPathComponent)"
+      )
+      return snapshotURL
+    } catch {
+      logger.debug("Failed to write preview snapshot: \(error.localizedDescription)")
+      return nil
     }
   }
 
@@ -493,6 +496,8 @@ final class SuperFastCaptureController {
     processingQueue.sync {
       isLiveMonitoring = true
       didLogFirstLiveBuffer = false
+      previewSamples.removeAll(keepingCapacity: true)
+      didLogPreviewSampleCap = false
     }
     logger.notice("Capture engine live monitoring started")
   }
@@ -565,7 +570,7 @@ final class SuperFastCaptureController {
       }
     }
 
-    if activeRecording != nil {
+    if activeRecording != nil || isLiveMonitoring {
       let maxPreviewSamples = Int(
         SuperFastCaptureConstants.previewMaximumDuration * SuperFastCaptureConstants.sampleRate
       )

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -65,7 +65,8 @@ private struct SuperFastCaptureConstants {
   static let defaultPreRollDuration: TimeInterval = 0.45
   /// Short ring-buffer seed for live preview only (not the saved recording).
   static let previewPreRollDuration: TimeInterval = 0.12
-  static let previewMinimumDuration: TimeInterval = 0.12
+  /// Match Parakeet preview padding so we do not transcribe clips that will be zero-padded.
+  static let previewMinimumDuration: TimeInterval = 1.0
   /// Stop accumulating in-memory preview PCM beyond this duration; recording to file continues.
   static let previewMaximumDuration: TimeInterval = 600
   static let captureReadyMinimumRingDuration: TimeInterval = 0.15

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -192,10 +192,22 @@ final class SuperFastCaptureController {
     processingQueue.sync { sessionSpeechMetrics }
   }
 
-  /// Speech levels in the current in-memory preview buffer (not cumulative session peak).
+  /// Speech levels in the recent trailing preview window (ignores earlier audio).
   func previewSpeechMetrics() -> SpeechActivityMetrics {
+    previewSpeechEvaluation().metrics
+  }
+
+  /// Whether the recent preview window contains speech above the estimated noise floor.
+  func previewHasSpeechActivity() -> Bool {
+    previewSpeechEvaluation().hasActivity
+  }
+
+  func previewSpeechEvaluation() -> (metrics: SpeechActivityMetrics, hasActivity: Bool) {
     processingQueue.sync {
-      SpeechActivityMetrics.analyze(samples: previewSamples)
+      SpeechActivityGate.evaluatePreviewActivity(
+        samples: previewSamples,
+        sampleRate: SuperFastCaptureConstants.sampleRate
+      )
     }
   }
 

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -50,18 +50,37 @@ private final class FloatRingBuffer {
     writeIndex = 0
     validSampleCount = 0
   }
+
+  func fillDuration(sampleRate: Double) -> TimeInterval {
+    lock.lock()
+    defer { lock.unlock() }
+    guard sampleRate > 0 else { return 0 }
+    return Double(validSampleCount) / sampleRate
+  }
 }
 
 private struct SuperFastCaptureConstants {
   static let sampleRate: Double = 16_000
   static let ringBufferDuration: TimeInterval = 1.0
   static let defaultPreRollDuration: TimeInterval = 0.45
-  static let tapBufferSize: AVAudioFrameCount = 2_048
+  /// Short ring-buffer seed for live preview only (not the saved recording).
+  static let previewPreRollDuration: TimeInterval = 0.12
+  static let previewMinimumDuration: TimeInterval = 0.12
+  /// Stop accumulating in-memory preview PCM beyond this duration; recording to file continues.
+  static let previewMaximumDuration: TimeInterval = 600
+  static let captureReadyMinimumRingDuration: TimeInterval = 0.15
+  static let captureReadyPrewarmRingDuration: TimeInterval = 0.20
+  static let captureWarmUpTimeout: TimeInterval = 1.5
+  static let captureReadyTimeout: TimeInterval = 2.5
+  static let tapBufferSize: AVAudioFrameCount = 4_096
   static let fallbackStopGracePeriod: TimeInterval = 0.05
   static let minimumStopGracePeriod: TimeInterval = 0.02
   static let maximumStopGracePeriod: TimeInterval = 0.08
   static let stopGraceSafetyMargin: TimeInterval = 0.008
   static let callbackTimingWindowSize = 8
+  static let configChangeGracePeriod: TimeInterval = 2.0
+  static let startRetryCount = 3
+  static let startRetryDelay: TimeInterval = 0.15
 }
 
 enum CaptureRecordingMode: String {
@@ -83,6 +102,13 @@ enum CaptureRecordingMode: String {
 }
 
 final class SuperFastCaptureController {
+  enum Readiness {
+    static let minimumRingDuration = SuperFastCaptureConstants.captureReadyMinimumRingDuration
+    static let prewarmRingDuration = SuperFastCaptureConstants.captureReadyPrewarmRingDuration
+    static let warmUpTimeout = SuperFastCaptureConstants.captureWarmUpTimeout
+    static let readyTimeout = SuperFastCaptureConstants.captureReadyTimeout
+  }
+
   struct StopTimingEstimate {
     let gracePeriod: TimeInterval
     let callbackInterval: TimeInterval
@@ -100,6 +126,7 @@ final class SuperFastCaptureController {
   private let logger = HexLog.recording
   private let processingQueue = DispatchQueue(label: "com.kitlangton.Hex.SuperFastCapture")
   private let meterContinuation: AsyncStream<Meter>.Continuation
+  private let liveAudioContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
   private let ringBuffer = FloatRingBuffer(
     capacity: Int(SuperFastCaptureConstants.sampleRate * SuperFastCaptureConstants.ringBufferDuration)
   )
@@ -114,17 +141,24 @@ final class SuperFastCaptureController {
   private var converter: AVAudioConverter?
   private var configurationChangeObserver: NSObjectProtocol?
   private var activeRecording: ActiveRecording?
+  private var isLiveMonitoring = false
+  private var didLogFirstLiveBuffer = false
   private var keepWarmBuffer = false
   private var lastProcessedBufferAt: Date?
   private var recentCallbackIntervals: [TimeInterval] = []
   private var recentBufferDurations: [TimeInterval] = []
+  private var previewSamples: [Float] = []
+  private var didLogPreviewSampleCap = false
+  private var lastArmedAt: Date?
   private let onEngineConfigurationChange: @Sendable () -> Void
 
   init(
     meterContinuation: AsyncStream<Meter>.Continuation,
+    liveAudioContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation? = nil,
     onEngineConfigurationChange: @escaping @Sendable () -> Void
   ) {
     self.meterContinuation = meterContinuation
+    self.liveAudioContinuation = liveAudioContinuation
     self.onEngineConfigurationChange = onEngineConfigurationChange
   }
 
@@ -138,6 +172,63 @@ final class SuperFastCaptureController {
 
   var isRecording: Bool {
     processingQueue.sync { activeRecording != nil }
+  }
+
+  var currentRecordingURL: URL? {
+    processingQueue.sync { activeRecording?.url }
+  }
+
+  var previewCaptureDuration: TimeInterval {
+    processingQueue.sync {
+      guard activeRecording != nil else { return 0 }
+      return Double(previewSamples.count) / SuperFastCaptureConstants.sampleRate
+    }
+  }
+
+  /// Writes accumulated PCM from the active recording to a standalone WAV for live preview.
+  /// In-progress capture files are not readable until finalized, so preview uses memory instead.
+  func makePreviewSnapshotURL(
+    minimumDuration: TimeInterval = SuperFastCaptureConstants.previewMinimumDuration
+  ) -> URL? {
+    processingQueue.sync {
+      guard activeRecording != nil else { return nil }
+
+      let duration = Double(previewSamples.count) / SuperFastCaptureConstants.sampleRate
+      guard duration >= minimumDuration else { return nil }
+
+      let snapshotURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("hex-preview-\(UUID().uuidString).wav")
+
+      do {
+        if FileManager.default.fileExists(atPath: snapshotURL.path) {
+          try FileManager.default.removeItem(at: snapshotURL)
+        }
+
+        let file = try AVAudioFile(
+          forWriting: snapshotURL,
+          settings: [
+            AVFormatIDKey: Int(kAudioFormatLinearPCM),
+            AVSampleRateKey: SuperFastCaptureConstants.sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: true,
+          ],
+          commonFormat: .pcmFormatFloat32,
+          interleaved: false
+        )
+        try write(samples: previewSamples, to: file)
+        let sampleCount = previewSamples.count
+        logger.debug(
+          "Preview snapshot written duration=\(String(format: "%.3f", duration))s samples=\(sampleCount) file=\(snapshotURL.lastPathComponent)"
+        )
+        return snapshotURL
+      } catch {
+        logger.debug("Failed to write preview snapshot: \(error.localizedDescription)")
+        return nil
+      }
+    }
   }
 
   var stopTimingEstimate: StopTimingEstimate {
@@ -162,6 +253,38 @@ final class SuperFastCaptureController {
     }
   }
 
+  var ringBufferFillDuration: TimeInterval {
+    processingQueue.sync {
+      ringBuffer.fillDuration(sampleRate: SuperFastCaptureConstants.sampleRate)
+    }
+  }
+
+  /// Waits until the capture engine is running and the warm ring buffer has enough audio
+  /// to seed the recording pre-roll (critical for the first hotkey press after launch).
+  func waitUntilReady(
+    minimumRingDuration: TimeInterval = SuperFastCaptureConstants.captureReadyMinimumRingDuration,
+    timeout: TimeInterval = SuperFastCaptureConstants.captureReadyTimeout
+  ) async -> Bool {
+    guard minimumRingDuration > 0 else {
+      return processingQueue.sync { engine?.isRunning == true }
+    }
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if Task.isCancelled { return false }
+
+      let isReady = processingQueue.sync { () -> Bool in
+        guard engine?.isRunning == true else { return false }
+        return ringBuffer.fillDuration(sampleRate: SuperFastCaptureConstants.sampleRate) >= minimumRingDuration
+      }
+      if isReady { return true }
+
+      try? await Task.sleep(for: .milliseconds(25))
+    }
+
+    return processingQueue.sync { engine?.isRunning == true }
+  }
+
   func startIfNeeded(reason: String = "unknown", keepWarmBuffer: Bool = false) throws {
     let didDisableWarmBuffer = self.keepWarmBuffer && !keepWarmBuffer
     self.keepWarmBuffer = keepWarmBuffer
@@ -178,30 +301,54 @@ final class SuperFastCaptureController {
       return
     }
 
-    stop(reason: "restart-before-arm")
+    var lastError: Error?
+    for attempt in 0 ..< SuperFastCaptureConstants.startRetryCount {
+      stop(reason: attempt == 0 ? "restart-before-arm" : "restart-before-arm-retry-\(attempt + 1)")
 
+      do {
+        try startEngineOnce(reason: reason, attempt: attempt + 1)
+        lastArmedAt = Date()
+        return
+      } catch {
+        lastError = error
+        guard isRecoverableStartError(error), attempt + 1 < SuperFastCaptureConstants.startRetryCount else {
+          throw error
+        }
+        logger.notice(
+          "Capture engine start failed, retrying reason=\(reason) attempt=\(attempt + 2)/\(SuperFastCaptureConstants.startRetryCount) error=\(error.localizedDescription)"
+        )
+        Thread.sleep(forTimeInterval: SuperFastCaptureConstants.startRetryDelay * Double(attempt + 1))
+      }
+    }
+
+    if let lastError {
+      throw lastError
+    }
+  }
+
+  private func startEngineOnce(reason: String, attempt: Int) throws {
     let engine = AVAudioEngine()
     let inputNode = engine.inputNode
-    let inputFormat = inputNode.inputFormat(forBus: 0)
-    guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+    engine.prepare()
+    let tapFormat = inputNode.outputFormat(forBus: 0)
+    guard let converter = AVAudioConverter(from: tapFormat, to: targetFormat) else {
       throw NSError(
         domain: "SuperFastCapture",
         code: -1,
         userInfo: [NSLocalizedDescriptionKey: "Unable to create the capture engine audio converter."]
       )
     }
-    if inputFormat.channelCount > 1 {
+    if tapFormat.channelCount > 1 {
       converter.channelMap = [NSNumber(value: 0)]
     }
 
     self.converter = converter
 
-    inputNode.installTap(onBus: 0, bufferSize: SuperFastCaptureConstants.tapBufferSize, format: inputFormat) {
+    inputNode.installTap(onBus: 0, bufferSize: SuperFastCaptureConstants.tapBufferSize, format: tapFormat) {
       [weak self] buffer, _ in
       self?.enqueue(buffer)
     }
 
-    engine.prepare()
     do {
       try engine.start()
     } catch {
@@ -218,8 +365,13 @@ final class SuperFastCaptureController {
       self?.handleConfigurationChange()
     }
     logger.notice(
-      "Capture engine armed reason=\(reason) sampleRate=\(String(format: "%.0f", inputFormat.sampleRate))Hz channels=\(inputFormat.channelCount) ringBuffer=\(String(format: "%.2f", SuperFastCaptureConstants.ringBufferDuration))s defaultPreRoll=\(String(format: "%.2f", SuperFastCaptureConstants.defaultPreRollDuration))s"
+      "Capture engine armed reason=\(reason) attempt=\(attempt) tapSampleRate=\(String(format: "%.0f", tapFormat.sampleRate))Hz channels=\(tapFormat.channelCount) ringBuffer=\(String(format: "%.2f", SuperFastCaptureConstants.ringBufferDuration))s defaultPreRoll=\(String(format: "%.2f", SuperFastCaptureConstants.defaultPreRollDuration))s"
     )
+  }
+
+  private func isRecoverableStartError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == "com.apple.coreaudio.avfaudio" && nsError.code == -10868
   }
 
   func stop(reason: String = "unknown") {
@@ -239,6 +391,8 @@ final class SuperFastCaptureController {
 
     processingQueue.sync {
       activeRecording = nil
+      isLiveMonitoring = false
+      didLogFirstLiveBuffer = false
       ringBuffer.clear()
       lastProcessedBufferAt = nil
       recentCallbackIntervals.removeAll(keepingCapacity: false)
@@ -248,6 +402,27 @@ final class SuperFastCaptureController {
 
   private func handleConfigurationChange() {
     logger.notice("Capture engine configuration changed")
+
+    let isRecording = processingQueue.sync { activeRecording != nil }
+    if isRecording {
+      onEngineConfigurationChange()
+      return
+    }
+
+    if let lastArmedAt,
+       Date().timeIntervalSince(lastArmedAt) < SuperFastCaptureConstants.configChangeGracePeriod
+    {
+      logger.debug(
+        "Re-arming capture engine after config change within grace period armedAgo=\(String(format: "%.3f", Date().timeIntervalSince(lastArmedAt)))s"
+      )
+      do {
+        try startIfNeeded(reason: "config-change-rearm", keepWarmBuffer: keepWarmBuffer)
+      } catch {
+        logger.error("Capture engine re-arm after config change failed: \(error.localizedDescription)")
+      }
+      return
+    }
+
     onEngineConfigurationChange()
   }
 
@@ -278,7 +453,20 @@ final class SuperFastCaptureController {
         let prependedDuration = Double(preRollSamples.count) / SuperFastCaptureConstants.sampleRate
         if !preRollSamples.isEmpty {
           try write(samples: preRollSamples, to: file)
+          if let liveAudioContinuation,
+             let preRollBuffer = makePCMBuffer(from: preRollSamples)
+          {
+            liveAudioContinuation.yield(preRollBuffer)
+          }
         }
+
+        // Live preview uses post-hotkey audio plus a short ring-buffer seed so the
+        // first words aren't missed, without the full pre-roll that caused ghost tokens.
+        let previewPreRollFrameCount = Int(
+          SuperFastCaptureConstants.previewPreRollDuration * SuperFastCaptureConstants.sampleRate
+        )
+        previewSamples = ringBuffer.recentSamples(count: previewPreRollFrameCount)
+        didLogPreviewSampleCap = false
 
         logger.notice(
           "Capture engine recording file opened prepended=\(String(format: "%.3f", prependedDuration))s requestedPreRoll=\(String(format: "%.3f", preRollDuration))s"
@@ -300,10 +488,28 @@ final class SuperFastCaptureController {
     }
   }
 
+  func beginLiveMonitoring() throws {
+    try startIfNeeded(reason: "begin-live-monitoring", keepWarmBuffer: false)
+    processingQueue.sync {
+      isLiveMonitoring = true
+      didLogFirstLiveBuffer = false
+    }
+    logger.notice("Capture engine live monitoring started")
+  }
+
+  func endLiveMonitoring() {
+    processingQueue.sync {
+      isLiveMonitoring = false
+    }
+    logger.notice("Capture engine live monitoring stopped")
+  }
+
   func finishRecording(clearBuffer: Bool = true) -> URL? {
     processingQueue.sync {
       let url = activeRecording?.url
       activeRecording = nil
+      previewSamples.removeAll(keepingCapacity: true)
+      didLogPreviewSampleCap = false
       if clearBuffer {
         ringBuffer.clear()
       }
@@ -349,6 +555,37 @@ final class SuperFastCaptureController {
       meterContinuation.yield(meter(for: samples, count: sampleCount))
     }
 
+    if activeRecording != nil || isLiveMonitoring {
+      if let liveAudioContinuation, let liveBuffer = clone(converted) {
+        if !didLogFirstLiveBuffer {
+          didLogFirstLiveBuffer = true
+          logger.notice("Capture engine yielding first live audio buffer frames=\(liveBuffer.frameLength)")
+        }
+        liveAudioContinuation.yield(liveBuffer)
+      }
+    }
+
+    if activeRecording != nil {
+      let maxPreviewSamples = Int(
+        SuperFastCaptureConstants.previewMaximumDuration * SuperFastCaptureConstants.sampleRate
+      )
+      if previewSamples.count < maxPreviewSamples {
+        let remaining = maxPreviewSamples - previewSamples.count
+        let appendCount = min(sampleCount, remaining)
+        if appendCount > 0 {
+          previewSamples.append(
+            contentsOf: UnsafeBufferPointer(start: samples, count: appendCount)
+          )
+        }
+        if appendCount < sampleCount, !didLogPreviewSampleCap {
+          didLogPreviewSampleCap = true
+          logger.notice(
+            "Live preview in-memory buffer capped at \(String(format: "%.0f", SuperFastCaptureConstants.previewMaximumDuration))s; recording continues, final transcription unaffected"
+          )
+        }
+      }
+    }
+
     guard var recording = activeRecording else { return }
     if !recording.didLogFirstBuffer {
       let timeToFirstBuffer = Date().timeIntervalSince(recording.requestedAt)
@@ -364,6 +601,8 @@ final class SuperFastCaptureController {
     } catch {
       logger.error("Failed to write capture engine audio: \(error.localizedDescription)")
       activeRecording = nil
+      previewSamples.removeAll(keepingCapacity: true)
+      didLogPreviewSampleCap = false
     }
   }
 
@@ -409,10 +648,20 @@ final class SuperFastCaptureController {
 
   private func write(samples: [Float], to file: AVAudioFile) throws {
     guard !samples.isEmpty,
+          let buffer = makePCMBuffer(from: samples)
+    else {
+      return
+    }
+
+    try file.write(from: buffer)
+  }
+
+  private func makePCMBuffer(from samples: [Float]) -> AVAudioPCMBuffer? {
+    guard !samples.isEmpty,
           let buffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: AVAudioFrameCount(samples.count)),
           let channelData = buffer.floatChannelData?[0]
     else {
-      return
+      return nil
     }
 
     buffer.frameLength = AVAudioFrameCount(samples.count)
@@ -420,7 +669,7 @@ final class SuperFastCaptureController {
       guard let baseAddress = sampleBuffer.baseAddress else { return }
       channelData.update(from: baseAddress, count: sampleBuffer.count)
     }
-    try file.write(from: buffer)
+    return buffer
   }
 
   private func meter(for samples: UnsafePointer<Float>, count: Int) -> Meter {

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -192,6 +192,13 @@ final class SuperFastCaptureController {
     processingQueue.sync { sessionSpeechMetrics }
   }
 
+  /// Speech levels in the current in-memory preview buffer (not cumulative session peak).
+  func previewSpeechMetrics() -> SpeechActivityMetrics {
+    processingQueue.sync {
+      SpeechActivityMetrics.analyze(samples: previewSamples)
+    }
+  }
+
   func resetSessionSpeechMetrics() {
     processingQueue.sync {
       sessionSpeechMetrics = .zero

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 import HexCore
+import HexCore
 
 private final class FloatRingBuffer {
   private let lock = NSLock()
@@ -150,6 +151,7 @@ final class SuperFastCaptureController {
   private var recentBufferDurations: [TimeInterval] = []
   private var previewSamples: [Float] = []
   private var didLogPreviewSampleCap = false
+  private var sessionSpeechMetrics = SpeechActivityMetrics.zero
   private var lastArmedAt: Date?
   private let onEngineConfigurationChange: @Sendable () -> Void
 
@@ -183,6 +185,16 @@ final class SuperFastCaptureController {
     processingQueue.sync {
       guard activeRecording != nil || isLiveMonitoring else { return 0 }
       return Double(previewSamples.count) / SuperFastCaptureConstants.sampleRate
+    }
+  }
+
+  func recordingSpeechMetrics() -> SpeechActivityMetrics {
+    processingQueue.sync { sessionSpeechMetrics }
+  }
+
+  func resetSessionSpeechMetrics() {
+    processingQueue.sync {
+      sessionSpeechMetrics = .zero
     }
   }
 
@@ -471,6 +483,7 @@ final class SuperFastCaptureController {
         )
         previewSamples = ringBuffer.recentSamples(count: previewPreRollFrameCount)
         didLogPreviewSampleCap = false
+        sessionSpeechMetrics = .zero
 
         logger.notice(
           "Capture engine recording file opened prepended=\(String(format: "%.3f", prependedDuration))s requestedPreRoll=\(String(format: "%.3f", preRollDuration))s"
@@ -558,7 +571,11 @@ final class SuperFastCaptureController {
     }
 
     if activeRecording != nil {
-      meterContinuation.yield(meter(for: samples, count: sampleCount))
+      let level = meter(for: samples, count: sampleCount)
+      meterContinuation.yield(level)
+      sessionSpeechMetrics.merge(
+        SpeechActivityMetrics(peakRMS: level.averagePower, peakSample: level.peakPower)
+      )
     }
 
     if activeRecording != nil || isLiveMonitoring {

--- a/Hex/Clients/TranscriptionClient.swift
+++ b/Hex/Clients/TranscriptionClient.swift
@@ -24,6 +24,15 @@ struct TranscriptionClient {
   /// Reports transcription progress via `progressCallback`.
   var transcribe: @Sendable (URL, String, DecodingOptions, @escaping (Progress) -> Void) async throws -> String
 
+  /// Fast Parakeet preview on a growing capture file while recording is in progress.
+  var transcribePreview: @Sendable (URL, String) async throws -> String = { _, _ in "" }
+
+  /// Waits until preview and final Parakeet transcribes are not in flight.
+  var waitForParakeetIdle: @Sendable () async -> Void = {}
+
+  /// Clears FluidAudio decoder state between preview and final passes.
+  var resetParakeetTranscriberState: @Sendable () async throws -> Void = {}
+
   /// Ensures a model is downloaded (if missing) and loaded into memory, reporting progress via `progressCallback`.
   var downloadModel: @Sendable (String, @escaping (Progress) -> Void) async throws -> Void
 
@@ -45,6 +54,9 @@ extension TranscriptionClient: DependencyKey {
     let live = TranscriptionClientLive()
     return Self(
       transcribe: { try await live.transcribe(url: $0, model: $1, options: $2, progressCallback: $3) },
+      transcribePreview: { try await live.transcribePreview(url: $0, model: $1) },
+      waitForParakeetIdle: { await live.waitForParakeetIdle() },
+      resetParakeetTranscriberState: { try await live.resetParakeetTranscriberState() },
       downloadModel: { try await live.downloadAndLoadModel(variant: $0, progressCallback: $1) },
       deleteModel: { try await live.deleteModel(variant: $0) },
       isModelDownloaded: { await live.isModelDownloaded($0) },
@@ -73,6 +85,8 @@ actor TranscriptionClientLive {
   /// The name of the currently loaded model, if any.
   private var currentModelName: String?
   private var parakeet: ParakeetClient = ParakeetClient()
+  private var parakeetPipelineHeld = false
+  private var parakeetPipelineWaiters: [CheckedContinuation<Void, Never>] = []
 
   /// The base folder under which we store model data (e.g., ~/Library/Application Support/...).
   private lazy var modelsBaseFolder: URL = {
@@ -229,6 +243,9 @@ actor TranscriptionClientLive {
   ) async throws -> String {
     let startAll = Date()
     if isParakeet(model) {
+      await acquireParakeetPipeline()
+      defer { releaseParakeetPipeline() }
+
       transcriptionLogger.notice("Transcribing with Parakeet model=\(model) file=\(url.lastPathComponent)")
       let startLoad = Date()
       try await downloadAndLoadModel(variant: model) { p in
@@ -276,6 +293,51 @@ actor TranscriptionClientLive {
     // Concatenate results from all segments.
     let text = results.map(\.text).joined(separator: " ")
     return text
+  }
+
+  func waitForParakeetIdle() async {
+    await parakeet.waitUntilTranscribeIdle()
+  }
+
+  func resetParakeetTranscriberState() async throws {
+    try await parakeet.resetTranscriberState()
+  }
+
+  /// Lightweight Parakeet pass for live preview while a capture file is still growing.
+  func transcribePreview(url: URL, model: String) async throws -> String {
+    try Task.checkCancellation()
+    await acquireParakeetPipeline()
+    defer { releaseParakeetPipeline() }
+
+    guard isParakeet(model) else { return "" }
+    guard FileManager.default.fileExists(atPath: url.path) else { return "" }
+
+    try await parakeet.ensureLoaded(modelName: model) { _ in }
+    let preparedClip = try ParakeetClipPreparer.ensureMinimumDuration(
+      url: url,
+      minimumDuration: ParakeetClipPreparer.previewMinimumDuration,
+      logger: parakeetLogger
+    )
+    defer { preparedClip.cleanup() }
+    return try await parakeet.transcribe(preparedClip.url)
+  }
+
+  private func acquireParakeetPipeline() async {
+    if !parakeetPipelineHeld {
+      parakeetPipelineHeld = true
+      return
+    }
+    await withCheckedContinuation { continuation in
+      parakeetPipelineWaiters.append(continuation)
+    }
+  }
+
+  private func releaseParakeetPipeline() {
+    if parakeetPipelineWaiters.isEmpty {
+      parakeetPipelineHeld = false
+      return
+    }
+    parakeetPipelineWaiters.removeFirst().resume()
   }
 
   // MARK: - Private Helpers

--- a/Hex/Clients/TranscriptionClient.swift
+++ b/Hex/Clients/TranscriptionClient.swift
@@ -87,6 +87,7 @@ actor TranscriptionClientLive {
   private var parakeet: ParakeetClient = ParakeetClient()
   private var parakeetPipelineHeld = false
   private var parakeetPipelineWaiters: [CheckedContinuation<Void, Never>] = []
+  private var parakeetPipelineIdleWaiters: [CheckedContinuation<Void, Never>] = []
 
   /// The base folder under which we store model data (e.g., ~/Library/Application Support/...).
   private lazy var modelsBaseFolder: URL = {
@@ -297,6 +298,11 @@ actor TranscriptionClientLive {
 
   func waitForParakeetIdle() async {
     await parakeet.waitUntilTranscribeIdle()
+    if parakeetPipelineHeld {
+      await withCheckedContinuation { continuation in
+        parakeetPipelineIdleWaiters.append(continuation)
+      }
+    }
   }
 
   func resetParakeetTranscriberState() async throws {
@@ -335,6 +341,9 @@ actor TranscriptionClientLive {
   private func releaseParakeetPipeline() {
     if parakeetPipelineWaiters.isEmpty {
       parakeetPipelineHeld = false
+      let idleWaiters = parakeetPipelineIdleWaiters
+      parakeetPipelineIdleWaiters.removeAll()
+      idleWaiters.forEach { $0.resume() }
       return
     }
     parakeetPipelineWaiters.removeFirst().resume()

--- a/Hex/Clients/TranscriptionClient.swift
+++ b/Hex/Clients/TranscriptionClient.swift
@@ -33,6 +33,9 @@ struct TranscriptionClient {
   /// Clears FluidAudio decoder state between preview and final passes.
   var resetParakeetTranscriberState: @Sendable () async throws -> Void = {}
 
+  /// Rebuilds the Parakeet AsrManager from cached models after repeated preview passes.
+  var reinitializeParakeetTranscriber: @Sendable () async throws -> Void = {}
+
   /// Ensures a model is downloaded (if missing) and loaded into memory, reporting progress via `progressCallback`.
   var downloadModel: @Sendable (String, @escaping (Progress) -> Void) async throws -> Void
 
@@ -57,6 +60,7 @@ extension TranscriptionClient: DependencyKey {
       transcribePreview: { try await live.transcribePreview(url: $0, model: $1) },
       waitForParakeetIdle: { await live.waitForParakeetIdle() },
       resetParakeetTranscriberState: { try await live.resetParakeetTranscriberState() },
+      reinitializeParakeetTranscriber: { try await live.reinitializeParakeetTranscriber() },
       downloadModel: { try await live.downloadAndLoadModel(variant: $0, progressCallback: $1) },
       deleteModel: { try await live.deleteModel(variant: $0) },
       isModelDownloaded: { await live.isModelDownloaded($0) },
@@ -306,7 +310,15 @@ actor TranscriptionClientLive {
   }
 
   func resetParakeetTranscriberState() async throws {
+    await acquireParakeetPipeline()
+    defer { releaseParakeetPipeline() }
     try await parakeet.resetTranscriberState()
+  }
+
+  func reinitializeParakeetTranscriber() async throws {
+    await acquireParakeetPipeline()
+    defer { releaseParakeetPipeline() }
+    try await parakeet.reinitializeTranscriber()
   }
 
   /// Lightweight Parakeet pass for live preview while a capture file is still growing.
@@ -325,7 +337,7 @@ actor TranscriptionClientLive {
       logger: parakeetLogger
     )
     defer { preparedClip.cleanup() }
-    return try await parakeet.transcribe(preparedClip.url)
+    return try await parakeet.transcribe(preparedClip.url, reinitializeOnEmpty: false)
   }
 
   private func acquireParakeetPipeline() async {

--- a/Hex/Features/App/AppFeature.swift
+++ b/Hex/Features/App/AppFeature.swift
@@ -138,8 +138,7 @@ struct AppFeature {
 
       case .settings(.revealAppInFinder):
         return .run { _ in
-          guard let url = Bundle.main.bundleURL.deletingLastPathComponent().deletingLastPathComponent() as URL? else { return }
-          NSWorkspace.shared.activateFileViewerSelecting([url])
+          NSWorkspace.shared.activateFileViewerSelecting([Bundle.main.bundleURL])
         }
 
       case .settings:
@@ -233,7 +232,9 @@ struct AppFeature {
           return false
         }
 
-        Task { await send(.settings(.keyEvent(keyEvent))) }
+        MainActor.assumeIsolated {
+          send(.settings(.keyEvent(keyEvent)))
+        }
         return true
       }
 

--- a/Hex/Features/App/AppFeature.swift
+++ b/Hex/Features/App/AppFeature.swift
@@ -33,6 +33,7 @@ struct AppFeature {
     var microphonePermission: PermissionStatus = .notDetermined
     var accessibilityPermission: PermissionStatus = .notDetermined
     var inputMonitoringPermission: PermissionStatus = .notDetermined
+    @Shared(.hotkeyPermissionState) var hotkeyPermissionState: HotkeyPermissionState
   }
 
   enum Action: BindableAction {
@@ -54,6 +55,7 @@ struct AppFeature {
   @Dependency(\.keyEventMonitor) var keyEventMonitor
   @Dependency(\.pasteboard) var pasteboard
   @Dependency(\.transcription) var transcription
+  @Dependency(\.liveTranscription) var liveTranscription
   @Dependency(\.permissions) var permissions
 
   var body: some ReducerOf<Self> {
@@ -79,6 +81,7 @@ struct AppFeature {
       case .task:
         return .merge(
           startPasteLastTranscriptMonitoring(),
+          startHotKeyCaptureMonitoring(),
           ensureSelectedModelReadiness(),
           startPermissionMonitoring()
         )
@@ -133,6 +136,12 @@ struct AppFeature {
           }
         }
 
+      case .settings(.revealAppInFinder):
+        return .run { _ in
+          guard let url = Bundle.main.bundleURL.deletingLastPathComponent().deletingLastPathComponent() as URL? else { return }
+          NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+
       case .settings:
         return .none
 
@@ -158,6 +167,11 @@ struct AppFeature {
         state.microphonePermission = mic
         state.accessibilityPermission = acc
         state.inputMonitoringPermission = input
+        state.$hotkeyPermissionState.withLock {
+          $0.accessibility = acc
+          $0.inputMonitoring = input
+          $0.lastUpdated = Date()
+        }
         return .none
 
       case .appActivated:
@@ -169,15 +183,16 @@ struct AppFeature {
       }
     }
   }
-  
+
   private func startPasteLastTranscriptMonitoring() -> Effect<Action> {
     .run { send in
+      @Shared(.isSettingHotKey) var isSettingHotKey: Bool
       @Shared(.isSettingPasteLastTranscriptHotkey) var isSettingPasteLastTranscriptHotkey: Bool
       @Shared(.hexSettings) var hexSettings: HexSettings
 
       let token = keyEventMonitor.handleKeyEvent { keyEvent in
-        // Skip if user is setting a hotkey
-        if isSettingPasteLastTranscriptHotkey {
+        // Skip while the user is configuring a hotkey in Settings.
+        if isSettingPasteLastTranscriptHotkey || isSettingHotKey {
           return false
         }
 
@@ -194,6 +209,32 @@ struct AppFeature {
           send(.pasteLastTranscript)
         }
         return true // Intercept the key event
+      }
+
+      defer { token.cancel() }
+
+      await withTaskCancellationHandler {
+        while !Task.isCancelled {
+          try? await Task.sleep(for: .seconds(60))
+        }
+      } onCancel: {
+        token.cancel()
+      }
+    }
+  }
+
+  private func startHotKeyCaptureMonitoring() -> Effect<Action> {
+    .run { send in
+      @Shared(.isSettingHotKey) var isSettingHotKey: Bool
+      @Shared(.isSettingPasteLastTranscriptHotkey) var isSettingPasteLastTranscriptHotkey: Bool
+
+      let token = keyEventMonitor.handleKeyEvent { keyEvent in
+        guard isSettingHotKey || isSettingPasteLastTranscriptHotkey else {
+          return false
+        }
+
+        Task { await send(.settings(.keyEvent(keyEvent))) }
+        return true
       }
 
       defer { token.cancel() }

--- a/Hex/Features/Settings/GeneralSectionView.swift
+++ b/Hex/Features/Settings/GeneralSectionView.swift
@@ -73,7 +73,7 @@ struct GeneralSectionView: View {
 				HStack(alignment: .center) {
 					Text("Live Preview")
 					Spacer()
-					Picker("", selection: Binding(
+					Picker("Live Preview", selection: Binding(
 						get: { store.hexSettings.livePreviewDisplayMode },
 						set: { store.send(.setLivePreviewDisplayMode($0)) }
 					)) {

--- a/Hex/Features/Settings/GeneralSectionView.swift
+++ b/Hex/Features/Settings/GeneralSectionView.swift
@@ -70,6 +70,24 @@ struct GeneralSectionView: View {
 			}
 
 			Label {
+				HStack(alignment: .center) {
+					Text("Live Preview")
+					Spacer()
+					Picker("", selection: Binding(
+						get: { store.hexSettings.livePreviewDisplayMode },
+						set: { store.send(.setLivePreviewDisplayMode($0)) }
+					)) {
+						Text("Insert at cursor").tag(LivePreviewDisplayMode.cursor)
+						Text("Overlay").tag(LivePreviewDisplayMode.overlay)
+					}
+					.pickerStyle(.menu)
+				}
+				Text("Show live transcription at the text cursor, or in Hex's floating overlay while recording. Requires a Parakeet model and Super Fast Mode.")
+			} icon: {
+				Image(systemName: "text.cursor")
+			}
+
+			Label {
 				Toggle(
 					"Super Fast Mode",
 					isOn: Binding(

--- a/Hex/Features/Settings/GeneralSectionView.swift
+++ b/Hex/Features/Settings/GeneralSectionView.swift
@@ -73,7 +73,7 @@ struct GeneralSectionView: View {
 				HStack(alignment: .center) {
 					Text("Live Preview")
 					Spacer()
-					Picker("Live Preview", selection: Binding(
+					Picker("", selection: Binding(
 						get: { store.hexSettings.livePreviewDisplayMode },
 						set: { store.send(.setLivePreviewDisplayMode($0)) }
 					)) {
@@ -81,6 +81,7 @@ struct GeneralSectionView: View {
 						Text("Overlay").tag(LivePreviewDisplayMode.overlay)
 					}
 					.pickerStyle(.menu)
+					.labelsHidden()
 				}
 				Text("Show live transcription at the text cursor, or in Hex's floating overlay while recording. Requires a Parakeet model and Super Fast Mode.")
 			} icon: {

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -199,12 +199,7 @@ struct SettingsFeature {
     }
 
     if target == .recording, !updatedModifiers.isEmpty {
-      // Confirm modifier-only hotkeys with Return or after all modifiers are released.
-      if keyEvent.key == .return {
-        applyCapturedHotKey(key: nil, modifiers: updatedModifiers, for: target, state: &state)
-        endCapture(target, state: &state)
-        return .none
-      }
+      // Confirm modifier-only hotkeys after all modifiers are released.
       if keyEvent.key == nil, keyEvent.modifiers.isEmpty {
         applyCapturedHotKey(key: nil, modifiers: updatedModifiers, for: target, state: &state)
         endCapture(target, state: &state)

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -77,6 +77,7 @@ struct SettingsFeature {
     case toggleSuperFastMode(Bool)
     case setUseClipboardPaste(Bool)
     case setCopyToClipboard(Bool)
+    case setLivePreviewDisplayMode(LivePreviewDisplayMode)
     case setDoubleTapLockEnabled(Bool)
     case setUseDoubleTapOnly(Bool)
     case setMinimumKeyTime(Double)
@@ -89,6 +90,7 @@ struct SettingsFeature {
     case requestMicrophone
     case requestAccessibility
     case requestInputMonitoring
+    case revealAppInFinder
 
     // Microphone selection
     case loadAvailableInputDevices
@@ -115,8 +117,7 @@ struct SettingsFeature {
     case setRemappingScratchpadFocused(Bool)
   }
 
-  @Dependency(\.keyEventMonitor) var keyEventMonitor
-  @Dependency(\.transcription) var transcription
+
   @Dependency(\.recording) var recording
   @Dependency(\.soundEffects) var soundEffects
   @Dependency(\.transcriptPersistence) var transcriptPersistence
@@ -197,15 +198,24 @@ struct SettingsFeature {
       return .none
     }
 
+    if target == .recording, !updatedModifiers.isEmpty {
+      // Confirm modifier-only hotkeys with Return or after all modifiers are released.
+      if keyEvent.key == .return {
+        applyCapturedHotKey(key: nil, modifiers: updatedModifiers, for: target, state: &state)
+        endCapture(target, state: &state)
+        return .none
+      }
+      if keyEvent.key == nil, keyEvent.modifiers.isEmpty {
+        applyCapturedHotKey(key: nil, modifiers: updatedModifiers, for: target, state: &state)
+        endCapture(target, state: &state)
+        return .none
+      }
+    }
+
     if let key = keyEvent.key {
       applyCapturedHotKey(key: key, modifiers: updatedModifiers, for: target, state: &state)
       endCapture(target, state: &state)
       return .none
-    }
-
-    if target == .recording, keyEvent.modifiers.isEmpty {
-      applyCapturedHotKey(key: nil, modifiers: updatedModifiers, for: target, state: &state)
-      endCapture(target, state: &state)
     }
 
     return .none
@@ -327,7 +337,6 @@ struct SettingsFeature {
           installAudioHardwareObserver(kAudioHardwarePropertyDefaultInputDevice)
           installAudioHardwareObserver(kAudioHardwarePropertyDevices)
 
-          // Be sure to clean up resources when the task is finished
           defer {
             deviceUpdateTask?.cancel()
             NotificationCenter.default.removeObserver(deviceConnectionObserver)
@@ -349,13 +358,20 @@ struct SettingsFeature {
             }
           }
 
-          for try await keyEvent in await keyEventMonitor.listenForKeyPress() {
-            await send(.keyEvent(keyEvent))
+          while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(60))
           }
-          
         }
 
       case .startSettingHotKey:
+        if state.hotkeyPermissionState.accessibility != .granted
+          || state.hotkeyPermissionState.inputMonitoring != .granted
+        {
+          return .merge(
+            .send(.requestAccessibility),
+            .send(.requestInputMonitoring)
+          )
+        }
         beginCapture(.recording, state: &state)
         return .none
 
@@ -447,6 +463,10 @@ struct SettingsFeature {
         state.$hexSettings.withLock { $0.copyToClipboard = enabled }
         return .none
 
+      case let .setLivePreviewDisplayMode(mode):
+        state.$hexSettings.withLock { $0.livePreviewDisplayMode = mode }
+        return .none
+
       case let .setRecordingAudioBehavior(behavior):
         state.$hexSettings.withLock { $0.recordingAudioBehavior = behavior }
         return .none
@@ -507,6 +527,10 @@ struct SettingsFeature {
 
       case .requestInputMonitoring:
         settingsLogger.info("User requested input monitoring permission from settings")
+        return .none
+
+      case .revealAppInFinder:
+        settingsLogger.info("User requested reveal app in Finder")
         return .none
 
       // Model Management

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -547,8 +547,8 @@ private extension TranscriptionFeature {
       guard !inFlightTranscribe else { continue }
       guard !keystrokeBusy else { continue }
 
-      let speechMetrics = await recording.recordingSpeechMetrics()
-      guard SpeechActivityGate.hasSpeechActivity(speechMetrics) else {
+      let snapshotMetrics = await recording.previewSpeechMetrics()
+      guard SpeechActivityGate.hasSpeechActivity(snapshotMetrics) else {
         try? await Task.sleep(for: .milliseconds(200))
         continue
       }
@@ -588,9 +588,9 @@ private extension TranscriptionFeature {
       let nowDuration = await recording.previewRecordingDuration()
       guard let text, !text.isEmpty else { continue }
 
-      guard SilentTranscriptionFilter.shouldAcceptTranscription(text: text, metrics: speechMetrics) else {
+      guard SilentTranscriptionFilter.shouldAcceptTranscription(text: text, metrics: snapshotMetrics) else {
         transcriptionFeatureLogger.debug(
-          "Rejected live preview — likely silent-audio hallucination chars=\(text.count)"
+          "Rejected live preview — likely silent-audio hallucination chars=\(text.count) peakRMS=\(String(format: "%.4f", snapshotMetrics.peakRMS)) peakSample=\(String(format: "%.4f", snapshotMetrics.peakSample))"
         )
         continue
       }

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -430,7 +430,7 @@ private extension TranscriptionFeature {
 
         // Let the cancelled preview loop finish any in-flight Parakeet work before final pass.
         await transcription.waitForParakeetIdle()
-        try? await transcription.resetParakeetTranscriberState()
+        try? await transcription.reinitializeParakeetTranscriber()
 
         var audioURL: URL?
         defer {
@@ -455,10 +455,17 @@ private extension TranscriptionFeature {
             "Final Parakeet transcribing capture file file=\(capturedURL.lastPathComponent)"
           )
           result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }
-          if result.isEmpty, !liveTranscriptSnapshot.isEmpty {
+          if result.isEmpty {
+            transcriptionFeatureLogger.notice(
+              "Final Parakeet returned empty; reinitializing and retrying file=\(capturedURL.lastPathComponent)"
+            )
+            try? await transcription.reinitializeParakeetTranscriber()
+            result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }
+          }
+          if result.isEmpty, !liveTranscriptSnapshot.isEmpty, duration < 1.5 {
             result = liveTranscriptSnapshot
             transcriptionFeatureLogger.notice(
-              "Using live preview transcript as final fallback chars=\(result.count)"
+              "Using live preview transcript as final fallback chars=\(result.count) duration=\(String(format: "%.2f", duration))s"
             )
           }
 
@@ -562,10 +569,12 @@ private extension TranscriptionFeature {
 
       guard !Task.isCancelled else { break }
 
+      // Always advance the scheduler after a completed preview pass, even when Parakeet
+      // returns empty — otherwise we re-transcribe every poll and overload audio + ASR.
+      transcribeScheduler.markTranscribed(duration: capturedDuration)
+
       let nowDuration = await recording.previewRecordingDuration()
       guard let text, !text.isEmpty else { continue }
-
-      transcribeScheduler.markTranscribed(duration: capturedDuration)
 
       if transcribeScheduler.shouldApplyResult(
         resultDuration: capturedDuration,

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -15,6 +15,13 @@ import WhisperKit
 
 private let transcriptionFeatureLogger = HexLog.transcription
 
+extension SharedReaderKey where Self == InMemoryKey<Bool>.Default {
+  /// Mirrors `TranscriptionFeature.State.isTranscribing` for hotkey monitor access.
+  static var isTranscriptionBusy: Self {
+    Self[.inMemory("isTranscriptionBusy"), default: false]
+  }
+}
+
 @Reducer
 struct TranscriptionFeature {
   @ObservableState
@@ -25,17 +32,25 @@ struct TranscriptionFeature {
     var error: String?
     var recordingStartTime: Date?
     var meter: Meter = .init(averagePower: 0, peakPower: 0)
+    var liveTranscript: String = ""
     var sourceAppBundleID: String?
     var sourceAppName: String?
     @Shared(.hexSettings) var hexSettings: HexSettings
     @Shared(.isRemappingScratchpadFocused) var isRemappingScratchpadFocused: Bool = false
+    @Shared(.isTranscriptionBusy) var isTranscriptionBusy: Bool = false
     @Shared(.modelBootstrapState) var modelBootstrapState: ModelBootstrapState
     @Shared(.transcriptionHistory) var transcriptionHistory: TranscriptionHistory
+
+    mutating func setTranscribing(_ value: Bool) {
+      isTranscribing = value
+      $isTranscriptionBusy.withLock { $0 = value }
+    }
   }
 
   enum Action {
     case task
     case audioLevelUpdated(Meter)
+    case liveTranscriptUpdated(String)
 
     // Hotkey actions
     case hotKeyPressed
@@ -62,9 +77,12 @@ struct TranscriptionFeature {
     case recordingStart
     case recordingCleanup
     case transcription
+    case liveTranscription
   }
 
   @Dependency(\.transcription) var transcription
+  @Dependency(\.liveTranscription) var liveTranscription
+  @Dependency(\.liveTextInsertion) var liveTextInsertion
   @Dependency(\.recording) var recording
   @Dependency(\.pasteboard) var pasteboard
   @Dependency(\.keyEventMonitor) var keyEventMonitor
@@ -83,10 +101,12 @@ struct TranscriptionFeature {
         // 1) Observing audio meter
         // 2) Monitoring hot key events
         // 3) Priming the recorder for instant startup
+        // 4) Preloading live transcription models when Parakeet is selected
         return .merge(
           startMeteringEffect(),
           startHotKeyMonitoringEffect(),
-          warmUpRecorderEffect()
+          warmUpRecorderEffect(),
+          warmUpLiveTranscriptionEffect()
         )
 
       // MARK: - Metering
@@ -95,11 +115,14 @@ struct TranscriptionFeature {
         state.meter = meter
         return .none
 
+      case let .liveTranscriptUpdated(text):
+        state.liveTranscript = text
+        return .none
+
       // MARK: - HotKey Flow
 
       case .hotKeyPressed:
-        // If we're transcribing, send a cancel first. Otherwise start recording immediately.
-        // We'll decide later (on release) whether to keep or discard the recording.
+        // Ignore presses while a prior recording is still being transcribed.
         return handleHotKeyPressed(isTranscribing: state.isTranscribing)
 
       case .hotKeyReleased:
@@ -159,12 +182,24 @@ private extension TranscriptionFeature {
     .cancellable(id: CancelID.metering, cancelInFlight: true)
   }
 
+  /// Preloads Parakeet models so live preview and final transcription start quickly.
+  func warmUpLiveTranscriptionEffect() -> Effect<Action> {
+    .run { _ in
+      @Shared(.hexSettings) var hexSettings: HexSettings
+      let model = hexSettings.selectedModel
+      guard ParakeetModel(rawValue: model) != nil else { return }
+      // Snapshot live preview and final transcription share the batch Parakeet client.
+      try? await transcription.downloadModel(model) { _ in }
+    }
+  }
+
   /// Effect to start monitoring hotkey events through the `keyEventMonitor`.
   func startHotKeyMonitoringEffect() -> Effect<Action> {
     .run { send in
-      var hotKeyProcessor: HotKeyProcessor = .init(hotkey: HotKey(key: nil, modifiers: [.option]))
       @Shared(.isSettingHotKey) var isSettingHotKey: Bool
+      @Shared(.isTranscriptionBusy) var isTranscriptionBusy: Bool
       @Shared(.hexSettings) var hexSettings: HexSettings
+      var hotKeyProcessor: HotKeyProcessor = .init(hotkey: hexSettings.hotkey)
 
       // Handle incoming input events (keyboard and mouse)
       let token = keyEventMonitor.handleInputEvent { inputEvent in
@@ -180,6 +215,11 @@ private extension TranscriptionFeature {
         hotKeyProcessor.useDoubleTapOnly = useDoubleTapOnly
         hotKeyProcessor.minimumKeyTime = hexSettings.minimumKeyTime
 
+        // Skip hotkey state while Hex is injecting live preview keystrokes.
+        if liveTextInsertion.isKeystrokeUpdateInFlight() {
+          return false
+        }
+
         switch inputEvent {
         case .keyboard(let keyEvent):
           // If Escape is pressed with no modifiers while idle, let's treat that as `cancel`.
@@ -193,11 +233,18 @@ private extension TranscriptionFeature {
           // Process the key event
           switch hotKeyProcessor.process(keyEvent: keyEvent) {
           case .startRecording:
-            // If double-tap lock is triggered, we start recording immediately
-            if hotKeyProcessor.state == .doubleTapLock {
-              Task { await send(.startRecording) }
-            } else {
-              Task { await send(.hotKeyPressed) }
+            guard !isTranscriptionBusy else { return false }
+            let isDoubleTapLock = hotKeyProcessor.state == .doubleTapLock
+            Task {
+              await recording.prewarmCapture()
+              if hexSettings.livePreviewDisplayMode == .cursor {
+                _ = liveTextInsertion.prepareNow()
+              }
+              if isDoubleTapLock {
+                await send(.startRecording)
+              } else {
+                await send(.hotKeyPressed)
+              }
             }
             // If the hotkey is purely modifiers, return false to keep it from interfering with normal usage
             // But if useDoubleTapOnly is true, always intercept the key
@@ -264,12 +311,8 @@ private extension TranscriptionFeature {
 
 private extension TranscriptionFeature {
   func handleHotKeyPressed(isTranscribing: Bool) -> Effect<Action> {
-    // If already transcribing, cancel first. Otherwise start recording immediately.
-    guard isTranscribing else { return .send(.startRecording) }
-    return .concatenate(
-      .send(.cancel),
-      .send(.startRecording)
-    )
+    guard !isTranscribing else { return .none }
+    return .send(.startRecording)
   }
 
   func handleHotKeyReleased(isRecording: Bool) -> Effect<Action> {
@@ -282,6 +325,7 @@ private extension TranscriptionFeature {
 
 private extension TranscriptionFeature {
   func handleStartRecording(_ state: inout State) -> Effect<Action> {
+    guard !state.isRecording, !state.isTranscribing else { return .none }
     guard state.modelBootstrapState.isModelReady else {
       return .merge(
         .send(.modelMissing),
@@ -289,6 +333,7 @@ private extension TranscriptionFeature {
       )
     }
     state.isRecording = true
+    state.liveTranscript = ""
     let startTime = now
     state.recordingStartTime = startTime
     
@@ -300,12 +345,11 @@ private extension TranscriptionFeature {
     transcriptionFeatureLogger.notice("Recording started at \(startTime.ISO8601Format())")
 
     // Prevent system sleep during recording
+    let model = state.hexSettings.selectedModel
+    let useLiveTranscription = ParakeetModel(rawValue: model) != nil
     return .merge(
       .cancel(id: CancelID.recordingCleanup),
-      .run { [sleepManagement, preventSleep = state.hexSettings.preventSystemSleep] _ in
-        // Play sound immediately for instant feedback
-        soundEffect.play(.startRecording)
-
+      .run { [sleepManagement, preventSleep = state.hexSettings.preventSystemSleep] send in
         if preventSleep {
           await sleepManagement.preventSleep(reason: "Hex Voice Recording")
         }
@@ -315,7 +359,20 @@ private extension TranscriptionFeature {
           }
           return
         }
-        await recording.startRecording()
+
+        await withTaskGroup(of: Void.self) { group in
+          group.addTask {
+            await recording.startRecording(requiresLiveAudio: false)
+          }
+
+          if useLiveTranscription {
+            group.addTask {
+              await runSnapshotLivePreview(model: model, send: send)
+            }
+          }
+        }
+
+        soundEffect.play(.startRecording)
       }
       .cancellable(id: CancelID.recordingStart, cancelInFlight: true)
     )
@@ -353,21 +410,38 @@ private extension TranscriptionFeature {
     }
 
     // Otherwise, proceed to transcription
-    state.isTranscribing = true
+    state.setTranscribing(true)
     state.error = nil
     let model = state.hexSettings.selectedModel
     let language = state.hexSettings.outputLanguage
+    let useLiveTranscription = ParakeetModel(rawValue: model) != nil
 
-    state.isPrewarming = true
+    state.isPrewarming = !useLiveTranscription
+    let liveTranscriptSnapshot = state.liveTranscript
 
-    return .merge(
+    return .concatenate(
       .cancel(id: CancelID.recordingStart),
-      .run { [sleepManagement] send in
+      .run { [sleepManagement, useLiveTranscription, liveTranscriptSnapshot] send in
+        await recording.setLiveAudioConsumer(nil)
+        await liveTranscription.cancel()
+
         // Allow system to sleep again
         await sleepManagement.allowSleep()
 
+        // Let the cancelled preview loop finish any in-flight Parakeet work before final pass.
+        await transcription.waitForParakeetIdle()
+        try? await transcription.resetParakeetTranscriberState()
+
+        var previewSnapshotURL: URL?
+        if useLiveTranscription {
+          previewSnapshotURL = await recording.snapshotRecordingForPreview()
+        }
+
         var audioURL: URL?
         defer {
+          if let previewSnapshotURL {
+            FileManager.default.removeItemIfExists(at: previewSnapshotURL)
+          }
           if let audioURL {
             FileManager.default.removeItemIfExists(at: audioURL)
           }
@@ -378,17 +452,35 @@ private extension TranscriptionFeature {
           guard !Task.isCancelled else { return }
           soundEffect.play(.stopRecording)
 
-          // Create transcription options with the selected language
-          // Note: cap concurrency to avoid audio I/O overloads on some Macs
           let decodeOptions = DecodingOptions(
             language: language,
-            detectLanguage: language == nil, // Only auto-detect if no language specified
+            detectLanguage: language == nil,
             chunkingStrategy: .vad,
           )
 
-          let result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }
+          var result = ""
+          if useLiveTranscription, let previewSnapshotURL {
+            transcriptionFeatureLogger.notice(
+              "Final Parakeet transcribing preview snapshot file=\(previewSnapshotURL.lastPathComponent)"
+            )
+            result = try await transcription.transcribe(previewSnapshotURL, model, decodeOptions) { _ in }
+          }
+          if result.isEmpty {
+            transcriptionFeatureLogger.notice(
+              "Final Parakeet transcribing capture file file=\(capturedURL.lastPathComponent)"
+            )
+            result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }
+          }
+          if result.isEmpty, !liveTranscriptSnapshot.isEmpty {
+            result = liveTranscriptSnapshot
+            transcriptionFeatureLogger.notice(
+              "Using live preview transcript as final fallback chars=\(result.count)"
+            )
+          }
 
-          transcriptionFeatureLogger.notice("Transcribed audio from \(capturedURL.lastPathComponent) to text length \(result.count)")
+          transcriptionFeatureLogger.notice(
+            "Transcribed audio from \(capturedURL.lastPathComponent) to text length \(result.count)"
+          )
           audioURL = nil
           await send(.transcriptionResult(result, capturedURL, duration))
         } catch {
@@ -396,8 +488,151 @@ private extension TranscriptionFeature {
           await send(.transcriptionError(error, nil))
         }
       }
-      .cancellable(id: CancelID.transcription)
+      .cancellable(id: CancelID.transcription),
     )
+  }
+
+  /// Feeds capture-engine audio into FluidAudio streaming ASR (~350ms chunks).
+  /// Reserved for future use; live preview currently uses batch snapshots for accuracy.
+  func runStreamingLivePreview(model: String, send: Send<Action>) async {
+    @Shared(.hexSettings) var hexSettings: HexSettings
+    let insertAtCursor = hexSettings.livePreviewDisplayMode == .cursor
+    do {
+      try await liveTranscription.start(model)
+      transcriptionFeatureLogger.notice("Streaming live preview started model=\(model)")
+
+      await recording.setLiveAudioConsumer { buffer in
+        await liveTranscription.feedAudio(buffer)
+      }
+
+      var previewGate = LivePreviewUpdateGate()
+      for await update in await liveTranscription.observeUpdates() {
+        guard !Task.isCancelled else { break }
+        let text = update.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        await applyLivePreviewText(
+          text,
+          insertAtCursor: insertAtCursor,
+          previewGate: &previewGate,
+          send: send
+        )
+      }
+    } catch {
+      transcriptionFeatureLogger.error(
+        "Streaming live preview failed: \(error.localizedDescription)"
+      )
+    }
+    await recording.setLiveAudioConsumer(nil)
+  }
+
+  /// Batch Parakeet on growing in-memory WAV snapshots (reliable live cursor updates).
+  func runSnapshotLivePreview(model: String, send: Send<Action>) async {
+    @Shared(.hexSettings) var hexSettings: HexSettings
+    let insertAtCursor = hexSettings.livePreviewDisplayMode == .cursor
+    var previewGate = LivePreviewUpdateGate()
+    var transcribeScheduler = LivePreviewTranscriptionScheduler()
+    var pollCount = 0
+    var inFlightTranscribe = false
+
+    while !Task.isCancelled {
+      let pollDelayMs = previewGate.lastApplied.isEmpty ? 60 : (insertAtCursor ? 180 : 220)
+      if pollCount > 0 {
+        try? await Task.sleep(for: .milliseconds(pollDelayMs))
+      }
+      pollCount += 1
+
+      guard !Task.isCancelled else { break }
+      guard !inFlightTranscribe else { continue }
+
+      let currentDuration = await recording.previewRecordingDuration()
+      guard transcribeScheduler.shouldScheduleTranscribe(
+        snapshotDuration: currentDuration,
+        hasInFlightTranscribe: inFlightTranscribe
+      ) else { continue }
+
+      guard !Task.isCancelled else { break }
+
+      guard let snapshotURL = await recording.snapshotRecordingForPreview() else { continue }
+      defer { try? FileManager.default.removeItem(at: snapshotURL) }
+
+      let capturedDuration = currentDuration
+      inFlightTranscribe = true
+      defer { inFlightTranscribe = false }
+
+      let text: String?
+      do {
+        let rawText = try await transcription.transcribePreview(snapshotURL, model)
+        text = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+      } catch is CancellationError {
+        break
+      } catch {
+        if Task.isCancelled { break }
+        text = nil
+      }
+
+      guard !Task.isCancelled else { break }
+
+      let nowDuration = await recording.previewRecordingDuration()
+      guard let text, !text.isEmpty else { continue }
+
+      transcribeScheduler.markTranscribed(duration: capturedDuration)
+
+      if transcribeScheduler.shouldApplyResult(
+        resultDuration: capturedDuration,
+        currentDuration: nowDuration
+      ) {
+        await applyLivePreviewText(
+          text,
+          insertAtCursor: insertAtCursor,
+          previewGate: &previewGate,
+          send: send
+        )
+      } else {
+        transcribeScheduler.noteSkippedStaleResult(at: capturedDuration)
+        transcriptionFeatureLogger.debug(
+          "Discarded stale live preview transcribe result captured=\(String(format: "%.3f", capturedDuration))s current=\(String(format: "%.3f", nowDuration))s"
+        )
+      }
+    }
+  }
+
+  func applyLivePreviewUpdate(_ text: String, send: Send<Action>) async -> Bool {
+    @Shared(.hexSettings) var hexSettings: HexSettings
+    let insertAtCursor = hexSettings.livePreviewDisplayMode == .cursor
+    guard !text.isEmpty else { return false }
+
+    if insertAtCursor {
+      guard await liveTextInsertion.update(text) else {
+        transcriptionFeatureLogger.debug("Live preview apply failed chars=\(text.count)")
+        return false
+      }
+      transcriptionFeatureLogger.notice("Live preview applied chars=\(text.count)")
+    } else {
+      transcriptionFeatureLogger.notice("Live preview overlay updated chars=\(text.count)")
+    }
+    await send(.liveTranscriptUpdated(text))
+    return true
+  }
+
+  func applyLivePreviewText(
+    _ text: String,
+    insertAtCursor: Bool,
+    previewGate: inout LivePreviewUpdateGate,
+    send: Send<Action>
+  ) async {
+    guard previewGate.shouldApply(next: text) else { return }
+
+    if insertAtCursor {
+      guard await liveTextInsertion.update(text) else {
+        transcriptionFeatureLogger.debug("Live preview apply failed chars=\(text.count)")
+        return
+      }
+      transcriptionFeatureLogger.notice("Live preview applied chars=\(text.count)")
+    } else {
+      transcriptionFeatureLogger.notice("Live preview overlay updated chars=\(text.count)")
+    }
+
+    previewGate.markApplied(text)
+    await send(.liveTranscriptUpdated(text))
   }
 }
 
@@ -410,8 +645,9 @@ private extension TranscriptionFeature {
     audioURL: URL,
     duration: TimeInterval
   ) -> Effect<Action> {
-    state.isTranscribing = false
+    state.setTranscribing(false)
     state.isPrewarming = false
+    state.liveTranscript = ""
 
     // Check for force quit command (emergency escape hatch)
     if ForceQuitCommandDetector.matches(result) {
@@ -424,9 +660,10 @@ private extension TranscriptionFeature {
       }
     }
 
-    // If empty text, nothing else to do
+    // If empty text, revert any live preview that was inserted at the cursor.
     guard !result.isEmpty else {
       return .run { _ in
+        await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
         FileManager.default.removeItemIfExists(at: audioURL)
       }
     }
@@ -458,6 +695,7 @@ private extension TranscriptionFeature {
 
     guard !modifiedResult.isEmpty else {
       return .run { _ in
+        await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
         FileManager.default.removeItemIfExists(at: audioURL)
       }
     }
@@ -474,7 +712,10 @@ private extension TranscriptionFeature {
           sourceAppBundleID: sourceAppBundleID,
           sourceAppName: sourceAppName,
           audioURL: audioURL,
-          transcriptionHistory: transcriptionHistory
+          transcriptionHistory: transcriptionHistory,
+          liveTextInsertion: liveTextInsertion,
+          pasteboard: pasteboard,
+          soundEffect: soundEffect
         )
       } catch {
         await send(.transcriptionError(error, audioURL))
@@ -488,15 +729,23 @@ private extension TranscriptionFeature {
     error: Error,
     audioURL: URL?
   ) -> Effect<Action> {
-    state.isTranscribing = false
+    state.setTranscribing(false)
     state.isPrewarming = false
+    state.liveTranscript = ""
     state.error = error.localizedDescription
     
     if let audioURL {
       FileManager.default.removeItemIfExists(at: audioURL)
     }
 
-    return .none
+    return .run { _ in
+      await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
+    }
+  }
+
+  static func revertLivePreviewIfNeeded(liveTextInsertion: LiveTextInsertionClient) async {
+    guard await liveTextInsertion.isActive() else { return }
+    await liveTextInsertion.revert()
   }
 
   /// Move file to permanent location, create a transcript record, paste text, and play sound.
@@ -506,7 +755,10 @@ private extension TranscriptionFeature {
     sourceAppBundleID: String?,
     sourceAppName: String?,
     audioURL: URL,
-    transcriptionHistory: Shared<TranscriptionHistory>
+    transcriptionHistory: Shared<TranscriptionHistory>,
+    liveTextInsertion: LiveTextInsertionClient,
+    pasteboard: PasteboardClient,
+    soundEffect: SoundEffectsClient
   ) async throws {
     @Shared(.hexSettings) var hexSettings: HexSettings
 
@@ -536,8 +788,18 @@ private extension TranscriptionFeature {
       FileManager.default.removeItemIfExists(at: audioURL)
     }
 
-    await pasteboard.paste(result)
-    soundEffect.play(.pasteTranscript)
+    if await liveTextInsertion.isActive() {
+      if await liveTextInsertion.finalize(result) {
+        soundEffect.play(.pasteTranscript)
+      } else {
+        await liveTextInsertion.revert()
+        await pasteboard.paste(result)
+        soundEffect.play(.pasteTranscript)
+      }
+    } else {
+      await pasteboard.paste(result)
+      soundEffect.play(.pasteTranscript)
+    }
   }
 }
 
@@ -546,14 +808,18 @@ private extension TranscriptionFeature {
 private extension TranscriptionFeature {
   func handleCancel(_ state: inout State) -> Effect<Action> {
     let wasRecording = state.isRecording
-    state.isTranscribing = false
+    state.setTranscribing(false)
     state.isRecording = false
     state.isPrewarming = false
+    state.liveTranscript = ""
 
     return .merge(
       .cancel(id: CancelID.transcription),
+      .cancel(id: CancelID.liveTranscription),
       .cancel(id: CancelID.recordingStart),
       .run { [sleepManagement] _ in
+        await liveTranscription.cancel()
+        await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
         // Allow system to sleep again
         await sleepManagement.allowSleep()
         guard wasRecording else {
@@ -573,11 +839,15 @@ private extension TranscriptionFeature {
   func handleDiscard(_ state: inout State) -> Effect<Action> {
     state.isRecording = false
     state.isPrewarming = false
+    state.liveTranscript = ""
 
     // Silently discard - no sound effect
     return .merge(
+      .cancel(id: CancelID.liveTranscription),
       .cancel(id: CancelID.recordingStart),
       .run { [sleepManagement] _ in
+        await liveTranscription.cancel()
+        await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
         // Allow system to sleep again
         await sleepManagement.allowSleep()
         let url = await recording.stopRecording()
@@ -593,6 +863,7 @@ private extension TranscriptionFeature {
 
 struct TranscriptionView: View {
   @Bindable var store: StoreOf<TranscriptionFeature>
+  @Shared(.hexSettings) var hexSettings: HexSettings
   @ObserveInjection var inject
 
   var status: TranscriptionIndicatorView.Status {
@@ -610,7 +881,9 @@ struct TranscriptionView: View {
   var body: some View {
     TranscriptionIndicatorView(
       status: status,
-      meter: store.meter
+      meter: store.meter,
+      liveTranscript: store.liveTranscript,
+      livePreviewDisplayMode: hexSettings.livePreviewDisplayMode
     )
     .task {
       await store.send(.task).finish()

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -65,7 +65,7 @@ struct TranscriptionFeature {
     case discard  // Silent discard (too short/accidental)
 
     // Transcription result flow
-    case transcriptionResult(String, URL, TimeInterval)
+    case transcriptionResult(String, URL, TimeInterval, SpeechActivityMetrics)
     case transcriptionError(Error, URL?)
 
     // Model availability
@@ -140,8 +140,14 @@ struct TranscriptionFeature {
 
       // MARK: - Transcription Results
 
-      case let .transcriptionResult(result, audioURL, duration):
-        return handleTranscriptionResult(&state, result: result, audioURL: audioURL, duration: duration)
+      case let .transcriptionResult(result, audioURL, duration, speechMetrics):
+        return handleTranscriptionResult(
+          &state,
+          result: result,
+          audioURL: audioURL,
+          duration: duration,
+          speechMetrics: speechMetrics
+        )
 
       case let .transcriptionError(error, audioURL):
         return handleTranscriptionError(&state, error: error, audioURL: audioURL)
@@ -541,6 +547,12 @@ private extension TranscriptionFeature {
       guard !inFlightTranscribe else { continue }
       guard !keystrokeBusy else { continue }
 
+      let speechMetrics = await recording.recordingSpeechMetrics()
+      guard SpeechActivityGate.hasSpeechActivity(speechMetrics) else {
+        try? await Task.sleep(for: .milliseconds(200))
+        continue
+      }
+
       let currentDuration = await recording.previewRecordingDuration()
       guard transcribeScheduler.shouldScheduleTranscribe(
         snapshotDuration: currentDuration,
@@ -575,6 +587,13 @@ private extension TranscriptionFeature {
 
       let nowDuration = await recording.previewRecordingDuration()
       guard let text, !text.isEmpty else { continue }
+
+      guard SilentTranscriptionFilter.shouldAcceptTranscription(text: text, metrics: speechMetrics) else {
+        transcriptionFeatureLogger.debug(
+          "Rejected live preview — likely silent-audio hallucination chars=\(text.count)"
+        )
+        continue
+      }
 
       if transcribeScheduler.shouldApplyResult(
         resultDuration: capturedDuration,
@@ -643,7 +662,8 @@ private extension TranscriptionFeature {
     _ state: inout State,
     result: String,
     audioURL: URL,
-    duration: TimeInterval
+    duration: TimeInterval,
+    speechMetrics _: SpeechActivityMetrics
   ) -> Effect<Action> {
     state.setTranscribing(false)
     state.isPrewarming = false

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -362,7 +362,7 @@ private extension TranscriptionFeature {
 
         await withTaskGroup(of: Void.self) { group in
           group.addTask {
-            await recording.startRecording(requiresLiveAudio: false)
+            await recording.startRecording(requiresLiveAudio: useLiveTranscription)
           }
 
           if useLiveTranscription {
@@ -432,16 +432,8 @@ private extension TranscriptionFeature {
         await transcription.waitForParakeetIdle()
         try? await transcription.resetParakeetTranscriberState()
 
-        var previewSnapshotURL: URL?
-        if useLiveTranscription {
-          previewSnapshotURL = await recording.snapshotRecordingForPreview()
-        }
-
         var audioURL: URL?
         defer {
-          if let previewSnapshotURL {
-            FileManager.default.removeItemIfExists(at: previewSnapshotURL)
-          }
           if let audioURL {
             FileManager.default.removeItemIfExists(at: audioURL)
           }
@@ -459,18 +451,10 @@ private extension TranscriptionFeature {
           )
 
           var result = ""
-          if useLiveTranscription, let previewSnapshotURL {
-            transcriptionFeatureLogger.notice(
-              "Final Parakeet transcribing preview snapshot file=\(previewSnapshotURL.lastPathComponent)"
-            )
-            result = try await transcription.transcribe(previewSnapshotURL, model, decodeOptions) { _ in }
-          }
-          if result.isEmpty {
-            transcriptionFeatureLogger.notice(
-              "Final Parakeet transcribing capture file file=\(capturedURL.lastPathComponent)"
-            )
-            result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }
-          }
+          transcriptionFeatureLogger.notice(
+            "Final Parakeet transcribing capture file file=\(capturedURL.lastPathComponent)"
+          )
+          result = try await transcription.transcribe(capturedURL, model, decodeOptions) { _ in }
           if result.isEmpty, !liveTranscriptSnapshot.isEmpty {
             result = liveTranscriptSnapshot
             transcriptionFeatureLogger.notice(
@@ -534,7 +518,13 @@ private extension TranscriptionFeature {
     var inFlightTranscribe = false
 
     while !Task.isCancelled {
-      let pollDelayMs = previewGate.lastApplied.isEmpty ? 60 : (insertAtCursor ? 180 : 220)
+      let keystrokeBusy = liveTextInsertion.isKeystrokeUpdateInFlight()
+      let pollDelayMs: Int = {
+        if previewGate.lastApplied.isEmpty { return 60 }
+        if keystrokeBusy { return 300 }
+        if insertAtCursor { return 220 }
+        return 240
+      }()
       if pollCount > 0 {
         try? await Task.sleep(for: .milliseconds(pollDelayMs))
       }
@@ -542,6 +532,7 @@ private extension TranscriptionFeature {
 
       guard !Task.isCancelled else { break }
       guard !inFlightTranscribe else { continue }
+      guard !keystrokeBusy else { continue }
 
       let currentDuration = await recording.previewRecordingDuration()
       guard transcribeScheduler.shouldScheduleTranscribe(

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -70,6 +70,9 @@ struct TranscriptionFeature {
 
     // Model availability
     case modelMissing
+
+    /// Transcription + paste/finalize pipeline finished; safe to start another recording.
+    case transcriptionPostProcessingDidFinish
   }
 
   enum CancelID {
@@ -155,6 +158,12 @@ struct TranscriptionFeature {
       case .modelMissing:
         return .none
 
+      case .transcriptionPostProcessingDidFinish:
+        state.setTranscribing(false)
+        return .run { _ in
+          await recording.resumeMediaIfNeeded()
+        }
+
       // MARK: - Cancel/Discard Flow
 
       case .cancel:
@@ -205,21 +214,19 @@ private extension TranscriptionFeature {
       @Shared(.isSettingHotKey) var isSettingHotKey: Bool
       @Shared(.isTranscriptionBusy) var isTranscriptionBusy: Bool
       @Shared(.hexSettings) var hexSettings: HexSettings
-      var hotKeyProcessor: HotKeyProcessor = .init(hotkey: hexSettings.hotkey)
+      let initialSettings = $hexSettings.withLock { $0 }
+      let monitorState = HotKeyMonitorState(hotkey: initialSettings.hotkey)
 
       // Handle incoming input events (keyboard and mouse)
       let token = keyEventMonitor.handleInputEvent { inputEvent in
         // Skip if the user is currently setting a hotkey
-        if isSettingHotKey {
+        if $isSettingHotKey.withLock({ $0 }) {
           return false
         }
 
-        // Always keep hotKeyProcessor in sync with current user hotkey preference
-        hotKeyProcessor.hotkey = hexSettings.hotkey
-        let useDoubleTapOnly = hexSettings.doubleTapLockEnabled && hexSettings.useDoubleTapOnly
-        hotKeyProcessor.doubleTapLockEnabled = hexSettings.doubleTapLockEnabled
-        hotKeyProcessor.useDoubleTapOnly = useDoubleTapOnly
-        hotKeyProcessor.minimumKeyTime = hexSettings.minimumKeyTime
+        let settings = $hexSettings.withLock { $0 }
+        monitorState.syncSettings(from: settings)
+        let useDoubleTapOnly = settings.doubleTapLockEnabled && settings.useDoubleTapOnly
 
         // Skip hotkey state while Hex is injecting live preview keystrokes.
         if liveTextInsertion.isKeystrokeUpdateInFlight() {
@@ -230,20 +237,21 @@ private extension TranscriptionFeature {
         case .keyboard(let keyEvent):
           // If Escape is pressed with no modifiers while idle, let's treat that as `cancel`.
           if keyEvent.key == .escape, keyEvent.modifiers.isEmpty,
-             hotKeyProcessor.state == .idle
+             monitorState.state == .idle
           {
             Task { await send(.cancel) }
             return false
           }
 
           // Process the key event
-          switch hotKeyProcessor.process(keyEvent: keyEvent) {
+          switch monitorState.process(keyEvent: keyEvent) {
           case .startRecording:
-            guard !isTranscriptionBusy else { return false }
-            let isDoubleTapLock = hotKeyProcessor.state == .doubleTapLock
+            guard !$isTranscriptionBusy.withLock({ $0 }) else { return false }
+            let isDoubleTapLock = monitorState.state == .doubleTapLock
+            let livePreviewDisplayMode = settings.livePreviewDisplayMode
             Task {
               await recording.prewarmCapture()
-              if hexSettings.livePreviewDisplayMode == .cursor {
+              if livePreviewDisplayMode == .cursor {
                 _ = liveTextInsertion.prepareNow()
               }
               if isDoubleTapLock {
@@ -270,9 +278,10 @@ private extension TranscriptionFeature {
 
           case .none:
             // If we detect repeated same chord, maybe intercept.
+            let hotkey = monitorState.hotkey
             if let pressedKey = keyEvent.key,
-               pressedKey == hotKeyProcessor.hotkey.key,
-               keyEvent.modifiers == hotKeyProcessor.hotkey.modifiers
+               pressedKey == hotkey.key,
+               keyEvent.modifiers == hotkey.modifiers
             {
               return true
             }
@@ -281,7 +290,7 @@ private extension TranscriptionFeature {
 
         case .mouseClick:
           // Process mouse click - for modifier-only hotkeys, this may cancel/discard
-          switch hotKeyProcessor.processMouseClick() {
+          switch monitorState.processMouseClick() {
           case .cancel:
             Task { await send(.cancel) }
             return false // Don't intercept the click itself
@@ -445,6 +454,7 @@ private extension TranscriptionFeature {
           }
         }
         do {
+          let speechMetrics = await recording.recordingSpeechMetrics()
           let capturedURL = await recording.stopRecording()
           audioURL = capturedURL
           guard !Task.isCancelled else { return }
@@ -479,7 +489,7 @@ private extension TranscriptionFeature {
             "Transcribed audio from \(capturedURL.lastPathComponent) to text length \(result.count)"
           )
           audioURL = nil
-          await send(.transcriptionResult(result, capturedURL, duration))
+          await send(.transcriptionResult(result, capturedURL, duration, speechMetrics))
         } catch {
           transcriptionFeatureLogger.error("Transcription failed: \(error.localizedDescription)")
           await send(.transcriptionError(error, nil))
@@ -547,8 +557,12 @@ private extension TranscriptionFeature {
       guard !inFlightTranscribe else { continue }
       guard !keystrokeBusy else { continue }
 
-      let snapshotMetrics = await recording.previewSpeechMetrics()
-      guard SpeechActivityGate.hasSpeechActivity(snapshotMetrics) else {
+      let previewEvaluation = await recording.previewSpeechEvaluation()
+      let snapshotMetrics = previewEvaluation.metrics
+      guard previewEvaluation.hasActivity else {
+        transcriptionFeatureLogger.debug(
+          "Skipping preview transcribe — no recent speech above noise floor peakRMS=\(String(format: "%.4f", snapshotMetrics.peakRMS)) peakSample=\(String(format: "%.4f", snapshotMetrics.peakSample))"
+        )
         try? await Task.sleep(for: .milliseconds(200))
         continue
       }
@@ -638,7 +652,13 @@ private extension TranscriptionFeature {
     previewGate: inout LivePreviewUpdateGate,
     send: Send<Action>
   ) async {
-    guard previewGate.shouldApply(next: text) else { return }
+    let lastAppliedCount = previewGate.lastApplied.count
+    guard previewGate.shouldApply(next: text) else {
+      transcriptionFeatureLogger.debug(
+        "Skipped live preview update — gate rejected revision chars=\(text.count) lastApplied=\(lastAppliedCount)"
+      )
+      return
+    }
 
     if insertAtCursor {
       guard await liveTextInsertion.update(text) else {
@@ -655,6 +675,51 @@ private extension TranscriptionFeature {
   }
 }
 
+// MARK: - Hot Key Monitor State
+
+/// Thread-safe wrapper for hotkey state machine used from the key event monitor callback.
+private final class HotKeyMonitorState: @unchecked Sendable {
+  private let lock = NSLock()
+  private var processor: HotKeyProcessor
+
+  init(hotkey: HotKey) {
+    processor = HotKeyProcessor(hotkey: hotkey)
+  }
+
+  var state: HotKeyProcessor.State {
+    lock.lock()
+    defer { lock.unlock() }
+    return processor.state
+  }
+
+  var hotkey: HotKey {
+    lock.lock()
+    defer { lock.unlock() }
+    return processor.hotkey
+  }
+
+  func syncSettings(from settings: HexSettings) {
+    lock.lock()
+    defer { lock.unlock() }
+    processor.hotkey = settings.hotkey
+    processor.doubleTapLockEnabled = settings.doubleTapLockEnabled
+    processor.useDoubleTapOnly = settings.doubleTapLockEnabled && settings.useDoubleTapOnly
+    processor.minimumKeyTime = settings.minimumKeyTime
+  }
+
+  func process(keyEvent: KeyEvent) -> HotKeyProcessor.Output? {
+    lock.lock()
+    defer { lock.unlock() }
+    return processor.process(keyEvent: keyEvent)
+  }
+
+  func processMouseClick() -> HotKeyProcessor.Output? {
+    lock.lock()
+    defer { lock.unlock() }
+    return processor.processMouseClick()
+  }
+}
+
 // MARK: - Transcription Handlers
 
 private extension TranscriptionFeature {
@@ -663,28 +728,51 @@ private extension TranscriptionFeature {
     result: String,
     audioURL: URL,
     duration: TimeInterval,
-    speechMetrics _: SpeechActivityMetrics
+    speechMetrics: SpeechActivityMetrics
   ) -> Effect<Action> {
-    state.setTranscribing(false)
     state.isPrewarming = false
     state.liveTranscript = ""
 
     // Check for force quit command (emergency escape hatch)
     if ForceQuitCommandDetector.matches(result) {
       transcriptionFeatureLogger.fault("Force quit voice command recognized; terminating Hex.")
-      return .run { _ in
+      return .run { send in
         FileManager.default.removeItemIfExists(at: audioURL)
         await MainActor.run {
           NSApp.terminate(nil)
         }
+        await send(.transcriptionPostProcessingDidFinish)
       }
     }
 
     // If empty text, revert any live preview that was inserted at the cursor.
     guard !result.isEmpty else {
-      return .run { _ in
+      return .run { send in
         await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
         FileManager.default.removeItemIfExists(at: audioURL)
+        await send(.transcriptionPostProcessingDidFinish)
+      }
+    }
+
+    guard SpeechActivityGate.hasSpeechActivity(speechMetrics) else {
+      transcriptionFeatureLogger.notice(
+        "Discarding transcription — no speech detected peakRMS=\(String(format: "%.4f", speechMetrics.peakRMS)) peakSample=\(String(format: "%.4f", speechMetrics.peakSample))"
+      )
+      return .run { send in
+        await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
+        FileManager.default.removeItemIfExists(at: audioURL)
+        await send(.transcriptionPostProcessingDidFinish)
+      }
+    }
+
+    guard SilentTranscriptionFilter.shouldAcceptTranscription(text: result, metrics: speechMetrics) else {
+      transcriptionFeatureLogger.notice(
+        "Discarding transcription — likely noise hallucination peakRMS=\(String(format: "%.4f", speechMetrics.peakRMS)) peakSample=\(String(format: "%.4f", speechMetrics.peakSample))"
+      )
+      return .run { send in
+        await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
+        FileManager.default.removeItemIfExists(at: audioURL)
+        await send(.transcriptionPostProcessingDidFinish)
       }
     }
 
@@ -714,9 +802,10 @@ private extension TranscriptionFeature {
     }
 
     guard !modifiedResult.isEmpty else {
-      return .run { _ in
+      return .run { send in
         await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
         FileManager.default.removeItemIfExists(at: audioURL)
+        await send(.transcriptionPostProcessingDidFinish)
       }
     }
 
@@ -740,6 +829,7 @@ private extension TranscriptionFeature {
       } catch {
         await send(.transcriptionError(error, audioURL))
       }
+      await send(.transcriptionPostProcessingDidFinish)
     }
     .cancellable(id: CancelID.transcription)
   }
@@ -760,6 +850,7 @@ private extension TranscriptionFeature {
 
     return .run { _ in
       await Self.revertLivePreviewIfNeeded(liveTextInsertion: liveTextInsertion)
+      await recording.resumeMediaIfNeeded()
     }
   }
 
@@ -844,6 +935,7 @@ private extension TranscriptionFeature {
         await sleepManagement.allowSleep()
         guard wasRecording else {
           soundEffect.play(.cancel)
+          await recording.resumeMediaIfNeeded()
           return
         }
         // Stop the recording to release microphone access
@@ -851,6 +943,7 @@ private extension TranscriptionFeature {
         guard !Task.isCancelled else { return }
         FileManager.default.removeItemIfExists(at: url)
         soundEffect.play(.cancel)
+        await recording.resumeMediaIfNeeded()
       }
       .cancellable(id: CancelID.recordingCleanup, cancelInFlight: true)
     )
@@ -873,6 +966,7 @@ private extension TranscriptionFeature {
         let url = await recording.stopRecording()
         guard !Task.isCancelled else { return }
         FileManager.default.removeItemIfExists(at: url)
+        await recording.resumeMediaIfNeeded()
       }
       .cancellable(id: CancelID.recordingCleanup, cancelInFlight: true)
     )

--- a/Hex/Features/Transcription/TranscriptionIndicatorView.swift
+++ b/Hex/Features/Transcription/TranscriptionIndicatorView.swift
@@ -5,6 +5,7 @@
 //  Created by Kit Langton on 1/25/25.
 
 import AppKit
+import HexCore
 import Inject
 import Pow
 import SwiftUI
@@ -22,6 +23,8 @@ struct TranscriptionIndicatorView: View {
 
   var status: Status
   var meter: Meter
+  var liveTranscript: String = ""
+  var livePreviewDisplayMode: LivePreviewDisplayMode = .cursor
 
   let transcribeBaseColor: Color = .blue
   private var backgroundColor: Color {
@@ -67,9 +70,16 @@ struct TranscriptionIndicatorView: View {
   private let cornerRadius: CGFloat = 8
   private let baseWidth: CGFloat = 16
   private let expandedWidth: CGFloat = 56
+  private let liveTranscriptMaxWidth: CGFloat = 420
 
   var isHidden: Bool {
     status == .hidden
+  }
+
+  private var showsLiveTranscriptOverlay: Bool {
+    livePreviewDisplayMode == .overlay
+      && status == .recording
+      && !liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
   @State var transcribeEffect = 0
@@ -137,6 +147,24 @@ struct TranscriptionIndicatorView: View {
             try? await Task.sleep(for: .seconds(0.25))
           }
         }
+
+      if showsLiveTranscriptOverlay {
+        Text(liveTranscript)
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.white)
+          .multilineTextAlignment(.leading)
+          .lineLimit(8)
+          .frame(maxWidth: liveTranscriptMaxWidth, alignment: .leading)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 8)
+          .background(
+            RoundedRectangle(cornerRadius: 8)
+              .fill(Color.black.opacity(0.85))
+          )
+          .offset(y: 40)
+          .transition(.opacity.combined(with: .move(edge: .top)))
+          .animation(.easeOut(duration: 0.15), value: liveTranscript)
+      }
       
       // Show tooltip when prewarming
       if status == .prewarming {

--- a/Hex/Utilities/SyntheticKeyboardEvent.swift
+++ b/Hex/Utilities/SyntheticKeyboardEvent.swift
@@ -1,0 +1,15 @@
+import CoreGraphics
+
+/// Tags CGEvents posted by Hex during live text insertion so our event tap ignores them.
+/// Untagged synthetic Shift/Cmd events look like hotkey releases for modifier-only bindings.
+enum SyntheticKeyboardEvent {
+  static let userData: Int64 = 0x48455801
+
+  static func tag(_ event: CGEvent?) {
+    event?.setIntegerValueField(.eventSourceUserData, value: userData)
+  }
+
+  static func isTagged(_ event: CGEvent) -> Bool {
+    event.getIntegerValueField(.eventSourceUserData) == userData
+  }
+}

--- a/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
+++ b/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+/// Tracks how live dictation text replaces content at the original insertion point.
+public struct LiveTextInsertionState: Equatable, Sendable {
+  public let prefix: String
+  public let suffix: String
+  public private(set) var insertedText: String
+
+  public init(prefix: String, suffix: String, insertedText: String = "") {
+    self.prefix = prefix
+    self.suffix = suffix
+    self.insertedText = insertedText
+  }
+
+  public mutating func update(with newText: String) -> String {
+    insertedText = newText
+    return composedValue
+  }
+
+  public var composedValue: String {
+    prefix + insertedText + suffix
+  }
+
+  public var cursorLocation: Int {
+    prefix.count + insertedText.count
+  }
+
+  public func revertedValue() -> String {
+    prefix + suffix
+  }
+
+  public var revertedCursorLocation: Int {
+    prefix.count
+  }
+}
+
+public enum LiveTextInsertionLogic {
+  public enum KeystrokeUpdateAction: Equatable, Sendable {
+    case none
+    case append(String)
+    case shrinkBackspaces(Int)
+    /// Delete `backspaces` characters at the insertion tail, then paste `insert`.
+    case replaceTail(backspaces: Int, insert: String)
+  }
+
+  public static func snapshot(
+    fullValue: String,
+    selectionLocation: Int,
+    selectionLength: Int
+  ) -> LiveTextInsertionState? {
+    guard selectionLocation >= 0, selectionLength >= 0 else { return nil }
+    let endIndex = selectionLocation + selectionLength
+    guard selectionLocation <= fullValue.count, endIndex <= fullValue.count else { return nil }
+
+    let prefix = String(fullValue.prefix(selectionLocation))
+    let suffix = String(fullValue.dropFirst(endIndex))
+    return LiveTextInsertionState(prefix: prefix, suffix: suffix)
+  }
+
+  /// Plans minimal keystroke edits when ASR preview text changes (append, trim suffix, or full replace).
+  public static func keystrokeUpdateAction(previous: String, new: String) -> KeystrokeUpdateAction {
+    guard previous != new else { return .none }
+
+    if new.isEmpty {
+      guard !previous.isEmpty else { return .none }
+      return .replaceTail(backspaces: previous.count, insert: "")
+    }
+
+    if previous.isEmpty {
+      return .replaceTail(backspaces: 0, insert: new)
+    }
+
+    let sharedPrefixLength = commonPrefixLength(previous, new)
+
+    if sharedPrefixLength == new.count {
+      let backspaces = previous.count - new.count
+      return backspaces > 0 ? .shrinkBackspaces(backspaces) : .none
+    }
+
+    if sharedPrefixLength == previous.count {
+      let suffix = String(new.dropFirst(previous.count))
+      return suffix.isEmpty ? .none : .append(suffix)
+    }
+
+    // Revise from the first changed character — do not wipe text before the shared prefix.
+    let backspaces = previous.count - sharedPrefixLength
+    let insert = String(new.dropFirst(sharedPrefixLength))
+    return .replaceTail(backspaces: backspaces, insert: insert)
+  }
+
+  private static func commonPrefixLength(_ lhs: String, _ rhs: String) -> Int {
+    var index = lhs.startIndex
+    var other = rhs.startIndex
+    var count = 0
+
+    while index < lhs.endIndex, other < rhs.endIndex, lhs[index] == rhs[other] {
+      lhs.formIndex(after: &index)
+      rhs.formIndex(after: &other)
+      count += 1
+    }
+
+    return count
+  }
+}
+
+/// Debounces live ASR preview updates to reduce cursor flicker from transient revisions.
+public struct LivePreviewUpdateGate: Equatable, Sendable {
+  public private(set) var lastApplied: String = ""
+  private var pendingShrinkCandidate: String?
+
+  public init() {}
+
+  /// Returns whether `next` should be applied at the cursor.
+  public mutating func shouldApply(next: String) -> Bool {
+    guard !next.isEmpty else { return false }
+    guard next != lastApplied else { return false }
+
+    guard !lastApplied.isEmpty else { return true }
+
+    if next.count >= lastApplied.count {
+      pendingShrinkCandidate = nil
+      return true
+    }
+
+    let sharedPrefixLength = lastApplied.commonPrefix(with: next).count
+    guard sharedPrefixLength >= next.count else {
+      pendingShrinkCandidate = nil
+      return false
+    }
+
+    if pendingShrinkCandidate == next {
+      pendingShrinkCandidate = nil
+      return true
+    }
+
+    pendingShrinkCandidate = next
+    return false
+  }
+
+  public mutating func markApplied(_ text: String) {
+    lastApplied = text
+    pendingShrinkCandidate = nil
+  }
+
+  public mutating func reset() {
+    lastApplied = ""
+    pendingShrinkCandidate = nil
+  }
+}
+
+/// Throttles live preview Parakeet passes and decides when to skip stale results.
+public struct LivePreviewTranscriptionScheduler: Equatable, Sendable {
+  public static let minimumAudioBeforeTranscribe: TimeInterval = 0.22
+  public static let minimumNewAudioBetweenTranscribes: TimeInterval = 0.12
+  /// Ignore preview results that lag the live capture by more than this.
+  public static let maxStaleResultDelta: TimeInterval = 0.5
+
+  public private(set) var lastTranscribedDuration: TimeInterval = 0
+
+  public init() {}
+
+  public mutating func shouldScheduleTranscribe(
+    snapshotDuration: TimeInterval,
+    hasInFlightTranscribe: Bool
+  ) -> Bool {
+    guard !hasInFlightTranscribe else { return false }
+    guard snapshotDuration >= Self.minimumAudioBeforeTranscribe else { return false }
+    guard snapshotDuration - lastTranscribedDuration >= Self.minimumNewAudioBetweenTranscribes else {
+      return false
+    }
+    return true
+  }
+
+  public func shouldApplyResult(resultDuration: TimeInterval, currentDuration: TimeInterval) -> Bool {
+    currentDuration - resultDuration <= Self.maxStaleResultDelta
+  }
+
+  public mutating func markTranscribed(duration: TimeInterval) {
+    lastTranscribedDuration = duration
+  }
+
+  /// Allows an immediate retry when a preview result was too stale to apply.
+  public mutating func noteSkippedStaleResult(at resultDuration: TimeInterval) {
+    lastTranscribedDuration = max(0, resultDuration - Self.minimumNewAudioBetweenTranscribes)
+  }
+}

--- a/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
+++ b/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
@@ -58,8 +58,16 @@ public enum LiveTextInsertionLogic {
   }
 
   /// Plans minimal keystroke edits when ASR preview text changes (append, trim suffix, or full replace).
-  public static func keystrokeUpdateAction(previous: String, new: String) -> KeystrokeUpdateAction {
+  public static func keystrokeUpdateAction(
+    previous: String,
+    new: String,
+    preferFullReplace: Bool = false
+  ) -> KeystrokeUpdateAction {
     guard previous != new else { return .none }
+
+    if preferFullReplace, !previous.isEmpty {
+      return .replaceTail(backspaces: previous.count, insert: new)
+    }
 
     if new.isEmpty {
       guard !previous.isEmpty else { return .none }

--- a/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
+++ b/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
@@ -126,6 +126,11 @@ public struct LivePreviewUpdateGate: Equatable, Sendable {
     guard !lastApplied.isEmpty else { return true }
 
     if next.count >= lastApplied.count {
+      let sharedPrefixLength = lastApplied.commonPrefix(with: next).count
+      // Short padded preview clips often hallucinate unrelated longer strings.
+      // Require growth to mostly extend the prior transcript instead of rewriting it.
+      let minimumStablePrefix = max(1, (lastApplied.count * 2) / 3)
+      guard sharedPrefixLength >= minimumStablePrefix else { return false }
       pendingShrinkCandidate = nil
       return true
     }
@@ -158,8 +163,8 @@ public struct LivePreviewUpdateGate: Equatable, Sendable {
 
 /// Throttles live preview Parakeet passes and decides when to skip stale results.
 public struct LivePreviewTranscriptionScheduler: Equatable, Sendable {
-  public static let minimumAudioBeforeTranscribe: TimeInterval = 0.22
-  public static let minimumNewAudioBetweenTranscribes: TimeInterval = 0.12
+  public static let minimumAudioBeforeTranscribe: TimeInterval = 0.45
+  public static let minimumNewAudioBetweenTranscribes: TimeInterval = 0.22
   /// Ignore preview results that lag the live capture by more than this.
   public static let maxStaleResultDelta: TimeInterval = 0.5
 

--- a/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
+++ b/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
@@ -172,13 +172,27 @@ public struct LivePreviewTranscriptionScheduler: Equatable, Sendable {
 
   public init() {}
 
+  public static func minimumNewAudioBetweenTranscribes(for snapshotDuration: TimeInterval) -> TimeInterval {
+    switch snapshotDuration {
+    case ..<3:
+      minimumNewAudioBetweenTranscribes
+    case ..<8:
+      0.50
+    case ..<15:
+      0.85
+    default:
+      1.25
+    }
+  }
+
   public mutating func shouldScheduleTranscribe(
     snapshotDuration: TimeInterval,
     hasInFlightTranscribe: Bool
   ) -> Bool {
     guard !hasInFlightTranscribe else { return false }
     guard snapshotDuration >= Self.minimumAudioBeforeTranscribe else { return false }
-    guard snapshotDuration - lastTranscribedDuration >= Self.minimumNewAudioBetweenTranscribes else {
+    let requiredNewAudio = Self.minimumNewAudioBetweenTranscribes(for: snapshotDuration)
+    guard snapshotDuration - lastTranscribedDuration >= requiredNewAudio else {
       return false
     }
     return true

--- a/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
+++ b/HexCore/Sources/HexCore/Logic/LiveTextInsertion.swift
@@ -113,6 +113,11 @@ public enum LiveTextInsertionLogic {
 
 /// Debounces live ASR preview updates to reduce cursor flicker from transient revisions.
 public struct LivePreviewUpdateGate: Equatable, Sendable {
+  /// Ignore very short first previews — padded 1s clips often hallucinate 1–4 chars.
+  public static let minimumInitialApplyLength = 8
+  /// When a prior apply was shorter than this, allow a fuller transcript to replace it.
+  public static let shortPreviewRecoveryThreshold = 8
+
   public private(set) var lastApplied: String = ""
   private var pendingShrinkCandidate: String?
 
@@ -123,13 +128,48 @@ public struct LivePreviewUpdateGate: Equatable, Sendable {
     guard !next.isEmpty else { return false }
     guard next != lastApplied else { return false }
 
-    guard !lastApplied.isEmpty else { return true }
+    if lastApplied.isEmpty {
+      return next.count >= Self.minimumInitialApplyLength
+    }
 
     if next.count >= lastApplied.count {
+      if next.hasPrefix(lastApplied) {
+        pendingShrinkCandidate = nil
+        return true
+      }
+      // Growing snapshot re-transcription often rewrites earlier words — allow refreshes
+      // that are materially longer than what is already at the cursor.
+      if lastApplied.count >= Self.minimumInitialApplyLength {
+        let sharedPrefixLength = lastApplied.commonPrefix(with: next).count
+        if next.count >= lastApplied.count + 15,
+           sharedPrefixLength >= max(4, lastApplied.count / 4)
+        {
+          pendingShrinkCandidate = nil
+          return true
+        }
+        if next.count >= lastApplied.count + 30 {
+          pendingShrinkCandidate = nil
+          return true
+        }
+        if next.count * 20 >= lastApplied.count * 21,
+           sharedPrefixLength >= max(8, lastApplied.count / 4)
+        {
+          pendingShrinkCandidate = nil
+          return true
+        }
+      }
       let sharedPrefixLength = lastApplied.commonPrefix(with: next).count
-      // Short padded preview clips often hallucinate unrelated longer strings.
-      // Require growth to mostly extend the prior transcript instead of rewriting it.
-      let minimumStablePrefix = max(1, (lastApplied.count * 2) / 3)
+      let minimumStablePrefix = max(4, lastApplied.count / 2)
+      // A tiny early preview (e.g. "Te") often diverges from the real transcript — replace it.
+      if lastApplied.count <= Self.shortPreviewRecoveryThreshold,
+         next.count >= 20,
+         sharedPrefixLength < minimumStablePrefix
+      {
+        pendingShrinkCandidate = nil
+        return true
+      }
+      // Reject unrelated growth (common on very short padded clips) while allowing
+      // normal ASR rewrites that share roughly half the prior preview text.
       guard sharedPrefixLength >= minimumStablePrefix else { return false }
       pendingShrinkCandidate = nil
       return true
@@ -139,6 +179,12 @@ public struct LivePreviewUpdateGate: Equatable, Sendable {
     guard sharedPrefixLength >= next.count else {
       pendingShrinkCandidate = nil
       return false
+    }
+
+    // Allow small ASR trim revisions without waiting for a second identical shrink.
+    if lastApplied.count - next.count <= 2 {
+      pendingShrinkCandidate = nil
+      return true
     }
 
     if pendingShrinkCandidate == next {
@@ -164,9 +210,10 @@ public struct LivePreviewUpdateGate: Equatable, Sendable {
 /// Throttles live preview Parakeet passes and decides when to skip stale results.
 public struct LivePreviewTranscriptionScheduler: Equatable, Sendable {
   public static let minimumAudioBeforeTranscribe: TimeInterval = 0.45
-  public static let minimumNewAudioBetweenTranscribes: TimeInterval = 0.22
+  public static let minimumNewAudioBetweenTranscribes: TimeInterval = 0.40
   /// Ignore preview results that lag the live capture by more than this.
-  public static let maxStaleResultDelta: TimeInterval = 0.5
+  /// Must exceed capture callback cadence (~0.51s) plus typical Parakeet latency.
+  public static let maxStaleResultDelta: TimeInterval = 1.25
 
   public private(set) var lastTranscribedDuration: TimeInterval = 0
 
@@ -177,11 +224,11 @@ public struct LivePreviewTranscriptionScheduler: Equatable, Sendable {
     case ..<3:
       minimumNewAudioBetweenTranscribes
     case ..<8:
-      0.50
+      0.55
     case ..<15:
-      0.85
+      0.75
     default:
-      1.25
+      1.00
     }
   }
 

--- a/HexCore/Sources/HexCore/Logic/SpeechActivity.swift
+++ b/HexCore/Sources/HexCore/Logic/SpeechActivity.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Peak audio levels observed during a recording session or PCM snapshot.
+public struct SpeechActivityMetrics: Equatable, Sendable {
+  public var peakRMS: Double
+  public var peakSample: Double
+
+  public init(peakRMS: Double, peakSample: Double) {
+    self.peakRMS = peakRMS
+    self.peakSample = peakSample
+  }
+
+  public static let zero = SpeechActivityMetrics(peakRMS: 0, peakSample: 0)
+
+  public mutating func merge(_ other: SpeechActivityMetrics) {
+    peakRMS = max(peakRMS, other.peakRMS)
+    peakSample = max(peakSample, other.peakSample)
+  }
+
+  /// Computes peak RMS and sample magnitude for normalized float32 mono PCM.
+  public static func analyze(samples: [Float]) -> SpeechActivityMetrics {
+    guard !samples.isEmpty else { return .zero }
+
+    var sumOfSquares: Double = 0
+    var peak: Double = 0
+    for sample in samples {
+      let magnitude = Double(abs(sample))
+      sumOfSquares += Double(sample) * Double(sample)
+      peak = max(peak, magnitude)
+    }
+
+    let rms = sqrt(sumOfSquares / Double(samples.count))
+    return SpeechActivityMetrics(peakRMS: rms, peakSample: peak)
+  }
+}
+
+/// Detects whether captured audio likely contains speech vs silence/noise.
+public enum SpeechActivityGate {
+  /// Minimum RMS for float32 mono PCM at 16 kHz (disconnected/silent mics stay well below this).
+  public static let minimumPeakRMS: Double = 0.012
+  /// Short spikes from padding/click noise can exceed RMS while still not being speech.
+  public static let minimumPeakSample: Double = 0.04
+
+  public static func hasSpeechActivity(_ metrics: SpeechActivityMetrics) -> Bool {
+    metrics.peakRMS >= minimumPeakRMS || metrics.peakSample >= minimumPeakSample
+  }
+}
+
+/// Common Parakeet/Whisper phrases on silent or padded audio.
+public enum SilentTranscriptionFilter {
+  private static let hallucinatedPhrases: Set<String> = [
+    "thank you",
+    "thanks",
+    "thank you for watching",
+    "thanks for watching",
+    "okay",
+    "ok",
+    "ok ay",
+    "yeah",
+    "yes",
+    "no",
+    "uh",
+    "um",
+    "hmm",
+    "hello",
+    "hi",
+    "bye",
+    "goodbye",
+    "you",
+    "the",
+    "so",
+    "well",
+    "right",
+    "subscribe",
+  ]
+
+  public static func normalized(_ text: String) -> String {
+    text
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+      .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?;:"))
+  }
+
+  public static func isLikelyHallucination(_ text: String) -> Bool {
+    let normalized = normalized(text)
+    guard !normalized.isEmpty else { return false }
+    return hallucinatedPhrases.contains(normalized)
+  }
+
+  /// Accept real speech always; reject silence and common silent-audio hallucinations.
+  public static func shouldAcceptTranscription(
+    text: String,
+    metrics: SpeechActivityMetrics
+  ) -> Bool {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+    if SpeechActivityGate.hasSpeechActivity(metrics) { return true }
+    return !isLikelyHallucination(trimmed)
+  }
+}

--- a/HexCore/Sources/HexCore/Logic/SpeechActivity.swift
+++ b/HexCore/Sources/HexCore/Logic/SpeechActivity.swift
@@ -36,19 +36,154 @@ public struct SpeechActivityMetrics: Equatable, Sendable {
 
 /// Detects whether captured audio likely contains speech vs silence/noise.
 public enum SpeechActivityGate {
-  /// Both must be met — Bluetooth idle noise often spikes peak without sustained RMS.
-  public static let minimumPeakRMS: Double = 0.018
-  public static let minimumPeakSample: Double = 0.055
+  /// Both must be met for normal speech — Bluetooth idle noise often spikes peak without sustained RMS.
+  public static let minimumPeakRMS: Double = 0.015
+  public static let minimumPeakSample: Double = 0.050
+  /// Quieter speech still needs both RMS and peak to avoid BT spike false positives.
+  public static let whisperPeakRMS: Double = 0.008
+  public static let whisperPeakSample: Double = 0.038
   /// Louder evidence required before accepting hallucination-prone short phrases.
   public static let strongPeakRMS: Double = 0.030
   public static let strongPeakSample: Double = 0.10
+  /// Trailing window used to detect current speech vs earlier audio in a growing preview buffer.
+  public static let previewRecentWindow: TimeInterval = 0.75
+  /// Longer window — keeps transcribing through brief between-word pauses.
+  public static let previewHoldWindow: TimeInterval = 1.5
+  /// Window size for estimating a noise floor from the quietest segments.
+  public static let noiseAnalysisWindow: TimeInterval = 0.25
+  /// Recent speech RMS must exceed the noise floor by this factor (weak speech only).
+  public static let minimumSpeechToNoiseRatio: Double = 1.6
+
+  public static func hasWhisperActivity(_ metrics: SpeechActivityMetrics) -> Bool {
+    guard metrics.peakRMS >= whisperPeakRMS, metrics.peakSample >= whisperPeakSample else {
+      return false
+    }
+    // Require sustained energy — BT idle noise often spikes peak without RMS.
+    return metrics.peakRMS >= metrics.peakSample * 0.12
+  }
 
   public static func hasSpeechActivity(_ metrics: SpeechActivityMetrics) -> Bool {
-    metrics.peakRMS >= minimumPeakRMS && metrics.peakSample >= minimumPeakSample
+    hasWhisperActivity(metrics)
+      || (metrics.peakRMS >= minimumPeakRMS && metrics.peakSample >= minimumPeakSample)
   }
 
   public static func hasStrongSpeechActivity(_ metrics: SpeechActivityMetrics) -> Bool {
-    metrics.peakRMS >= strongPeakRMS || metrics.peakSample >= strongPeakSample
+    metrics.peakRMS >= strongPeakRMS && metrics.peakSample >= strongPeakSample
+  }
+
+  /// Returns metrics for the trailing window and whether preview transcription should run.
+  public static func evaluatePreviewActivity(
+    samples: [Float],
+    sampleRate: Double = 16_000
+  ) -> (metrics: SpeechActivityMetrics, hasActivity: Bool) {
+    let recentSamples = recentSlice(
+      samples,
+      sampleRate: sampleRate,
+      windowDuration: previewRecentWindow
+    )
+    let recentMetrics = SpeechActivityMetrics.analyze(samples: recentSamples)
+
+    if windowHasSpeechActivity(
+      samples: samples,
+      sampleRate: sampleRate,
+      windowDuration: previewRecentWindow,
+      metrics: recentMetrics
+    ) {
+      return (recentMetrics, true)
+    }
+
+    let holdSamples = recentSlice(
+      samples,
+      sampleRate: sampleRate,
+      windowDuration: previewHoldWindow
+    )
+    let holdMetrics = SpeechActivityMetrics.analyze(samples: holdSamples)
+    if windowHasSpeechActivity(
+      samples: samples,
+      sampleRate: sampleRate,
+      windowDuration: previewHoldWindow,
+      metrics: holdMetrics
+    ) {
+      return (recentMetrics, true)
+    }
+
+    return (recentMetrics, false)
+  }
+
+  private static func windowHasSpeechActivity(
+    samples: [Float],
+    sampleRate: Double,
+    windowDuration: TimeInterval,
+    metrics: SpeechActivityMetrics
+  ) -> Bool {
+    guard hasSpeechActivity(metrics) else { return false }
+
+    if hasStrongSpeechActivity(metrics) || hasWhisperActivity(metrics) {
+      return true
+    }
+
+    if metrics.peakSample >= 0.10, metrics.peakRMS >= minimumPeakRMS {
+      return true
+    }
+
+    let noiseFloor = estimatedNoiseFloorRMS(
+      samples: samples,
+      sampleRate: sampleRate,
+      analysisDuration: min(windowDuration * 4, Double(samples.count) / sampleRate)
+    )
+    let requiredRMS = max(minimumPeakRMS, noiseFloor * minimumSpeechToNoiseRatio)
+    return metrics.peakRMS >= requiredRMS
+  }
+
+  public static func recentSlice(
+    _ samples: [Float],
+    sampleRate: Double,
+    windowDuration: TimeInterval
+  ) -> [Float] {
+    let windowSamples = max(1, Int((windowDuration * sampleRate).rounded(.up)))
+    guard !samples.isEmpty else { return [] }
+    let startIndex = max(0, samples.count - windowSamples)
+    return Array(samples[startIndex...])
+  }
+
+  /// 25th-percentile RMS of overlapping windows — approximates background noise floor.
+  public static func estimatedNoiseFloorRMS(
+    samples: [Float],
+    sampleRate: Double = 16_000,
+    windowDuration: TimeInterval = noiseAnalysisWindow,
+    analysisDuration: TimeInterval? = nil
+  ) -> Double {
+    let analysisSamples: [Float]
+    if let analysisDuration {
+      analysisSamples = recentSlice(
+        samples,
+        sampleRate: sampleRate,
+        windowDuration: analysisDuration
+      )
+    } else {
+      analysisSamples = samples
+    }
+
+    let windowSamples = max(1, Int((windowDuration * sampleRate).rounded(.up)))
+    let hopSamples = max(1, windowSamples / 2)
+    guard analysisSamples.count >= windowSamples else {
+      return SpeechActivityMetrics.analyze(samples: analysisSamples).peakRMS
+    }
+
+    var windowLevels: [Double] = []
+    windowLevels.reserveCapacity(analysisSamples.count / hopSamples)
+    var startIndex = 0
+    while startIndex + windowSamples <= analysisSamples.count {
+      let window = Array(analysisSamples[startIndex ..< startIndex + windowSamples])
+      windowLevels.append(SpeechActivityMetrics.analyze(samples: window).peakRMS)
+      startIndex += hopSamples
+    }
+
+    guard !windowLevels.isEmpty else { return 0 }
+    windowLevels.sort()
+    // Use the quietest 10% of windows — 25th percentile stays too high during speech.
+    let quietIndex = max(0, windowLevels.count / 10)
+    return windowLevels[quietIndex]
   }
 }
 

--- a/HexCore/Sources/HexCore/Logic/SpeechActivity.swift
+++ b/HexCore/Sources/HexCore/Logic/SpeechActivity.swift
@@ -36,13 +36,19 @@ public struct SpeechActivityMetrics: Equatable, Sendable {
 
 /// Detects whether captured audio likely contains speech vs silence/noise.
 public enum SpeechActivityGate {
-  /// Minimum RMS for float32 mono PCM at 16 kHz (disconnected/silent mics stay well below this).
-  public static let minimumPeakRMS: Double = 0.012
-  /// Short spikes from padding/click noise can exceed RMS while still not being speech.
-  public static let minimumPeakSample: Double = 0.04
+  /// Both must be met — Bluetooth idle noise often spikes peak without sustained RMS.
+  public static let minimumPeakRMS: Double = 0.018
+  public static let minimumPeakSample: Double = 0.055
+  /// Louder evidence required before accepting hallucination-prone short phrases.
+  public static let strongPeakRMS: Double = 0.030
+  public static let strongPeakSample: Double = 0.10
 
   public static func hasSpeechActivity(_ metrics: SpeechActivityMetrics) -> Bool {
-    metrics.peakRMS >= minimumPeakRMS || metrics.peakSample >= minimumPeakSample
+    metrics.peakRMS >= minimumPeakRMS && metrics.peakSample >= minimumPeakSample
+  }
+
+  public static func hasStrongSpeechActivity(_ metrics: SpeechActivityMetrics) -> Bool {
+    metrics.peakRMS >= strongPeakRMS || metrics.peakSample >= strongPeakSample
   }
 }
 
@@ -74,6 +80,8 @@ public enum SilentTranscriptionFilter {
     "subscribe",
   ]
 
+  public static let maxShortPreviewCharsWithoutStrongSpeech = 8
+
   public static func normalized(_ text: String) -> String {
     text
       .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -87,14 +95,22 @@ public enum SilentTranscriptionFilter {
     return hallucinatedPhrases.contains(normalized)
   }
 
-  /// Accept real speech always; reject silence and common silent-audio hallucinations.
+  /// Accept real speech; reject silence/noise and common silent-audio hallucinations.
   public static func shouldAcceptTranscription(
     text: String,
     metrics: SpeechActivityMetrics
   ) -> Bool {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return false }
-    if SpeechActivityGate.hasSpeechActivity(metrics) { return true }
-    return !isLikelyHallucination(trimmed)
+
+    if isLikelyHallucination(trimmed) {
+      return SpeechActivityGate.hasStrongSpeechActivity(metrics)
+    }
+
+    if trimmed.count <= maxShortPreviewCharsWithoutStrongSpeech {
+      return SpeechActivityGate.hasStrongSpeechActivity(metrics)
+    }
+
+    return SpeechActivityGate.hasSpeechActivity(metrics)
   }
 }

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -6,9 +6,18 @@ public enum RecordingAudioBehavior: String, Codable, CaseIterable, Equatable, Se
 	case doNothing
 }
 
+/// Where live dictation preview text appears while recording.
+public enum LivePreviewDisplayMode: String, Codable, CaseIterable, Equatable, Sendable {
+	/// Insert preview text at the cursor in the frontmost app.
+	case cursor
+	/// Show preview text in Hex's floating overlay; paste final text on release.
+	case overlay
+}
+
 /// User-configurable settings saved to disk.
 public struct HexSettings: Codable, Equatable, Sendable {
 	public static let defaultPasteLastTranscriptHotkey = HotKey(key: .v, modifiers: [.option, .shift])
+	public static let defaultRecordingHotkey = HotKey(key: nil, modifiers: [.control, .option])
 	public static let baseSoundEffectsVolume: Double = HexCoreConstants.baseSoundEffectsVolume
 	public static let defaultWordRemovals: [WordRemoval] = [
 		.init(pattern: "uh+"),
@@ -44,9 +53,13 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var pasteLastTranscriptHotkey: HotKey?
 	public var hasCompletedModelBootstrap: Bool
 	public var hasCompletedStorageMigration: Bool
+	public var hasMigratedLegacyRecordingHotkey: Bool
 	public var wordRemovalsEnabled: Bool
 	public var wordRemovals: [WordRemoval]
 	public var wordRemappings: [WordRemapping]
+	public var livePreviewDisplayMode: LivePreviewDisplayMode
+
+	private static let legacyRecordingHotkey = HotKey(key: nil, modifiers: [.option])
 
 	private mutating func normalizeDoubleTapSettings() {
 		if !doubleTapLockEnabled {
@@ -54,10 +67,27 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		}
 	}
 
+	/// Upgrades the old default (Option-only) to Control+Option once for existing installs.
+	private mutating func normalizeLegacyRecordingHotkey() {
+		guard !hasMigratedLegacyRecordingHotkey else { return }
+
+		if hotkey.key == nil,
+		   hotkey.modifiers.erasingSides() == Self.legacyRecordingHotkey.modifiers.erasingSides() {
+			hotkey = Self.defaultRecordingHotkey
+		}
+
+		hasMigratedLegacyRecordingHotkey = true
+	}
+
+	private mutating func normalizeSettings() {
+		normalizeDoubleTapSettings()
+		normalizeLegacyRecordingHotkey()
+	}
+
 	public init(
 		soundEffectsEnabled: Bool = true,
 		soundEffectsVolume: Double = HexSettings.baseSoundEffectsVolume,
-		hotkey: HotKey = .init(key: nil, modifiers: [.option]),
+		hotkey: HotKey = HexSettings.defaultRecordingHotkey,
 		openOnLogin: Bool = false,
 		showDockIcon: Bool = true,
 		selectedModel: String = ParakeetModel.multilingualV3.identifier,
@@ -76,9 +106,11 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		pasteLastTranscriptHotkey: HotKey? = HexSettings.defaultPasteLastTranscriptHotkey,
 		hasCompletedModelBootstrap: Bool = false,
 		hasCompletedStorageMigration: Bool = false,
+		hasMigratedLegacyRecordingHotkey: Bool = false,
 		wordRemovalsEnabled: Bool = false,
 		wordRemovals: [WordRemoval] = HexSettings.defaultWordRemovals,
-		wordRemappings: [WordRemapping] = []
+		wordRemappings: [WordRemapping] = [],
+		livePreviewDisplayMode: LivePreviewDisplayMode = .cursor
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
 		self.soundEffectsVolume = soundEffectsVolume
@@ -101,10 +133,12 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.pasteLastTranscriptHotkey = pasteLastTranscriptHotkey
 		self.hasCompletedModelBootstrap = hasCompletedModelBootstrap
 		self.hasCompletedStorageMigration = hasCompletedStorageMigration
+		self.hasMigratedLegacyRecordingHotkey = hasMigratedLegacyRecordingHotkey
 		self.wordRemovalsEnabled = wordRemovalsEnabled
 		self.wordRemovals = wordRemovals
 		self.wordRemappings = wordRemappings
-		normalizeDoubleTapSettings()
+		self.livePreviewDisplayMode = livePreviewDisplayMode
+		normalizeSettings()
 	}
 
 	public init(from decoder: Decoder) throws {
@@ -113,7 +147,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		for field in HexSettingsSchema.fields {
 			try field.decode(into: &self, from: container)
 		}
-		normalizeDoubleTapSettings()
+		normalizeSettings()
 	}
 
 	public func encode(to encoder: Encoder) throws {
@@ -149,9 +183,11 @@ private enum HexSettingKey: String, CodingKey, CaseIterable {
 	case pasteLastTranscriptHotkey
 	case hasCompletedModelBootstrap
 	case hasCompletedStorageMigration
+	case hasMigratedLegacyRecordingHotkey
 	case wordRemovalsEnabled
 	case wordRemovals
 	case wordRemappings
+	case livePreviewDisplayMode
 }
 
 private struct SettingsField<Value: Codable & Sendable> {
@@ -274,6 +310,7 @@ private enum HexSettingsSchema {
 		).eraseToAny(),
 		SettingsField(.hasCompletedModelBootstrap, keyPath: \.hasCompletedModelBootstrap, default: defaults.hasCompletedModelBootstrap).eraseToAny(),
 		SettingsField(.hasCompletedStorageMigration, keyPath: \.hasCompletedStorageMigration, default: defaults.hasCompletedStorageMigration).eraseToAny(),
+		SettingsField(.hasMigratedLegacyRecordingHotkey, keyPath: \.hasMigratedLegacyRecordingHotkey, default: false).eraseToAny(),
 		SettingsField(.wordRemovalsEnabled, keyPath: \.wordRemovalsEnabled, default: defaults.wordRemovalsEnabled).eraseToAny(),
 		SettingsField(
 			.wordRemovals,
@@ -284,6 +321,11 @@ private enum HexSettingsSchema {
 			.wordRemappings,
 			keyPath: \.wordRemappings,
 			default: defaults.wordRemappings
+		).eraseToAny(),
+		SettingsField(
+			.livePreviewDisplayMode,
+			keyPath: \.livePreviewDisplayMode,
+			default: defaults.livePreviewDisplayMode
 		).eraseToAny()
 	]
 }

--- a/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
+++ b/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
@@ -49,4 +49,15 @@ final class LivePreviewLogicTests: XCTestCase {
     XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.65, hasInFlightTranscribe: false))
     XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.75, hasInFlightTranscribe: false))
   }
+
+  func testLivePreviewTranscriptionSchedulerSlowsOnLongRecordings() {
+    var scheduler = LivePreviewTranscriptionScheduler()
+    scheduler.markTranscribed(duration: 5.0)
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 5.4, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 5.55, hasInFlightTranscribe: false))
+
+    scheduler.markTranscribed(duration: 14.0)
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 14.7, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 14.9, hasInFlightTranscribe: false))
+  }
 }

--- a/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
+++ b/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
@@ -17,6 +17,15 @@ final class LivePreviewLogicTests: XCTestCase {
     XCTAssertEqual(action, .replaceTail(backspaces: 1, insert: "ld"))
   }
 
+  func testKeystrokeUpdateActionPrefersFullReplace() {
+    let action = LiveTextInsertionLogic.keystrokeUpdateAction(
+      previous: "hello",
+      new: "hello world",
+      preferFullReplace: true
+    )
+    XCTAssertEqual(action, .replaceTail(backspaces: 5, insert: "hello world"))
+  }
+
   func testLivePreviewUpdateGateRequiresDoubleShrink() {
     var gate = LivePreviewUpdateGate()
     XCTAssertTrue(gate.shouldApply(next: "hello"))

--- a/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
+++ b/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
@@ -26,19 +26,69 @@ final class LivePreviewLogicTests: XCTestCase {
     XCTAssertEqual(action, .replaceTail(backspaces: 5, insert: "hello world"))
   }
 
-  func testLivePreviewUpdateGateRequiresDoubleShrink() {
+  func testLivePreviewUpdateGateRequiresMinimumInitialLength() {
     var gate = LivePreviewUpdateGate()
+    XCTAssertFalse(gate.shouldApply(next: "Te"))
+    XCTAssertTrue(gate.shouldApply(next: "Testing live"))
+  }
+
+  func testLivePreviewUpdateGateAllowsModerateGrowthFromSmallBase() {
+    var gate = LivePreviewUpdateGate()
+    gate.markApplied("Testing live preview")
+    XCTAssertTrue(
+      gate.shouldApply(
+        next: "Testing live preview with more words added here."
+      )
+    )
+  }
+
+  func testLivePreviewUpdateGateRecoversFromShortPoisonedPreview() {
+    var gate = LivePreviewUpdateGate()
+    gate.markApplied("Te")
+    XCTAssertTrue(
+      gate.shouldApply(
+        next: "Testing life transcription, testing the life inscription."
+      )
+    )
+  }
+
+  func testLivePreviewUpdateGateAllowsSmallShrinkRevision() {
+    var gate = LivePreviewUpdateGate()
+    gate.markApplied("Testing the live transcription")
+    XCTAssertTrue(gate.shouldApply(next: "Testing the live transcriptio"))
+  }
+
+  func testLivePreviewUpdateGateRequiresDoubleShrinkForLargeTrim() {
+    var gate = LivePreviewUpdateGate()
+    XCTAssertTrue(gate.shouldApply(next: "hello world again"))
+    gate.markApplied("hello world again")
+    XCTAssertFalse(gate.shouldApply(next: "hello"))
     XCTAssertTrue(gate.shouldApply(next: "hello"))
-    gate.markApplied("hello")
-    XCTAssertFalse(gate.shouldApply(next: "hell"))
-    XCTAssertTrue(gate.shouldApply(next: "hell"))
   }
 
   func testLivePreviewUpdateGateRejectsUnrelatedGrowth() {
     var gate = LivePreviewUpdateGate()
     gate.markApplied("The setting seems fine")
-    XCTAssertFalse(gate.shouldApply(next: "Random words completely different"))
+    XCTAssertFalse(
+      gate.shouldApply(next: "Random words completely different here")
+    )
     XCTAssertTrue(gate.shouldApply(next: "The setting seems fine now"))
+  }
+
+  func testLivePreviewUpdateGateAcceptsPrefixExtension() {
+    var gate = LivePreviewUpdateGate()
+    gate.markApplied("hello world")
+    XCTAssertTrue(gate.shouldApply(next: "hello world again"))
+  }
+
+  func testLivePreviewUpdateGateAcceptsMateriallyLongerRefresh() {
+    var gate = LivePreviewUpdateGate()
+    gate.markApplied("Testing the live transcription. Seems to be working okay. Seems to be cutting off the last word.")
+    XCTAssertTrue(
+      gate.shouldApply(
+        next: "Testing the live transcription. Seems to be working okay. Seems to be cutting off the last word. Sometimes getting stuck."
+      )
+    )
   }
 
   func testLivePreviewTranscriptionSchedulerThrottles() {
@@ -47,17 +97,17 @@ final class LivePreviewLogicTests: XCTestCase {
     XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.5, hasInFlightTranscribe: false))
     scheduler.markTranscribed(duration: 0.5)
     XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.65, hasInFlightTranscribe: false))
-    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.75, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.95, hasInFlightTranscribe: false))
   }
 
   func testLivePreviewTranscriptionSchedulerSlowsOnLongRecordings() {
     var scheduler = LivePreviewTranscriptionScheduler()
     scheduler.markTranscribed(duration: 5.0)
     XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 5.4, hasInFlightTranscribe: false))
-    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 5.55, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 5.85, hasInFlightTranscribe: false))
 
     scheduler.markTranscribed(duration: 14.0)
-    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 14.7, hasInFlightTranscribe: false))
-    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 14.9, hasInFlightTranscribe: false))
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 14.5, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 14.8, hasInFlightTranscribe: false))
   }
 }

--- a/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
+++ b/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import HexCore
+
+final class LivePreviewLogicTests: XCTestCase {
+  func testKeystrokeUpdateActionAppendsSuffix() {
+    let action = LiveTextInsertionLogic.keystrokeUpdateAction(previous: "hello", new: "hello world")
+    XCTAssertEqual(action, .append(" world"))
+  }
+
+  func testKeystrokeUpdateActionShrinksWhenPreviewShortens() {
+    let action = LiveTextInsertionLogic.keystrokeUpdateAction(previous: "hello world", new: "hello")
+    XCTAssertEqual(action, .shrinkBackspaces(6))
+  }
+
+  func testKeystrokeUpdateActionReplacesTailOnRevision() {
+    let action = LiveTextInsertionLogic.keystrokeUpdateAction(previous: "hello word", new: "hello world")
+    XCTAssertEqual(action, .replaceTail(backspaces: 1, insert: "ld"))
+  }
+
+  func testLivePreviewUpdateGateRequiresDoubleShrink() {
+    var gate = LivePreviewUpdateGate()
+    XCTAssertTrue(gate.shouldApply(next: "hello"))
+    gate.markApplied("hello")
+    XCTAssertFalse(gate.shouldApply(next: "hell"))
+    XCTAssertTrue(gate.shouldApply(next: "hell"))
+  }
+
+  func testLivePreviewTranscriptionSchedulerThrottles() {
+    var scheduler = LivePreviewTranscriptionScheduler()
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.1, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.5, hasInFlightTranscribe: false))
+    scheduler.markTranscribed(duration: 0.5)
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.55, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.65, hasInFlightTranscribe: false))
+  }
+}

--- a/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
+++ b/HexCore/Tests/HexCoreTests/LivePreviewLogicTests.swift
@@ -34,12 +34,19 @@ final class LivePreviewLogicTests: XCTestCase {
     XCTAssertTrue(gate.shouldApply(next: "hell"))
   }
 
+  func testLivePreviewUpdateGateRejectsUnrelatedGrowth() {
+    var gate = LivePreviewUpdateGate()
+    gate.markApplied("The setting seems fine")
+    XCTAssertFalse(gate.shouldApply(next: "Random words completely different"))
+    XCTAssertTrue(gate.shouldApply(next: "The setting seems fine now"))
+  }
+
   func testLivePreviewTranscriptionSchedulerThrottles() {
     var scheduler = LivePreviewTranscriptionScheduler()
-    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.1, hasInFlightTranscribe: false))
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.3, hasInFlightTranscribe: false))
     XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.5, hasInFlightTranscribe: false))
     scheduler.markTranscribed(duration: 0.5)
-    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.55, hasInFlightTranscribe: false))
-    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.65, hasInFlightTranscribe: false))
+    XCTAssertFalse(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.65, hasInFlightTranscribe: false))
+    XCTAssertTrue(scheduler.shouldScheduleTranscribe(snapshotDuration: 0.75, hasInFlightTranscribe: false))
   }
 }

--- a/HexCore/Tests/HexCoreTests/SpeechActivityTests.swift
+++ b/HexCore/Tests/HexCoreTests/SpeechActivityTests.swift
@@ -10,7 +10,7 @@ final class SpeechActivityTests: XCTestCase {
 
   func testAnalyzeDetectsSpeechLikeSignal() {
     let speechLike = (0 ..< 16_000).map { index in
-      Float(sin(Double(index) / 40.0) * 0.08)
+      Float(sin(Double(index) / 40.0) * 0.12)
     }
     let metrics = SpeechActivityMetrics.analyze(samples: speechLike)
     XCTAssertTrue(SpeechActivityGate.hasSpeechActivity(metrics))
@@ -20,6 +20,12 @@ final class SpeechActivityTests: XCTestCase {
   func testPeakSampleAloneDoesNotCountAsSpeech() {
     let metrics = SpeechActivityMetrics(peakRMS: 0.005, peakSample: 0.08)
     XCTAssertFalse(SpeechActivityGate.hasSpeechActivity(metrics))
+    XCTAssertFalse(SpeechActivityGate.hasWhisperActivity(metrics))
+  }
+
+  func testStrongSpeechRequiresBothRMSAndPeak() {
+    let peakOnly = SpeechActivityMetrics(peakRMS: 0.010, peakSample: 0.12)
+    XCTAssertFalse(SpeechActivityGate.hasStrongSpeechActivity(peakOnly))
   }
 
   func testSilentTranscriptionFilterRejectsCommonHallucinations() {
@@ -29,7 +35,7 @@ final class SpeechActivityTests: XCTestCase {
   }
 
   func testShouldRejectHallucinationOnWeakSpeechMetrics() {
-    let weakMetrics = SpeechActivityMetrics(peakRMS: 0.020, peakSample: 0.06)
+    let weakMetrics = SpeechActivityMetrics(peakRMS: 0.024, peakSample: 0.065)
     XCTAssertTrue(SpeechActivityGate.hasSpeechActivity(weakMetrics))
     XCTAssertFalse(SpeechActivityGate.hasStrongSpeechActivity(weakMetrics))
     XCTAssertFalse(
@@ -51,5 +57,34 @@ final class SpeechActivityTests: XCTestCase {
         metrics: metrics
       )
     )
+  }
+
+  func testEvaluatePreviewActivityRejectsConstantBackgroundNoise() {
+    let noise = (0 ..< 16_000).map { index in
+      Float(sin(Double(index) / 17.0) * 0.025)
+    }
+    let evaluation = SpeechActivityGate.evaluatePreviewActivity(samples: noise)
+    XCTAssertFalse(evaluation.hasActivity)
+  }
+
+  func testEvaluatePreviewActivityAcceptsWhisperLevelSpeech() {
+    let metrics = SpeechActivityMetrics(peakRMS: 0.010, peakSample: 0.074)
+    XCTAssertTrue(SpeechActivityGate.hasWhisperActivity(metrics))
+
+    let whisper = (0 ..< 12_000).map { index in
+      Float(sin(Double(index) / 45.0) * 0.08)
+    }
+    let evaluation = SpeechActivityGate.evaluatePreviewActivity(samples: whisper)
+    XCTAssertTrue(evaluation.hasActivity)
+  }
+
+  func testEvaluatePreviewActivityAcceptsHoldWindowDuringPause() {
+    let speech = (0 ..< 8_000).map { index in
+      Float(sin(Double(index) / 35.0) * 0.10)
+    }
+    let pause = [Float](repeating: 0.0005, count: 8_000)
+    let samples = speech + pause
+    let evaluation = SpeechActivityGate.evaluatePreviewActivity(samples: samples)
+    XCTAssertTrue(evaluation.hasActivity)
   }
 }

--- a/HexCore/Tests/HexCoreTests/SpeechActivityTests.swift
+++ b/HexCore/Tests/HexCoreTests/SpeechActivityTests.swift
@@ -14,6 +14,12 @@ final class SpeechActivityTests: XCTestCase {
     }
     let metrics = SpeechActivityMetrics.analyze(samples: speechLike)
     XCTAssertTrue(SpeechActivityGate.hasSpeechActivity(metrics))
+    XCTAssertTrue(SpeechActivityGate.hasStrongSpeechActivity(metrics))
+  }
+
+  func testPeakSampleAloneDoesNotCountAsSpeech() {
+    let metrics = SpeechActivityMetrics(peakRMS: 0.005, peakSample: 0.08)
+    XCTAssertFalse(SpeechActivityGate.hasSpeechActivity(metrics))
   }
 
   func testSilentTranscriptionFilterRejectsCommonHallucinations() {
@@ -22,20 +28,28 @@ final class SpeechActivityTests: XCTestCase {
     XCTAssertFalse(SilentTranscriptionFilter.isLikelyHallucination("The settings section seems fine"))
   }
 
-  func testShouldAcceptTranscriptionWithoutSpeechActivity() {
-    let metrics = SpeechActivityMetrics.zero
+  func testShouldRejectHallucinationOnWeakSpeechMetrics() {
+    let weakMetrics = SpeechActivityMetrics(peakRMS: 0.020, peakSample: 0.06)
+    XCTAssertTrue(SpeechActivityGate.hasSpeechActivity(weakMetrics))
+    XCTAssertFalse(SpeechActivityGate.hasStrongSpeechActivity(weakMetrics))
     XCTAssertFalse(
-      SilentTranscriptionFilter.shouldAcceptTranscription(text: "Thank you.", metrics: metrics)
+      SilentTranscriptionFilter.shouldAcceptTranscription(text: "Thank you.", metrics: weakMetrics)
     )
     XCTAssertFalse(
-      SilentTranscriptionFilter.shouldAcceptTranscription(text: "okay", metrics: metrics)
+      SilentTranscriptionFilter.shouldAcceptTranscription(text: "hello", metrics: weakMetrics)
     )
   }
 
-  func testShouldAcceptTranscriptionWithSpeechActivity() {
+  func testShouldAcceptTranscriptionWithStrongSpeechActivity() {
     let metrics = SpeechActivityMetrics(peakRMS: 0.05, peakSample: 0.12)
     XCTAssertTrue(
       SilentTranscriptionFilter.shouldAcceptTranscription(text: "Thank you.", metrics: metrics)
+    )
+    XCTAssertTrue(
+      SilentTranscriptionFilter.shouldAcceptTranscription(
+        text: "The settings section seems fine",
+        metrics: metrics
+      )
     )
   }
 }

--- a/HexCore/Tests/HexCoreTests/SpeechActivityTests.swift
+++ b/HexCore/Tests/HexCoreTests/SpeechActivityTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import HexCore
+
+final class SpeechActivityTests: XCTestCase {
+  func testAnalyzeDetectsSilence() {
+    let silent = [Float](repeating: 0, count: 16_000)
+    let metrics = SpeechActivityMetrics.analyze(samples: silent)
+    XCTAssertFalse(SpeechActivityGate.hasSpeechActivity(metrics))
+  }
+
+  func testAnalyzeDetectsSpeechLikeSignal() {
+    let speechLike = (0 ..< 16_000).map { index in
+      Float(sin(Double(index) / 40.0) * 0.08)
+    }
+    let metrics = SpeechActivityMetrics.analyze(samples: speechLike)
+    XCTAssertTrue(SpeechActivityGate.hasSpeechActivity(metrics))
+  }
+
+  func testSilentTranscriptionFilterRejectsCommonHallucinations() {
+    XCTAssertTrue(SilentTranscriptionFilter.isLikelyHallucination("Thank you."))
+    XCTAssertTrue(SilentTranscriptionFilter.isLikelyHallucination("okay"))
+    XCTAssertFalse(SilentTranscriptionFilter.isLikelyHallucination("The settings section seems fine"))
+  }
+
+  func testShouldAcceptTranscriptionWithoutSpeechActivity() {
+    let metrics = SpeechActivityMetrics.zero
+    XCTAssertFalse(
+      SilentTranscriptionFilter.shouldAcceptTranscription(text: "Thank you.", metrics: metrics)
+    )
+    XCTAssertFalse(
+      SilentTranscriptionFilter.shouldAcceptTranscription(text: "okay", metrics: metrics)
+    )
+  }
+
+  func testShouldAcceptTranscriptionWithSpeechActivity() {
+    let metrics = SpeechActivityMetrics(peakRMS: 0.05, peakSample: 0.12)
+    XCTAssertTrue(
+      SilentTranscriptionFilter.shouldAcceptTranscription(text: "Thank you.", metrics: metrics)
+    )
+  }
+}

--- a/HexTests/RecordingRaceTests.swift
+++ b/HexTests/RecordingRaceTests.swift
@@ -193,7 +193,7 @@ struct RecordingRaceTests {
       TranscriptionFeature()
     }
 
-    await store.send(.transcriptionResult("", audioURL, 1.25))
+    await store.send(.transcriptionResult("", audioURL, 1.25, .zero))
     await store.finish()
 
     #expect(!FileManager.default.fileExists(atPath: audioURL.path))
@@ -223,7 +223,14 @@ struct RecordingRaceTests {
       $0.soundEffects.play = { _ in }
     }
 
-    await store.send(.transcriptionResult("hello", audioURL, duration))
+    await store.send(
+      .transcriptionResult(
+        "hello",
+        audioURL,
+        duration,
+        SpeechActivityMetrics(peakRMS: 0.05, peakSample: 0.12)
+      )
+    )
     await store.finish()
 
     let storedDuration = await probe.duration

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -4,9 +4,6 @@
     "" : {
       "shouldTranslate" : false
     },
-    "(%@)" : {
-
-    },
     "%@ %@" : {
       "localizations" : {
         "en" : {
@@ -386,7 +383,13 @@
     "Input Monitoring is required so Hex can listen for your hotkey." : {
 
     },
+    "Insert at cursor" : {
+
+    },
     "Keep the microphone warm and prepend a short in-memory buffer for near-instant capture. macOS will keep showing the microphone indicator while this mode is armed." : {
+
+    },
+    "Live Preview" : {
 
     },
     "Match" : {
@@ -479,6 +482,9 @@
         }
       }
     },
+    "Overlay" : {
+
+    },
     "Override the system default microphone with a specific input device. This setting will persist across sessions." : {
 
     },
@@ -539,7 +545,7 @@
     "Preview" : {
 
     },
-    "Quit" : {
+    "Quit Hex" : {
 
     },
     "Refresh available input devices" : {
@@ -612,6 +618,7 @@
     },
     "Settings..." : {
       "comment" : "button in top bar for opening settings",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -620,6 +627,9 @@
           }
         }
       }
+    },
+    "Settings…" : {
+
     },
     "Show Changelog" : {
       "localizations" : {
@@ -646,6 +656,9 @@
 
     },
     "Show less" : {
+
+    },
+    "Show live transcription at the text cursor, or in Hex's floating overlay while recording." : {
 
     },
     "Show more" : {
@@ -711,6 +724,9 @@
       }
     },
     "Transforms" : {
+
+    },
+    "Unavailable Device" : {
 
     },
     "Unlimited" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -686,9 +686,6 @@
     "Show less" : {
 
     },
-    "Show live transcription at the text cursor, or in Hex's floating overlay while recording." : {
-
-    },
     "Show live transcription at the text cursor, or in Hex's floating overlay while recording. Requires a Parakeet model and Super Fast Mode." : {
       "localizations" : {
         "de" : {

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -384,13 +384,27 @@
 
     },
     "Insert at cursor" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Am Cursor einfügen"
+          }
+        }
+      }
     },
     "Keep the microphone warm and prepend a short in-memory buffer for near-instant capture. macOS will keep showing the microphone indicator while this mode is armed." : {
 
     },
     "Live Preview" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Vorschau"
+          }
+        }
+      }
     },
     "Match" : {
 
@@ -483,7 +497,14 @@
       }
     },
     "Overlay" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overlay"
+          }
+        }
+      }
     },
     "Override the system default microphone with a specific input device. This setting will persist across sessions." : {
 
@@ -546,7 +567,14 @@
 
     },
     "Quit Hex" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hex beenden"
+          }
+        }
+      }
     },
     "Refresh available input devices" : {
 
@@ -660,6 +688,16 @@
     },
     "Show live transcription at the text cursor, or in Hex's floating overlay while recording." : {
 
+    },
+    "Show live transcription at the text cursor, or in Hex's floating overlay while recording. Requires a Parakeet model and Super Fast Mode." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt die Live-Transkription am Textcursor oder in Hexs schwebendem Overlay während der Aufnahme. Erfordert ein Parakeet-Modell und den Super-Schnell-Modus."
+          }
+        }
+      }
     },
     "Show more" : {
 


### PR DESCRIPTION
Fixes #237

## Summary

- Show partial Parakeet transcription **while the hotkey is held**, not only after release
- **Insert at cursor** (Accessibility + keystroke fallback for Electron) or **Overlay** (Settings → Live Preview)
- Tag synthetic CGEvents (`SyntheticKeyboardEvent`) so modifier-only hotkeys are not false-released during live insertion
- Revert cursor preview on cancel/discard; reset Parakeet decoder before final pass; cap in-memory preview buffer at 10 minutes

## Test plan

- [ ] Hold modifier-only hotkey 30s in Cursor — recording continues until release
- [ ] Cursor mode: preview at caret; final text matches on release
- [ ] Overlay mode: no target-app mutation until release
- [ ] Esc cancel removes preview text from target app
- [ ] Short tap (< minimum key time) discards cleanly
- [ ] `cd HexCore && swift test --filter LivePreviewLogicTests` passes

## Notes

- Parakeet + Super Fast Mode required for live preview; Whisper unchanged
- Changeset: minor (`Show live dictation preview while recording (#237)`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live dictation preview during recording with real‑time transcript updates, optional insertion at cursor or floating overlay, and background live transcription support.

* **Settings & Configuration**
  * New "Live Preview" setting (Cursor vs Overlay) and automatic recording hotkey normalization/migration; reveal-in-Finder action added.

* **Improvements**
  * More robust hotkey/permission handling, live-audio monitoring/preview snapshotting, resilient recording lifecycle, and improved paste/keystroke insertion behavior.

* **Localization**
  * Added localized strings for Live Preview, Insert at cursor, Overlay, and related UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->