### PR TITLE
fix: respect user's minimumKeyTime for modifier-only hotkeys

### DIFF
--- a/HexCore/Sources/HexCore/Constants.swift
+++ b/HexCore/Sources/HexCore/Constants.swift
@@ -47,7 +47,7 @@ public enum HexCoreConstants {
     /// key within 1 second, it's likely accidental (fat-finger, muscle memory for different shortcut).
     /// After 1 second, we assume the user wants to type while recording.
     ///
-    /// Does NOT apply to modifier-only hotkeys (they use `modifierOnlyMinimumDuration` instead).
+    /// Does NOT apply to modifier-only hotkeys (they use the user's `minimumKeyTime` directly).
     ///
     /// **Used in:**
     /// - `HotKeyProcessor`: Accidental key press detection for key+modifier hotkeys
@@ -60,8 +60,7 @@ public enum HexCoreConstants {
     /// **Value:** 0.2 seconds
     ///
     /// **Rationale:** Prevents very quick accidental taps while still feeling responsive.
-    /// User-configurable in Settings. Modifier-only hotkeys override this with
-    /// `modifierOnlyMinimumDuration` if higher.
+    /// User-configurable in Settings. Applies to all hotkey types.
     ///
     /// **Used in:**
     /// - `HexSettings`: Default value for user preference

--- a/HexCore/Sources/HexCore/Logic/HotKeyProcessor.swift
+++ b/HexCore/Sources/HexCore/Logic/HotKeyProcessor.swift
@@ -43,7 +43,7 @@ private let hotKeyLogger = HexLog.hotKey
 /// For hotkeys with no key component (e.g., Option-only):
 /// - "Press" = all required modifiers held, no key pressed
 /// - "Release" = any required modifier released
-/// - Uses higher minimum duration (0.3s) to prevent conflicts with OS shortcuts
+/// - Uses user's `minimumKeyTime` setting as the discard threshold
 /// - Mouse clicks within threshold → silent discard (prevents Option+click conflicts)
 /// - After threshold, only ESC cancels (mouse clicks ignored)
 ///
@@ -135,7 +135,7 @@ public struct HotKeyProcessor {
     ///   - hotkey: The key combination to detect
     ///   - useDoubleTapOnly: If true, disables press-and-hold for key+modifier hotkeys
     ///   - doubleTapLockEnabled: If false, disables double-tap lock behavior
-    ///   - minimumKeyTime: Minimum duration for valid key press (overridden to modifierOnlyMinimumDuration for modifier-only)
+    ///   - minimumKeyTime: Minimum duration for valid key press (user configured)
     public init(
         hotkey: HotKey,
         useDoubleTapOnly: Bool = false,
@@ -232,9 +232,8 @@ public struct HotKeyProcessor {
         case let .pressAndHold(startTime):
             // Mouse click during modifier-only recording
             let elapsed = now.timeIntervalSince(startTime)
-            // For modifier-only hotkeys, use the same threshold as RecordingDecisionEngine
-            // (max of minimumKeyTime and 0.3s) to be consistent
-            let effectiveMinimum = max(minimumKeyTime, RecordingDecisionEngine.modifierOnlyMinimumDuration)
+            // Use the user's minimumKeyTime directly (consistent with RecordingDecisionEngine)
+            let effectiveMinimum = minimumKeyTime
             
             // Only discard if within threshold - after threshold, ignore clicks (only ESC cancels)
             if elapsed < effectiveMinimum {
@@ -396,7 +395,7 @@ extension HotKeyProcessor {
                 
                 // Modifier-only hotkeys: Only discard within threshold, ignore after
                 if hotkey.key == nil {
-                    let effectiveMinimum = max(minimumKeyTime, RecordingDecisionEngine.modifierOnlyMinimumDuration)
+                    let effectiveMinimum = minimumKeyTime
                     
                     if elapsed < effectiveMinimum {
                         // Within threshold => discard silently (accidental trigger)

--- a/HexCore/Sources/HexCore/Logic/RecordingDecision.swift
+++ b/HexCore/Sources/HexCore/Logic/RecordingDecision.swift
@@ -7,7 +7,7 @@ import Foundation
 public struct RecordingDecisionEngine {
     /// Minimum duration for modifier-only hotkeys to avoid OS shortcut conflicts.
     ///
-    /// This is applied regardless of user's minimumKeyTime setting.
+    /// Kept for reference; no longer enforced as a floor.
     /// See `HexCoreConstants.modifierOnlyMinimumDuration` for rationale.
     public static let modifierOnlyMinimumDuration: TimeInterval = HexCoreConstants.modifierOnlyMinimumDuration
     
@@ -52,8 +52,9 @@ public struct RecordingDecisionEngine {
     /// # Decision Logic
     ///
     /// **Modifier-only hotkeys** (e.g., Option):
-    /// - Must meet `max(minimumKeyTime, modifierOnlyMinimumDuration)`
-    /// - Always enforces 0.3s minimum to prevent OS shortcut conflicts
+    /// - Must meet `minimumKeyTime` (user configured)
+    /// - Default of 0.2s provides a reasonable guard against accidental triggers;
+    ///   users with obscure hotkeys (e.g. right Option) can lower it further
     ///
     /// **Key+modifier hotkeys** (e.g., Cmd+A):
     /// - Always proceeds to transcription (duration checked elsewhere)
@@ -65,11 +66,10 @@ public struct RecordingDecisionEngine {
         let elapsed = context.recordingStartTime.map { context.currentTime.timeIntervalSince($0) } ?? 0
         let includesPrintableKey = context.hotkey.key != nil
         
-        // For modifier-only hotkeys, use the higher of minimumKeyTime or modifierOnlyMinimumDuration
-        // to prevent conflicts with system shortcuts
-        let effectiveMinimum = includesPrintableKey 
-            ? context.minimumKeyTime 
-            : max(context.minimumKeyTime, modifierOnlyMinimumDuration)
+        // Respect the user's minimumKeyTime setting directly.
+        // Previously enforced a 0.3s floor for modifier-only hotkeys, but users with
+        // obscure hotkeys (e.g. right Option) may want faster response.
+        let effectiveMinimum = context.minimumKeyTime
         
         let durationIsLongEnough = elapsed >= effectiveMinimum
         return (durationIsLongEnough || includesPrintableKey) ? .proceedToTranscription : .discardShortRecording

--- a/HexCore/Tests/HexCoreTests/HotKeyProcessorTests.swift
+++ b/HexCore/Tests/HexCoreTests/HotKeyProcessorTests.swift
@@ -358,7 +358,7 @@ struct HotKeyProcessorTests {
                 ScenarioStep(time: 0.05, key: nil, modifiers: [],    expectedOutput: nil, expectedIsMatched: false),
                 // Next standalone Fn press should trigger recording
                 ScenarioStep(time: 0.20, key: nil, modifiers: [.fn], expectedOutput: .startRecording, expectedIsMatched: true),
-                // Release Fn should stop recording (must exceed modifierOnlyMinimumDuration)
+                // Release Fn should stop recording (must exceed minimumKeyTime)
                 ScenarioStep(time: 0.40, key: nil, modifiers: [],    expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
@@ -378,7 +378,7 @@ struct HotKeyProcessorTests {
                 // Only once the user fully releases and presses Fn again should it start
                 ScenarioStep(time: 0.10, key: nil, modifiers: [],    expectedOutput: nil, expectedIsMatched: false),
                 ScenarioStep(time: 0.25, key: nil, modifiers: [.fn], expectedOutput: .startRecording, expectedIsMatched: true),
-                // Must exceed modifierOnlyMinimumDuration before stopping
+                // Must exceed minimumKeyTime before stopping
                 ScenarioStep(time: 0.60, key: nil, modifiers: [],    expectedOutput: .stopRecording, expectedIsMatched: false),
             ]
         )
@@ -738,8 +738,8 @@ struct RecordingDecisionTests {
 
     @Test
     func longPressModifierOnlyProceeds() {
-        // Duration at modifierOnlyMinimumDuration threshold (0.3s)
-        let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), duration: 0.3)
+        // Duration above default minimumKeyTime (0.2s)
+        let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), duration: 0.2)
         #expect(RecordingDecisionEngine.decide(ctx) == .proceedToTranscription)
     }
 
@@ -757,29 +757,29 @@ struct RecordingDecisionTests {
     // MARK: - Modifier-Only Minimum Duration Tests
     
     @Test
-    func modifierOnly_enforcesMinimumDuration_0_3s() {
-        // User sets minimumKeyTime to 0.1s, but modifier-only enforces modifierOnlyMinimumDuration (0.3s)
-        let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), minimumKeyTime: 0.1, duration: 0.25)
+    func modifierOnly_respectsUserMinimumKeyTime() {
+        // User sets minimumKeyTime to 0.1s, modifier-only hotkey respects it directly
+        let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), minimumKeyTime: 0.1, duration: 0.05)
         #expect(RecordingDecisionEngine.decide(ctx) == .discardShortRecording)
     }
     
     @Test
-    func modifierOnly_proceedsWhenAboveMinimumDuration() {
-        // User sets minimumKeyTime to 0.1s, recording is 0.35s (above modifierOnlyMinimumDuration)
-        let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), minimumKeyTime: 0.1, duration: 0.35)
+    func modifierOnly_proceedsWhenAboveUserMinimumKeyTime() {
+        // User sets minimumKeyTime to 0.1s, recording is 0.15s (above user setting)
+        let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), minimumKeyTime: 0.1, duration: 0.15)
         #expect(RecordingDecisionEngine.decide(ctx) == .proceedToTranscription)
     }
     
     @Test
     func modifierOnly_respectsUserPreferenceWhenHigher() {
-        // User sets minimumKeyTime to 0.5s (higher than modifierOnlyMinimumDuration)
+        // User sets minimumKeyTime to 0.5s
         let ctx = makeContext(hotkey: HotKey(key: nil, modifiers: [.option]), minimumKeyTime: 0.5, duration: 0.4)
         #expect(RecordingDecisionEngine.decide(ctx) == .discardShortRecording)
     }
     
     @Test
     func printableKey_doesNotEnforceModifierOnlyMinimum() {
-        // Printable key hotkeys use user's minimumKeyTime, not modifierOnlyMinimumDuration
+        // Printable key hotkeys use user's minimumKeyTime
         let ctx = makeContext(hotkey: HotKey(key: .a, modifiers: [.command]), minimumKeyTime: 0.1, duration: 0.15)
         #expect(RecordingDecisionEngine.decide(ctx) == .proceedToTranscription)
     }
@@ -804,9 +804,9 @@ struct MouseClickTests {
         }
         #expect(startOutput == .startRecording)
         
-        // Mouse click 0.25s later (< 0.3s threshold for modifier-only) should discard silently
+        // Mouse click 0.1s later (< 0.15s minimumKeyTime) should discard silently
         let clickOutput = withDependencies {
-            $0.date.now = Date(timeIntervalSince1970: 0.25)
+            $0.date.now = Date(timeIntervalSince1970: 0.1)
         } operation: {
             processor.processMouseClick()
         }
@@ -829,9 +829,9 @@ struct MouseClickTests {
         }
         #expect(startOutput == .startRecording)
         
-        // Mouse click 0.35s later (> 0.3s threshold) should be ignored - only ESC cancels
+        // Mouse click 0.2s later (> 0.15s minimumKeyTime) should be ignored - only ESC cancels
         let clickOutput = withDependencies {
-            $0.date.now = Date(timeIntervalSince1970: 0.35)
+            $0.date.now = Date(timeIntervalSince1970: 0.2)
         } operation: {
             processor.processMouseClick()
         }
@@ -923,7 +923,7 @@ struct MouseClickTests {
         }
         #expect(startOutput == .startRecording)
         
-        // Mouse click 0.4s later (> 0.3s but < 0.5s user preference) should still discard
+        // Mouse click 0.4s later (< 0.5s user minimumKeyTime) should still discard
         let clickOutput = withDependencies {
             $0.date.now = Date(timeIntervalSince1970: 0.4)
         } operation: {


### PR DESCRIPTION
## Summary

Remove the hardcoded 0.3s floor that was enforced for modifier-only hotkeys regardless of the user's `minimumKeyTime` setting. The Settings slider already allows values down to 0.0s, but `max(minimumKeyTime, 0.3)` silently overrode it.

Users with obscure hotkeys (e.g. right Option) that don't conflict with OS shortcuts should be able to set a lower threshold for faster response. The default of 0.2s still provides a reasonable guard against accidental triggers.

## Changes

- **`RecordingDecisionEngine.decide()`** — use `minimumKeyTime` directly instead of `max(minimumKeyTime, modifierOnlyMinimumDuration=0.3)`
- **`HotKeyProcessor.process(keyEvent:)`** — same for extra key press threshold during hold
- **`HotKeyProcessor.processMouseClick()`** — same for mouse click cancellation threshold
- Updated tests and doc comments to reflect the new behavior

The `modifierOnlyMinimumDuration` constant is kept for reference but no longer enforced as a floor.

## Testing

All 62 existing tests pass with updated assertions. No new tests added — existing tests were adjusted to verify that the user's `minimumKeyTime` is respected directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modifier-only hotkeys now respect the user-configured minimum key time directly, removing a previously enforced separate minimum duration constraint.

* **Documentation**
  * Updated hotkey timing constant descriptions to reflect the new modifier-only hotkey behavior.

* **Tests**
  * Adjusted timing-related test cases to align with updated modifier-only hotkey minimum duration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->