### PR TITLE
Agent Plugins: a voice window for Claude Code

### DIFF
--- a/.changeset/agent-autosend.md
+++ b/.changeset/agent-autosend.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Auto-send pasted or dictated replies in the agent window after a short countdown, and let Shift+Enter send too

--- a/.changeset/agent-hook-single-instance.md
+++ b/.changeset/agent-hook-single-instance.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Fix the Agent Plugins hook launching extra Hex instances when multiple Claude terminals are open. The hook now delivers its deeplink to the specific Hex that installed it (by bundle id, then exact app path) instead of letting the `hex://` URL scheme pick any registered Hex, so every terminal talks to one window and the request queue coalesces. Existing installs self-heal: the hook script is rewritten on launch when out of date.

--- a/.changeset/agent-per-session-voices.md
+++ b/.changeset/agent-per-session-voices.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add a "Distinct Voice per Project" option (Settings → Agent Plugins) so each Claude session is read aloud in its own consistent voice — your first/primary session keeps your chosen default voice, and additional sessions get distinct voices that stay the same across turns (even when a project is the only one active), making it easy to tell projects apart by ear. Enabling it preloads the Kokoro model so the extra voices are ready on first use.

--- a/.changeset/agent-plugins.md
+++ b/.changeset/agent-plugins.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add Agent Plugins: a voice window for Claude Code. When Claude Code finishes a turn, asks a question, or requests a permission, Hex pops a floating window showing the prompt with a field you can dictate or type a reply into. Answers are delivered in-band: the Claude Code hook blocks while Hex is open, and Hex answers it directly (Stop follow-ups, AskUserQuestion answers, permission allow/deny) — no terminal focusing or synthetic keystrokes, so replies always reach the right session even while you work in another app. Answering in the terminal instead just dismisses the Hex window. Includes a new Agent Plugins settings tab with one-click install of the Claude Code hooks.

--- a/.changeset/agent-session-queue.md
+++ b/.changeset/agent-session-queue.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Queue multiple blocked Claude sessions in the Agent voice window instead of dropping all but the newest. Each waiting session gets its own card (one per project) with its own draft reply, the card header shows the project and host app plus an `n / N` position when several are waiting, concurrent sessions are read aloud in distinct voices, and quitting Hex now releases every blocked hook so no session hangs on its timeout.

--- a/.changeset/agent-speak-output.md
+++ b/.changeset/agent-speak-output.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add a speaker toggle to the agent window that reads Claude's output aloud via text-to-speech, with a voice picker in Agent Plugins settings

--- a/.changeset/agent-summon-hotkey.md
+++ b/.changeset/agent-summon-hotkey.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add a global hotkey that summons the agent window from anywhere and targets the running Claude Code terminal

--- a/.changeset/e0e78381.md
+++ b/.changeset/e0e78381.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Read agent replies aloud as a condensed, TTS-friendly summary: skip code blocks, read link labels not URLs, and surface the spoken text as a collapsible section in the panel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,19 @@ FluidAudio models reside under `Application Support/FluidAudio/Models`.
 - Settings → Transcription Model shows a compact list with radio selection, accuracy/speed dots, size on right, and trailing menu / download‑check icon.
 - Context menu offers Show in Finder / Delete.
 
+## Agent Voice Replies (`Spoken:` line)
+
+When working in this repo via the Hex Agent Plugins voice window, **end every reply with a `Spoken:` line** — a TTS-ready version Hex reads aloud and surfaces as a banner above the full detail. Keep the written reply above it as detailed as usual. The `Spoken:` line is what the user *hears*, so it should be a **condensed version of the reply (keep ~60% of the substance), not a micro-summary** — preserve every action taken and every decision/ask; drop only pleasantries, redundancy, file/symbol names, code, and exact paths. Usually 2–4 sentences, ending with the question when you need input. See `SpokenText.swift` — if no `Spoken:` line is present Hex falls back to a ~60% heuristic condense, so the marker is how you control the spoken output precisely.
+
+Example:
+
+```
+Rebuilt and relaunched. The speaker button now has a solid backing circle, opaque blue
+when on and muted gray when off, and I dropped it to 20×20 to match the row.
+Spoken: Rebuilt and relaunched — the speaker button now has a solid circle, blue when
+on and gray when off, sized to match the row. Want it bigger or a different color?
+```
+
 ## Troubleshooting
 
 - Repeated mic prompts during debug: ensure Debug signing uses "Apple Development" so TCC sticks

--- a/Hex.xcodeproj/project.pbxproj
+++ b/Hex.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		47E05E0A2D44525B00D26DA6 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E092D44525B00D26DA6 /* Dependencies */; };
 		47E05E0C2D44525B00D26DA6 /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 47E05E0B2D44525B00D26DA6 /* DependenciesMacros */; };
 		47E16A622EC6C9D300885CF7 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 47E16A612EC6C9D300885CF7 /* FluidAudio */; };
+		47E16A712EC6C9D300885CF7 /* FluidAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = 47E16A702EC6C9D300885CF7 /* FluidAudioTTS */; };
 		B5045C972D78DED500D0A119 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = B5045C962D78DED500D0A119 /* MarkdownUI */; };
 		B53356002D7B8D4900E5F542 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B53355FF2D7B8D4900E5F542 /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
@@ -89,6 +90,7 @@
 				47512ABF2E14D8C9000E25BA /* WhisperKit in Frameworks */,
 				47E05E052D444EF800D26DA6 /* Sauce in Frameworks */,
 				47E16A622EC6C9D300885CF7 /* FluidAudio in Frameworks */,
+				47E16A712EC6C9D300885CF7 /* FluidAudioTTS in Frameworks */,
 				47C08AB62DE9F61B00564AE6 /* Inject in Frameworks */,
 				4765045E2D45900200C7EA60 /* Pow in Frameworks */,
 				47E05E0C2D44525B00D26DA6 /* DependenciesMacros in Frameworks */,
@@ -185,6 +187,7 @@
 				47512ABE2E14D8C9000E25BA /* WhisperKit */,
 				476316262E5FB31400913CDE /* HexCore */,
 				47E16A612EC6C9D300885CF7 /* FluidAudio */,
+				47E16A702EC6C9D300885CF7 /* FluidAudioTTS */,
 			);
 			productName = Hex;
 			productReference = 47E05DEE2D444EC600D26DA6 /* Hex Debug.app */;
@@ -355,7 +358,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = QC99C9JE59;
+				DEVELOPMENT_TEAM = G9R5L25MR8;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -421,7 +424,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = QC99C9JE59;
+				DEVELOPMENT_TEAM = G9R5L25MR8;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -456,9 +459,9 @@
 				CURRENT_PROJECT_VERSION = 86;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Hex/Preview Content\"";
-				DEVELOPMENT_TEAM = QC99C9JE59;
+				DEVELOPMENT_TEAM = G9R5L25MR8;
 				EMIT_FRONTEND_COMMAND_LINES = YES;
-				ENABLE_APP_SANDBOX = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -511,9 +514,9 @@
 				CURRENT_PROJECT_VERSION = 86;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Hex/Preview Content\"";
-				DEVELOPMENT_TEAM = QC99C9JE59;
+				DEVELOPMENT_TEAM = G9R5L25MR8;
 				EMIT_FRONTEND_COMMAND_LINES = NO;
-				ENABLE_APP_SANDBOX = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
@@ -711,6 +714,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 47E16A602EC6C9D300885CF7 /* XCRemoteSwiftPackageReference "FluidAudio" */;
 			productName = FluidAudio;
+		};
+		47E16A702EC6C9D300885CF7 /* FluidAudioTTS */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 47E16A602EC6C9D300885CF7 /* XCRemoteSwiftPackageReference "FluidAudio" */;
+			productName = FluidAudioTTS;
 		};
 		B5045C962D78DED500D0A119 /* MarkdownUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Hex/App/HexAppDelegate.swift
+++ b/Hex/App/HexAppDelegate.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ComposableArchitecture
 import HexCore
 import SwiftUI
@@ -8,8 +9,14 @@ private let cacheLogger = HexLog.caches
 class HexAppDelegate: NSObject, NSApplicationDelegate {
 	var invisibleWindow: InvisibleWindow?
 	var settingsWindow: NSWindow?
+	var agentWindow: AgentPanel?
 	var statusItem: NSStatusItem!
 	private var launchedAtLogin = false
+
+	/// The most recent non-Hex app to come to the foreground — the terminal we paste
+	/// agent replies back into. Tracked because opening the hex:// URL activates Hex.
+	private var lastForegroundApp: NSRunningApplication?
+	private var agentVisibilityToken: ObserveToken?
 
 	@Dependency(\.soundEffects) var soundEffect
 	@Dependency(\.recording) var recording
@@ -42,6 +49,21 @@ class HexAppDelegate: NSObject, NSApplicationDelegate {
 			name: .updateAppMode,
 			object: nil
 		)
+
+		// Track the foreground app so Agent Plugins can paste back into the terminal.
+		startTrackingForegroundApp()
+
+		// Show/hide the agent voice window whenever the feature's visibility changes.
+		agentVisibilityToken = observe { [weak self] in
+			guard let self else { return }
+			let visible = HexApp.appStore.agent.isVisible
+			appLogger.notice("Agent panel visibility observed: \(visible, privacy: .public)")
+			if visible {
+				self.showAgentPanel()
+			} else {
+				self.hideAgentPanel()
+			}
+		}
 
 		// Start long-running app effects (global hotkeys, permissions, etc.)
 		startLifecycleTasksIfNeeded()
@@ -131,6 +153,76 @@ class HexAppDelegate: NSObject, NSApplicationDelegate {
 		self.settingsWindow = settingsWindow
 	}
 
+	// MARK: - Agent Plugins (Claude Code integration)
+
+	private func startTrackingForegroundApp() {
+		lastForegroundApp = NSWorkspace.shared.frontmostApplication
+		NSWorkspace.shared.notificationCenter.addObserver(
+			self,
+			selector: #selector(activeAppDidChange(_:)),
+			name: NSWorkspace.didActivateApplicationNotification,
+			object: nil
+		)
+	}
+
+	@objc private func activeAppDidChange(_ notification: Notification) {
+		guard
+			let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+			app.bundleIdentifier != Bundle.main.bundleIdentifier
+		else { return }
+		lastForegroundApp = app
+	}
+
+	/// Handles `hex://agent-update?…` deeplinks fired by the Claude Code hook script.
+	func application(_: NSApplication, open urls: [URL]) {
+		for url in urls where url.scheme == "hex" {
+			handleHexURL(url)
+		}
+	}
+
+	private func handleHexURL(_ url: URL) {
+		appLogger.notice("Received hex URL: \(url.absoluteString, privacy: .public)")
+		guard url.host == "agent-update" else {
+			appLogger.notice("Ignoring unknown hex URL host: \(url.host ?? "nil", privacy: .public)")
+			return
+		}
+		let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+		func value(_ name: String) -> String? {
+			items.first { $0.name == name }?.value
+		}
+
+		let source = lastForegroundApp
+		let payload = AgentFeature.ShowPayload(
+			event: value("event"),
+			tool: value("tool"),
+			sessionID: value("session"),
+			cwd: value("cwd"),
+			transcriptPath: value("transcript"),
+			payloadPath: value("payload"),
+			inlineMessage: value("message"),
+			sourceAppBundleID: source?.bundleIdentifier,
+			sourceAppName: source?.localizedName,
+			sourceAppPID: source?.processIdentifier
+		)
+		Task { @MainActor in
+			HexApp.appStore.send(.agent(.show(payload)))
+		}
+	}
+
+	private func showAgentPanel() {
+		if agentWindow == nil {
+			let agentStore = HexApp.appStore.scope(state: \.agent, action: \.agent)
+			agentWindow = AgentPanel.fromView(AgentView(store: agentStore))
+		}
+		agentWindow?.positionNearMouse()
+		agentWindow?.orderFrontRegardless()
+		agentWindow?.makeKey()
+	}
+
+	private func hideAgentPanel() {
+		agentWindow?.orderOut(nil)
+	}
+
 	@objc private func handleAppModeUpdate() {
 		Task {
 			await updateAppMode()
@@ -153,6 +245,13 @@ class HexAppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func applicationWillTerminate(_: Notification) {
+		// Release every still-blocked agent hook so quitting Hex never leaves a Claude
+		// session hanging on its 600s timeout. An empty response yields to the terminal UI.
+		for request in HexApp.appStore.agent.requests {
+			if let payloadPath = request.payloadPath {
+				AgentHookResponder.respond(payloadPath: payloadPath, json: nil)
+			}
+		}
 		Task {
 			await recording.cleanup()
 		}

--- a/Hex/Clients/AgentTranscriptClient.swift
+++ b/Hex/Clients/AgentTranscriptClient.swift
@@ -1,0 +1,158 @@
+//
+//  AgentTranscriptClient.swift
+//  Hex
+//
+//  Decides what the agent window should show. For PreToolUse (AskUserQuestion) and
+//  PermissionRequest it reads the hook's own payload file — the CURRENT tool_input,
+//  which is authoritative. The transcript is only used for the plain "last message"
+//  case (Stop), since the current tool call may not be flushed yet at PreToolUse time.
+//
+
+import ComposableArchitecture
+import Dependencies
+import DependenciesMacros
+import Foundation
+import HexCore
+
+private let agentLogger = HexLog.app
+
+/// What Claude Code is presenting to the user.
+enum AgentPrompt: Equatable, Sendable {
+  case message(String)              // plain assistant text (markdown)
+  case question(AgentQuestion)      // AskUserQuestion multiple choice
+  case permission(AgentPermission)  // tool awaiting allow/deny
+}
+
+struct AgentQuestion: Equatable, Sendable {
+  var header: String
+  var question: String
+  var multiSelect: Bool
+  var options: [AgentOption]
+}
+
+struct AgentOption: Equatable, Sendable, Identifiable {
+  var label: String
+  var detail: String
+  var id: String { label }
+}
+
+struct AgentPermission: Equatable, Sendable {
+  var tool: String
+  var summary: String   // e.g. the Bash command or the file path
+}
+
+@DependencyClient
+struct AgentTranscriptClient {
+  /// Resolves the prompt to display.
+  /// - payloadPath: temp file the hook wrote with the full hook JSON (incl. tool_input).
+  /// - transcriptPath: the session transcript (.jsonl), used for the last-message fallback.
+  var latestPrompt: @Sendable (_ payloadPath: String?, _ transcriptPath: String?) async throws -> AgentPrompt = { _, _ in .message("") }
+}
+
+extension AgentTranscriptClient: DependencyKey {
+  static var liveValue: Self {
+    .init(latestPrompt: { payloadPath, transcriptPath in
+      // 1) Authoritative: the hook payload holds the CURRENT event + tool_input.
+      if let hook = readJSON(payloadPath) {
+        let event = hook["hook_event_name"] as? String ?? ""
+        let toolName = hook["tool_name"] as? String ?? ""
+        let input = hook["tool_input"] as? [String: Any]
+
+        if toolName == "AskUserQuestion", let input, let q = question(from: input) {
+          return .question(q)
+        }
+        if event == "PermissionRequest" {
+          return .permission(AgentPermission(tool: toolName, summary: permissionSummary(toolName, input)))
+        }
+        // Stop payloads carry the final text directly — no transcript parse needed.
+        if let last = hook["last_assistant_message"] as? String, !last.isEmpty {
+          return .message(last)
+        }
+      }
+
+      // 2) Fallback (Stop / Notification): the last assistant text from the transcript.
+      if let transcriptPath {
+        let expanded = (transcriptPath as NSString).expandingTildeInPath
+        if let contents = try? String(contentsOf: URL(fileURLWithPath: expanded), encoding: .utf8) {
+          let lines = contents.split(separator: "\n", omittingEmptySubsequences: true)
+          return .message(lastAssistantText(lines))
+        }
+      }
+      return .message("")
+    })
+  }
+}
+
+private func readJSON(_ path: String?) -> [String: Any]? {
+  guard let path, !path.isEmpty else { return nil }
+  let expanded = (path as NSString).expandingTildeInPath
+  guard let data = try? Data(contentsOf: URL(fileURLWithPath: expanded)) else { return nil }
+  return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+}
+
+/// Parses an AskUserQuestion tool_input into a question (first question only).
+private func question(from input: [String: Any]) -> AgentQuestion? {
+  guard
+    let questions = input["questions"] as? [[String: Any]],
+    let first = questions.first
+  else { return nil }
+
+  let options = (first["options"] as? [[String: Any]] ?? []).map {
+    AgentOption(label: $0["label"] as? String ?? "", detail: $0["description"] as? String ?? "")
+  }
+  return AgentQuestion(
+    header: first["header"] as? String ?? "",
+    question: first["question"] as? String ?? "",
+    multiSelect: first["multiSelect"] as? Bool ?? false,
+    options: options
+  )
+}
+
+/// A short human-readable summary of what a tool wants to do, for the permission card.
+private func permissionSummary(_ tool: String, _ input: [String: Any]?) -> String {
+  guard let input else { return tool }
+  for key in ["command", "file_path", "path", "url", "pattern", "description"] {
+    if let value = input[key] as? String, !value.isEmpty { return value }
+  }
+  if let data = try? JSONSerialization.data(withJSONObject: input, options: [.sortedKeys]),
+     let s = String(data: data, encoding: .utf8) {
+    return s.count > 300 ? String(s.prefix(300)) + "…" : s
+  }
+  return tool
+}
+
+/// Last assistant message's joined text blocks (bottom-up, stopping at the user turn).
+private func lastAssistantText(_ lines: [Substring]) -> String {
+  var collected: [String] = []
+  for line in lines.reversed() {
+    guard let obj = parseLine(line), let type = obj["type"] as? String else { continue }
+    if type == "assistant" {
+      if let text = textBlocks(obj), !text.isEmpty { collected.append(text) }
+    } else if type == "user", !collected.isEmpty {
+      break
+    }
+  }
+  return collected.reversed().joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func textBlocks(_ obj: [String: Any]) -> String? {
+  guard let message = obj["message"] as? [String: Any] else { return nil }
+  if let blocks = message["content"] as? [[String: Any]] {
+    let texts = blocks.compactMap { ($0["type"] as? String) == "text" ? $0["text"] as? String : nil }
+    return texts.isEmpty ? nil : texts.joined(separator: "\n")
+  }
+  if let text = message["content"] as? String { return text }
+  return nil
+}
+
+private func parseLine(_ line: Substring) -> [String: Any]? {
+  guard let data = line.data(using: .utf8) else { return nil }
+  return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+}
+
+extension DependencyValues {
+  var agentTranscript: AgentTranscriptClient {
+    get { self[AgentTranscriptClient.self] }
+    set { self[AgentTranscriptClient.self] = newValue }
+  }
+}

--- a/Hex/Clients/ClaudePluginClient.swift
+++ b/Hex/Clients/ClaudePluginClient.swift
@@ -1,0 +1,321 @@
+//
+//  ClaudePluginClient.swift
+//  Hex
+//
+//  Installs/uninstalls the Hex ↔ Claude Code integration by writing a local hook
+//  script under ~/.claude and merging hook registrations into ~/.claude/settings.json.
+//  No GitHub marketplace required — everything lives on the user's machine.
+//
+//  Requires the app to be UNSANDBOXED (see Hex.entitlements) so it can read/write
+//  the real ~/.claude directory.
+//
+
+import ComposableArchitecture
+import Dependencies
+import DependenciesMacros
+import Foundation
+import HexCore
+
+private let pluginLogger = HexLog.app
+
+@DependencyClient
+struct ClaudePluginClient {
+  /// True if the Hex hook script exists and is referenced by ~/.claude/settings.json.
+  var isInstalled: @Sendable () async -> Bool = { false }
+  /// Writes the hook script and registers all five hook events.
+  var install: @Sendable () async throws -> Void
+  /// Removes Hex's hook registrations and deletes the hook script directory.
+  var uninstall: @Sendable () async throws -> Void
+  /// If the hook is installed but its script is out of date (e.g. an app update changed
+  /// the delivery logic), rewrite the script in place. No-op when not installed.
+  var refreshIfStale: @Sendable () async -> Void = {}
+}
+
+extension ClaudePluginClient: DependencyKey {
+  static var liveValue: Self {
+    let live = ClaudePluginClientLive()
+    return .init(
+      isInstalled: { live.isInstalled() },
+      install: { try live.install() },
+      uninstall: { try live.uninstall() },
+      refreshIfStale: { live.refreshIfStale() }
+    )
+  }
+}
+
+extension DependencyValues {
+  var claudePlugin: ClaudePluginClient {
+    get { self[ClaudePluginClient.self] }
+    set { self[ClaudePluginClient.self] = newValue }
+  }
+}
+
+// MARK: - Live implementation
+
+struct ClaudePluginClientLive {
+  /// Hook events to register, with their matcher. Empty matcher == match all.
+  /// PreToolUse only fires our window when Claude asks a question.
+  // Fire at the end of a turn, and on the two moments that genuinely need user input:
+  // a multiple-choice question and a permission request. We deliberately skip the noisy
+  // Notification hook that pops mid-conversation.
+  private let events: [(event: String, matcher: String)] = [
+    ("Stop", ""),
+    ("PreToolUse", "AskUserQuestion"),
+    ("PermissionRequest", ""),
+    // Bookkeeping only: when the user answers directly in the terminal, release any
+    // hooks still blocked waiting on Hex and hide the Hex panel.
+    ("UserPromptSubmit", ""),
+  ]
+
+  private var claudeDir: URL {
+    URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".claude", isDirectory: true)
+  }
+  private var hexDir: URL { claudeDir.appendingPathComponent("hex", isDirectory: true) }
+  private var scriptURL: URL { hexDir.appendingPathComponent("hex-agent-hook.sh") }
+  private var settingsURL: URL { claudeDir.appendingPathComponent("settings.json") }
+  private var scriptPath: String { scriptURL.path }
+
+  // MARK: Status
+
+  func isInstalled() -> Bool {
+    guard FileManager.default.fileExists(atPath: scriptPath) else { return false }
+    guard let hooks = readSettings()["hooks"] as? [String: Any] else { return false }
+    return hooks.values.contains { value in
+      guard let groups = value as? [[String: Any]] else { return false }
+      return groups.contains { groupReferencesScript($0) }
+    }
+  }
+
+  // MARK: Install
+
+  func install() throws {
+    try FileManager.default.createDirectory(at: hexDir, withIntermediateDirectories: true)
+    // Bake in OUR bundle id + path so the hook delivers the deeplink to this exact Hex,
+    // never launching a different (or extra) Hex that also claims the hex:// scheme.
+    let bundleID = Bundle.main.bundleIdentifier ?? "com.kitlangton.Hex"
+    let appPath = Bundle.main.bundlePath
+    try Self.hookScript(bundleID: bundleID, appPath: appPath)
+      .write(to: scriptURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptPath)
+
+    var settings = readSettings()
+    var hooks = settings["hooks"] as? [String: Any] ?? [:]
+
+    for (event, matcher) in events {
+      var groups = hooks[event] as? [[String: Any]] ?? []
+      // Re-register from scratch so upgrades (e.g. the blocking timeout) take effect.
+      groups.removeAll { groupReferencesScript($0) }
+      groups.append([
+        "matcher": matcher,
+        "hooks": [["type": "command", "command": scriptPath, "timeout": 600]],
+      ])
+      hooks[event] = groups
+    }
+
+    settings["hooks"] = hooks
+    try writeSettings(settings)
+    pluginLogger.notice("Installed Claude Code agent hooks at \(self.scriptPath, privacy: .private)")
+  }
+
+  // MARK: Refresh
+
+  /// Rewrites the hook script if it exists but doesn't match what this app would install
+  /// now. Only touches the script file — the settings.json registration points at the same
+  /// path, so it needs no change. Cheap to call on every launch (skips when already current).
+  func refreshIfStale() {
+    guard FileManager.default.fileExists(atPath: scriptPath) else { return }
+    let bundleID = Bundle.main.bundleIdentifier ?? "com.kitlangton.Hex"
+    let desired = Self.hookScript(bundleID: bundleID, appPath: Bundle.main.bundlePath)
+    let current = try? String(contentsOf: scriptURL, encoding: .utf8)
+    guard current != desired else { return }
+    do {
+      try desired.write(to: scriptURL, atomically: true, encoding: .utf8)
+      try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptPath)
+      pluginLogger.notice("Refreshed Claude Code agent hook script for \(bundleID, privacy: .public)")
+    } catch {
+      pluginLogger.error("Failed to refresh agent hook script: \(error.localizedDescription)")
+    }
+  }
+
+  // MARK: Uninstall
+
+  func uninstall() throws {
+    var settings = readSettings()
+    if var hooks = settings["hooks"] as? [String: Any] {
+      for (event, _) in events {
+        guard var groups = hooks[event] as? [[String: Any]] else { continue }
+        groups.removeAll { groupReferencesScript($0) }
+        if groups.isEmpty {
+          hooks.removeValue(forKey: event)
+        } else {
+          hooks[event] = groups
+        }
+      }
+      if hooks.isEmpty {
+        settings.removeValue(forKey: "hooks")
+      } else {
+        settings["hooks"] = hooks
+      }
+      try writeSettings(settings)
+    }
+
+    if FileManager.default.fileExists(atPath: hexDir.path) {
+      try FileManager.default.removeItem(at: hexDir)
+    }
+    pluginLogger.notice("Uninstalled Claude Code agent hooks")
+  }
+
+  // MARK: Helpers
+
+  /// Whether a hook group references our script (so we can find/remove only ours).
+  private func groupReferencesScript(_ group: [String: Any]) -> Bool {
+    guard let entries = group["hooks"] as? [[String: Any]] else { return false }
+    return entries.contains { ($0["command"] as? String) == scriptPath }
+  }
+
+  private func readSettings() -> [String: Any] {
+    guard
+      let data = try? Data(contentsOf: settingsURL),
+      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return [:] }
+    return obj
+  }
+
+  private func writeSettings(_ settings: [String: Any]) throws {
+    let data = try JSONSerialization.data(
+      withJSONObject: settings,
+      options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    )
+    try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+    try data.write(to: settingsURL, options: .atomic)
+  }
+
+  // MARK: Hook script
+
+  /// Reads the Claude Code hook JSON on stdin, opens a `hex://agent-update` deeplink, then
+  /// BLOCKS polling for `<payload>.response`. Hex writes the complete hook-output JSON into
+  /// that file (or an empty file for "dismissed, yield to the terminal UI") and this script
+  /// relays it on stdout. The answer travels in-band to the exact Claude session — no app
+  /// focusing, no synthetic keystrokes. Prefers jq, falls back to python3.
+  ///
+  /// `bundleID` and `appPath` identify the installing app, baked into the script so every
+  /// invocation targets that exact Hex (`open -b`, then `open -a` as a fallback) rather than
+  /// letting the URL scheme launch a different — or extra — Hex.
+  static func hookScript(bundleID: String, appPath: String) -> String {
+    hookScriptTemplate
+      .replacingOccurrences(of: "__HEX_BUNDLE_ID__", with: bundleID)
+      .replacingOccurrences(of: "__HEX_APP_PATH__", with: appPath)
+  }
+
+  private static let hookScriptTemplate: String = #"""
+  #!/bin/sh
+  # Hex Agent Plugins hook — bridges Claude Code to the Hex voice window.
+  # Installed and managed by Hex.app (Settings → Agent Plugins). Safe to delete there.
+  input=$(cat)
+
+  # The exact Hex that installed this hook. Delivering the deeplink to this specific app
+  # keeps every Claude terminal talking to one Hex window — otherwise the hex:// scheme can
+  # launch a different, or additional, Hex and the queue never coalesces. We try the bundle
+  # id first (survives the app moving), then the absolute path (robust when LaunchServices
+  # has stale/duplicate registrations), then the bare scheme as a last resort.
+  HEX_BUNDLE_ID="__HEX_BUNDLE_ID__"
+  HEX_APP_PATH="__HEX_APP_PATH__"
+
+  # NB: we deliberately do NOT bail on stop_hook_active. That flag stays set on every
+  # Stop that follows a decision:block reply, but since this hook always blocks for real
+  # user input there's no auto-continue loop to guard against — skipping it here would
+  # suppress the panel on every turn after the first voice reply.
+
+  # Dump the full hook JSON to a temp file so Hex can read the CURRENT tool_input
+  # (the live question / permission), avoiding stale transcript data and URL limits.
+  dir="${TMPDIR:-/tmp}/hex-agent"
+  mkdir -p "$dir" 2>/dev/null
+  payload="$dir/hook.$$.json"
+  printf '%s' "$input" > "$payload" 2>/dev/null
+  response="$payload.response"
+
+  encode() {
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c 'import sys,urllib.parse;sys.stdout.write(urllib.parse.quote(sys.stdin.read()))'
+    else
+      sed 's/ /%20/g'
+    fi
+  }
+
+  # Deliver a hex:// URL to the specific Hex that installed us: bundle id, then exact app
+  # path, then the default scheme handler as a last resort.
+  open_url() {
+    if [ -n "$HEX_BUNDLE_ID" ] && /usr/bin/open -b "$HEX_BUNDLE_ID" "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ -n "$HEX_APP_PATH" ] && [ -d "$HEX_APP_PATH" ] && /usr/bin/open -a "$HEX_APP_PATH" "$1" >/dev/null 2>&1; then
+      return 0
+    fi
+    /usr/bin/open "$1" >/dev/null 2>&1 || open "$1" >/dev/null 2>&1
+  }
+
+  if command -v jq >/dev/null 2>&1; then
+    base=$(printf '%s' "$input" | jq -r '
+      "hex://agent-update?event=\(.hook_event_name // "")"
+      + "&tool=\(.tool_name // "")"
+      + "&session=\(.session_id // "")"
+      + "&transcript=\((.transcript_path // "")|@uri)"
+      + "&cwd=\((.cwd // "")|@uri)"' 2>/dev/null)
+  elif command -v python3 >/dev/null 2>&1; then
+    base=$(printf '%s' "$input" | python3 -c '
+  import sys, json, urllib.parse
+  try:
+      d = json.load(sys.stdin)
+  except Exception:
+      sys.exit(0)
+  q = urllib.parse.urlencode({
+      "event": d.get("hook_event_name", ""),
+      "tool": d.get("tool_name", ""),
+      "session": d.get("session_id", ""),
+      "transcript": d.get("transcript_path", ""),
+      "cwd": d.get("cwd", ""),
+  })
+  sys.stdout.write("hex://agent-update?" + q)' 2>/dev/null)
+  else
+    base="hex://agent-update?event=unknown"
+  fi
+
+  [ -z "$base" ] && { rm -f "$payload"; exit 0; }
+
+  # User answered in the terminal: release every hook still blocked on this session,
+  # tell Hex to hide its panel, and get out of the way.
+  case "$base" in
+    *"event=UserPromptSubmit"*)
+      sid=${base#*session=}
+      sid=${sid%%&*}
+      for p in "$dir"/hook.*.json; do
+        [ -f "$p" ] && [ "$p" != "$payload" ] || continue
+        case "$(cat "$p" 2>/dev/null)" in
+          *"$sid"*) : > "$p.response" ;;
+        esac
+      done
+      rm -f "$payload"
+      open_url "$base"
+      exit 0 ;;
+  esac
+
+  penc=$(printf '%s' "$payload" | encode)
+  open_url "${base}&payload=${penc}"
+
+  # Block until Hex answers (or ~9.5 min, under the 600s hook timeout).
+  # Non-empty response = hook-output JSON to relay; empty = user dismissed.
+  i=0
+  while [ "$i" -lt 2850 ]; do
+    if [ -f "$response" ]; then
+      out=$(cat "$response" 2>/dev/null)
+      rm -f "$response" "$payload"
+      [ -n "$out" ] && printf '%s' "$out"
+      exit 0
+    fi
+    sleep 0.2
+    i=$((i + 1))
+  done
+  rm -f "$response" "$payload"
+  exit 0
+  """#
+}

--- a/Hex/Clients/PasteboardClient.swift
+++ b/Hex/Clients/PasteboardClient.swift
@@ -20,6 +20,10 @@ struct PasteboardClient {
     var paste: @Sendable (String) async -> Void
     var copy: @Sendable (String) async -> Void
     var sendKeyboardCommand: @Sendable (KeyboardCommand) async -> Void
+    /// Types `text` as synthesized character keystrokes into the focused app. Unlike
+    /// `paste` (⌘V), this works with terminal TUIs (e.g. Claude Code's question prompt)
+    /// that read typed input but ignore clipboard paste.
+    var type: @Sendable (String) async -> Void
 }
 
 extension PasteboardClient: DependencyKey {
@@ -34,6 +38,9 @@ extension PasteboardClient: DependencyKey {
             },
             sendKeyboardCommand: { command in
                 await live.sendKeyboardCommand(command)
+            },
+            type: { text in
+                await live.typeText(text)
             }
         )
     }
@@ -94,6 +101,25 @@ struct PasteboardClientLive {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+    }
+
+    /// Types `text` one character at a time as Unicode key events. Works in terminal
+    /// TUIs that read typed input but ignore ⌘V.
+    @MainActor
+    func typeText(_ text: String) async {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        for scalar in text.unicodeScalars {
+            let units = Array(String(scalar).utf16)
+            if let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true) {
+                down.keyboardSetUnicodeString(stringLength: units.count, unicodeString: units)
+                down.post(tap: .cghidEventTap)
+            }
+            if let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) {
+                up.keyboardSetUnicodeString(stringLength: units.count, unicodeString: units)
+                up.post(tap: .cghidEventTap)
+            }
+            try? await Task.sleep(for: .milliseconds(4))
+        }
     }
     
     @MainActor

--- a/Hex/Clients/SpeechSynthesizerClient.swift
+++ b/Hex/Clients/SpeechSynthesizerClient.swift
@@ -1,0 +1,142 @@
+//
+//  SpeechSynthesizerClient.swift
+//  Hex
+//
+//  Reads agent output aloud with Kokoro (FluidAudio CoreML), an on-device neural
+//  TTS model. The ~300 MB model downloads on first use and is cached alongside
+//  Parakeet under the app container. Voice identifiers are Kokoro voice names
+//  (e.g. "af_heart"); nil selects the recommended default.
+//
+//  Calling `speak` cancels any in-progress utterance first so the panel never
+//  talks over itself.
+//
+
+import AVFoundation
+import Dependencies
+import DependenciesMacros
+import FluidAudioTTS
+import HexCore
+
+private let speechLogger = HexLog.app
+
+@DependencyClient
+struct SpeechSynthesizerClient {
+    /// Speaks `text` with the given Kokoro voice (nil = default). Returns once
+    /// audio playback has started.
+    var speak: @Sendable (String, String?) async -> Void
+    var stop: @Sendable () async -> Void
+    /// Downloads (if needed) and warms up the Kokoro model, reporting 0...1 progress.
+    var prepareKokoro: @Sendable (_ progress: @escaping @Sendable (Double) -> Void) async throws -> Void
+}
+
+extension SpeechSynthesizerClient: DependencyKey {
+    static var liveValue: Self {
+        let kokoro = KokoroSpeechLive()
+        return .init(
+            speak: { text, voiceIdentifier in
+                await kokoro.speak(text, voice: KokoroVoice.voiceName(fromIdentifier: voiceIdentifier))
+            },
+            stop: { await kokoro.stop() },
+            prepareKokoro: { progress in
+                try await kokoro.prepare(progress: progress)
+            }
+        )
+    }
+}
+
+extension DependencyValues {
+    var speechSynthesizer: SpeechSynthesizerClient {
+        get { self[SpeechSynthesizerClient.self] }
+        set { self[SpeechSynthesizerClient.self] = newValue }
+    }
+}
+
+// MARK: - Kokoro voice identifiers
+
+/// Maps the persisted `agentVoiceIdentifier` to/from Kokoro voice names.
+enum KokoroVoice {
+    /// Curated, supported subset (FluidAudio's TTS is beta and American English only).
+    static let voices: [String] = TtsConstants.availableVoices.filter {
+        $0.hasPrefix("af_") || $0.hasPrefix("am_")
+    }
+
+    static let defaultVoice = TtsConstants.recommendedVoice
+
+    /// Resolves a stored identifier to a known voice name, tolerating the legacy
+    /// "kokoro:" prefix and falling back to the default for unknown values.
+    static func voiceName(fromIdentifier identifier: String?) -> String {
+        guard var name = identifier else { return defaultVoice }
+        if name.hasPrefix("kokoro:") { name = String(name.dropFirst("kokoro:".count)) }
+        return voices.contains(name) ? name : defaultVoice
+    }
+
+    /// "af_heart" → "Heart — English (US, female)"
+    static func label(forVoiceName name: String) -> String {
+        let parts = name.split(separator: "_")
+        let displayName = parts.last.map { $0.prefix(1).uppercased() + $0.dropFirst() } ?? name
+        let gender = name.hasPrefix("af_") ? "female" : "male"
+        return "\(displayName) — English (US, \(gender))"
+    }
+}
+
+// MARK: - Synthesis + playback
+
+private actor KokoroSpeechLive {
+    /// Shared init task so concurrent callers (settings preview + agent panel) join
+    /// one download instead of racing to start two.
+    private var managerTask: Task<TtSManager, Error>?
+    private var player: AVAudioPlayer?
+    /// Bumped on every speak/stop so a slow synthesis can't play stale audio.
+    private var generation = 0
+
+    func prepare(progress: @escaping @Sendable (Double) -> Void) async throws {
+        _ = try await readyManager(progress: progress)
+    }
+
+    func speak(_ text: String, voice: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        generation += 1
+        let requested = generation
+        player?.stop()
+        player = nil
+
+        do {
+            let manager = try await readyManager()
+            let wav = try await manager.synthesize(text: trimmed, voice: voice)
+            guard requested == generation else { return } // superseded while synthesizing
+            let player = try AVAudioPlayer(data: wav)
+            self.player = player
+            player.play()
+        } catch {
+            speechLogger.error("Kokoro synthesis failed: \(error.localizedDescription)")
+        }
+    }
+
+    func stop() {
+        generation += 1
+        player?.stop()
+        player = nil
+    }
+
+    private func readyManager(progress: (@Sendable (Double) -> Void)? = nil) async throws -> TtSManager {
+        if let managerTask {
+            return try await managerTask.value
+        }
+        speechLogger.notice("Initializing Kokoro TTS (downloads the model on first use)")
+        let task = Task<TtSManager, Error> {
+            let models = try await TtsModels.download(progressHandler: { progress?($0) })
+            let manager = TtSManager()
+            try await manager.initialize(models: models)
+            speechLogger.notice("Kokoro TTS ready")
+            return manager
+        }
+        managerTask = task
+        do {
+            return try await task.value
+        } catch {
+            managerTask = nil // allow retry after a failed download
+            throw error
+        }
+    }
+}

--- a/Hex/Features/Agent/AgentFeature.swift
+++ b/Hex/Features/Agent/AgentFeature.swift
@@ -1,0 +1,574 @@
+//
+//  AgentFeature.swift
+//  Hex
+//
+//  Drives the Agent Plugins voice window. Shows what Claude Code is presenting (a plain
+//  message, a multiple-choice question, or a permission request), lets the user answer by
+//  voice / typing / tapping an option, then answers the BLOCKED hook in-band: Hex writes
+//  the complete hook-output JSON to `<payload>.response`, which the hook script relays to
+//  Claude Code on stdout. No app focusing, no synthetic keystrokes — the answer can never
+//  land in the wrong window. (Typing into the terminal remains only as a legacy fallback
+//  when no payload file is available.)
+//
+//  Multiple Claude sessions can be blocked at once — each on its own hook — so the feature
+//  holds a FIFO queue of `AgentRequest`s (one card per active project). The oldest is shown;
+//  newcomers wait their turn; answering or dismissing advances to the next. Nothing is ever
+//  silently abandoned: every teardown (answer, dismiss, supersede, even app quit) writes a
+//  response so no session hangs on its 600s hook timeout.
+//
+
+import AppKit
+import ComposableArchitecture
+import Foundation
+import HexCore
+import SwiftUI
+
+private let agentFeatureLogger = HexLog.app
+
+@Reducer
+struct AgentFeature {
+  /// Parsed from a `hex://agent-update?…` deeplink, plus the terminal we should send
+  /// the answer to (captured by the app delegate, which tracks the last foreground app).
+  struct ShowPayload: Equatable {
+    var event: String?
+    var tool: String?
+    var sessionID: String?
+    var cwd: String?
+    var transcriptPath: String?
+    var payloadPath: String?
+    var inlineMessage: String?
+    var sourceAppBundleID: String?
+    var sourceAppName: String?
+    var sourceAppPID: pid_t?
+  }
+
+  /// One waiting Claude session. Each owns its own payload/session context plus its own
+  /// draft reply and selection, so flipping between cards never loses what you typed.
+  struct AgentRequest: Equatable, Identifiable {
+    var event: String?
+    var sessionID: String?
+    var cwd: String?
+    var transcriptPath: String?
+    var payloadPath: String?
+    var sourceAppBundleID: String?
+    var sourceAppName: String?
+    var sourceAppPID: pid_t?
+
+    var prompt: AgentPrompt = .message("")
+    var selectedOptions: Set<String> = []
+    var draftReply: String = ""
+    /// 0...1 while the auto-send countdown runs after a paste/dictation; nil otherwise.
+    var autoSendProgress: Double?
+    /// The voice to read this card in (nil = the user's chosen default). Assigned once, at
+    /// enqueue, and kept for the card's lifetime — so a session that arrived alongside
+    /// another keeps its distinct voice even after the other is answered and it's alone.
+    var voice: String?
+
+    /// A session blocks on a single hook at a time, so the session id is the natural
+    /// identity; fall back to the payload path, then a singleton id for manually-summoned
+    /// cards that have no hook at all.
+    var id: String { sessionID ?? payloadPath ?? "manual" }
+
+    init(from payload: ShowPayload) {
+      event = payload.event
+      sessionID = payload.sessionID
+      cwd = payload.cwd
+      transcriptPath = payload.transcriptPath
+      payloadPath = payload.payloadPath
+      sourceAppBundleID = payload.sourceAppBundleID
+      sourceAppName = payload.sourceAppName
+      sourceAppPID = payload.sourceAppPID
+      prompt = .message(payload.inlineMessage ?? "")
+    }
+
+    /// A manually-summoned card (hotkey) with no hook — replies go to the captured app
+    /// via the legacy typing path. `id` resolves to "manual".
+    init(manualSourceApp app: NSRunningApplication?) {
+      sourceAppBundleID = app?.bundleIdentifier
+      sourceAppName = app?.localizedName
+      sourceAppPID = app?.processIdentifier
+    }
+  }
+
+  @ObservableState
+  struct State: Equatable {
+    /// FIFO queue of blocked sessions. The front (`first`) is the visible card.
+    var requests: IdentifiedArrayOf<AgentRequest> = []
+    /// The card currently shown; kept in sync with `requests.first`.
+    var currentID: AgentRequest.ID?
+    /// Remembered voice per Claude session id, so a project keeps one consistent voice for
+    /// the whole run (even across turns where it's the only active card). Assigned lazily;
+    /// not persisted — a fresh launch is a fresh working session.
+    var sessionVoices: [String: String] = [:]
+
+    var isVisible: Bool = false
+    /// True while the panel is intentionally hidden waiting for speech synthesis.
+    var pendingReveal: Bool = false
+
+    @Shared(.hexSettings) var hexSettings: HexSettings
+
+    // MARK: Convenience accessors for the current card (keep the View unchanged).
+
+    var current: AgentRequest? { currentID.flatMap { requests[id: $0] } }
+    var prompt: AgentPrompt { current?.prompt ?? .message("") }
+    var draftReply: String { current?.draftReply ?? "" }
+    var selectedOptions: Set<String> { current?.selectedOptions ?? [] }
+    var autoSendProgress: Double? { current?.autoSendProgress }
+
+    // MARK: Header
+
+    /// The project name shown in the card header — the basename of the session's cwd.
+    var projectName: String? {
+      guard let cwd = current?.cwd, !cwd.isEmpty else { return nil }
+      return URL(fileURLWithPath: cwd).lastPathComponent
+    }
+    var sourceAppName: String? { current?.sourceAppName }
+    var queueCount: Int { requests.count }
+    /// 1-based position of the current card in the queue (0 when nothing is showing).
+    var queuePosition: Int {
+      guard let currentID, let idx = requests.index(id: currentID) else { return 0 }
+      return idx + 1
+    }
+  }
+
+  enum Action {
+    case show(ShowPayload)
+    case openManually
+    case promptLoaded(AgentRequest.ID, AgentPrompt)
+    case revealPanel
+    case dismiss
+    case draftChanged(String)
+    case selectOption(AgentOption)        // single-select: answers immediately
+    case toggleOption(AgentOption)        // multi-select: toggles, Send submits
+    case respondPermission(allow: Bool)   // permission allow/deny
+    case toggleSpeakOutput
+    case autoSendTicked(Double)
+    case cancelAutoSend
+    case send
+    case sent
+  }
+
+  enum CancelID { case autoSend }
+
+  @Dependency(\.pasteboard) var pasteboard
+  @Dependency(\.soundEffects) var soundEffect
+  @Dependency(\.agentTranscript) var agentTranscript
+  @Dependency(\.speechSynthesizer) var speechSynthesizer
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case let .show(payload):
+        let enabled = state.hexSettings.agentPluginsEnabled
+        agentFeatureLogger.notice("Agent show requested (enabled=\(enabled), event=\(payload.event ?? "nil", privacy: .public), tool=\(payload.tool ?? "nil", privacy: .public))")
+        guard enabled else { return .none }
+
+        // The user answered in the terminal — the hook script already released this
+        // session's blocked sibling. Drop its queued card and advance if it was showing.
+        if payload.event == "UserPromptSubmit" {
+          let key = payload.sessionID ?? payload.payloadPath ?? "manual"
+          guard state.requests[id: key] != nil else { return .none }
+          let wasCurrent = state.currentID == key
+          state.requests.remove(id: key)
+          return wasCurrent ? advance(&state) : .none
+        }
+
+        var request = AgentRequest(from: payload)
+        let id = request.id
+        // Assign (or recall) this session's voice so each project sounds consistent across
+        // turns and concurrent projects are distinguishable by ear.
+        request.voice = sessionVoice(&state, for: request.sessionID)
+
+        if let existing = state.requests[id: id] {
+          // Same session re-presenting: release its now-stale hook before replacing it.
+          if let oldPath = existing.payloadPath, oldPath != request.payloadPath {
+            AgentHookResponder.respond(payloadPath: oldPath, json: nil)
+          }
+          state.requests[id: id] = request
+        } else {
+          // A newer request from a *different* session no longer releases the current
+          // one — it joins the queue behind it.
+          state.requests.append(request)
+        }
+
+        // Become the visible card only when nothing is showing, or when the card being
+        // updated IS the current one. Otherwise it waits its turn (FIFO) silently.
+        if state.currentID == nil || state.currentID == id {
+          return present(&state, id: id)
+        }
+        return .none
+
+      case .openManually:
+        guard state.hexSettings.agentPluginsEnabled else { return .none }
+        // Second press toggles the panel away.
+        if state.isVisible { return .send(.dismiss) }
+        agentFeatureLogger.notice("Agent window summoned via hotkey")
+        // Prefer the terminal actually hosting a claude session; fall back to whatever is
+        // frontmost so the hotkey still does something useful.
+        let hostApp = MainActor.assumeIsolated {
+          ClaudeTerminalLocator.locate() ?? NSWorkspace.shared.frontmostApplication
+        }
+        let request = AgentRequest(manualSourceApp: hostApp)
+        // A manual card has no blocked hook; jump it to the front so the summon shows now,
+        // and let any queued hook cards resume when it's dismissed.
+        state.requests[id: request.id] = nil
+        state.requests.insert(request, at: 0)
+        state.currentID = request.id
+        state.isVisible = true
+        state.pendingReveal = false
+        return .cancel(id: CancelID.autoSend)
+
+      case let .promptLoaded(id, prompt):
+        state.requests[id: id]?.prompt = prompt
+        // Only the front card speaks/reveals; a preloaded waiting card just caches.
+        guard id == state.currentID else { return .none }
+        return speakThenReveal(state)
+
+      case .revealPanel:
+        // Ignore a reveal that arrives after the prompt was answered or dismissed.
+        guard state.pendingReveal else { return .none }
+        state.pendingReveal = false
+        state.isVisible = true
+        return .none
+
+      case .dismiss:
+        guard let id = state.currentID, let request = state.requests[id: id] else {
+          state.isVisible = false
+          state.pendingReveal = false
+          return .merge(
+            .cancel(id: CancelID.autoSend),
+            .run { _ in await speechSynthesizer.stop() }
+          )
+        }
+        // Release this card's blocked hook with an empty response (yield to the TUI).
+        if let payloadPath = request.payloadPath {
+          AgentHookResponder.respond(payloadPath: payloadPath, json: nil)
+        }
+        state.requests.remove(id: id)
+        return .merge(
+          .cancel(id: CancelID.autoSend),
+          .run { _ in await speechSynthesizer.stop() },
+          advance(&state)
+        )
+
+      case .toggleSpeakOutput:
+        let nowEnabled = !state.hexSettings.agentSpeakOutput
+        state.$hexSettings.withLock { $0.agentSpeakOutput = nowEnabled }
+        if nowEnabled {
+          return speakIfEnabled(state)
+        }
+        return .run { _ in await speechSynthesizer.stop() }
+
+      case let .draftChanged(text):
+        guard let id = state.currentID, let current = state.requests[id: id] else { return .none }
+        // Multi-character growth means a paste or a dictated transcript landed in the
+        // field; start a short countdown that sends it unless the user intervenes.
+        let isBulkInsert = text.count > current.draftReply.count + 1
+          && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        state.requests[id: id]?.draftReply = text
+        if isBulkInsert {
+          state.requests[id: id]?.autoSendProgress = 0
+          return .run { send in
+            let steps = 60
+            let totalMillis = Self.autoSendDelay.components.seconds * 1000
+              + Self.autoSendDelay.components.attoseconds / 1_000_000_000_000_000
+            for step in 1 ... steps {
+              try await Task.sleep(for: .milliseconds(Int(totalMillis) / steps))
+              await send(.autoSendTicked(Double(step) / Double(steps)))
+            }
+            await send(.send)
+          }
+          .cancellable(id: CancelID.autoSend, cancelInFlight: true)
+        }
+        // Manual typing takes over: stop any pending auto-send.
+        if current.autoSendProgress != nil {
+          state.requests[id: id]?.autoSendProgress = nil
+          return .cancel(id: CancelID.autoSend)
+        }
+        return .none
+
+      case let .autoSendTicked(progress):
+        if let id = state.currentID {
+          state.requests[id: id]?.autoSendProgress = progress
+        }
+        return .none
+
+      case .cancelAutoSend:
+        if let id = state.currentID {
+          state.requests[id: id]?.autoSendProgress = nil
+        }
+        return .cancel(id: CancelID.autoSend)
+
+      case let .selectOption(option):
+        guard let id = state.currentID else { return .none }
+        state.requests[id: id]?.draftReply = option.label
+        return .send(.send)
+
+      case let .toggleOption(option):
+        guard let id = state.currentID, var selected = state.requests[id: id]?.selectedOptions else {
+          return .none
+        }
+        if selected.contains(option.label) {
+          selected.remove(option.label)
+        } else {
+          selected.insert(option.label)
+        }
+        state.requests[id: id]?.selectedOptions = selected
+        state.requests[id: id]?.draftReply = selected.sorted().joined(separator: ", ")
+        return .none
+
+      case let .respondPermission(allow):
+        guard let id = state.currentID, let request = state.requests[id: id] else { return .none }
+        if let payloadPath = request.payloadPath {
+          state.requests.remove(id: id)
+          return .merge(
+            .cancel(id: CancelID.autoSend),
+            .run { _ in await speechSynthesizer.stop() },
+            advance(&state),
+            .run { send in
+              AgentHookResponder.respondPermission(payloadPath: payloadPath, allow: allow)
+              await send(.sent)
+            }
+          )
+        }
+        // Legacy fallback (no payload file): the terminal permission prompt is a
+        // numbered menu, 1 = allow, 2 = deny.
+        state.requests[id: id]?.draftReply = allow ? "1" : "2"
+        return .send(.send)
+
+      case .send:
+        guard let id = state.currentID, let request = state.requests[id: id] else { return .none }
+        let text = request.draftReply.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return .none }
+
+        let payloadPath = request.payloadPath
+        let prompt = request.prompt
+        let pid = request.sourceAppPID
+        let bundleID = request.sourceAppBundleID
+        let autoSubmit = state.hexSettings.agentAutoSubmit
+        state.requests.remove(id: id)
+
+        let teardown: Effect<Action> = .merge(
+          .cancel(id: CancelID.autoSend),
+          .run { _ in await speechSynthesizer.stop() },
+          advance(&state)
+        )
+
+        // In-band path: answer the blocked hook directly. The hook script relays this
+        // JSON to Claude Code on stdout, so the right session gets it without focus.
+        if let payloadPath {
+          return .merge(teardown, .run { send in
+            AgentHookResponder.respondAnswer(payloadPath: payloadPath, prompt: prompt, answer: text)
+            await send(.sent)
+          })
+        }
+
+        // Legacy fallback: re-focus the captured terminal and type the answer.
+        return .merge(teardown, .run { send in
+          let activated = await Self.activateTargetApp(pid: pid, bundleID: bundleID)
+          if !activated {
+            agentFeatureLogger.error("Could not bring target app to front; typing anyway")
+          }
+          // Let the frontmost-app handoff settle before posting keystrokes.
+          try? await Task.sleep(for: .milliseconds(160))
+          // Type (not paste) so Claude Code's terminal prompt receives it.
+          await pasteboard.type(text)
+          if autoSubmit {
+            try? await Task.sleep(for: .milliseconds(90))
+            await pasteboard.sendKeyboardCommand(.enter)
+          }
+          await send(.sent)
+        })
+
+      case .sent:
+        soundEffect.play(.pasteTranscript)
+        return .none
+      }
+    }
+  }
+
+  // MARK: Queue navigation
+
+  /// Sets `id` as the visible card, loading its prompt then speaking/revealing. When the
+  /// panel is already up (advancing between cards) it stays visible and just speaks the
+  /// new card; coming up fresh it honors the hidden-until-spoken behavior.
+  private func present(_ state: inout State, id: AgentRequest.ID) -> Effect<Action> {
+    state.currentID = id
+    guard let request = state.requests[id: id] else {
+      state.isVisible = false
+      state.pendingReveal = false
+      return .none
+    }
+    if !state.isVisible {
+      // With read-aloud on, keep the panel hidden until the audio is ready so the window
+      // appears the moment it starts talking (capped — see speakThenReveal).
+      state.isVisible = !state.hexSettings.agentSpeakOutput
+      state.pendingReveal = !state.isVisible
+    }
+    let payloadPath = request.payloadPath
+    let transcriptPath = request.transcriptPath
+    guard payloadPath != nil || transcriptPath != nil else { return speakThenReveal(state) }
+    let fallback = request.prompt
+    return .run { send in
+      let prompt = (try? await agentTranscript.latestPrompt(payloadPath, transcriptPath)) ?? fallback
+      await send(.promptLoaded(id, prompt))
+    }
+  }
+
+  /// Moves to the next queued card (FIFO), or tears the panel down when the queue empties.
+  private func advance(_ state: inout State) -> Effect<Action> {
+    guard let next = state.requests.first?.id else {
+      state.currentID = nil
+      state.isVisible = false
+      state.pendingReveal = false
+      return .none
+    }
+    return present(&state, id: next)
+  }
+
+  /// How long we'll sit on a hidden panel waiting for synthesis (Kokoro can be slow
+  /// on first use while its model downloads) before showing it anyway.
+  static let revealCap: Duration = .seconds(60)
+
+  /// Grace period before a pasted/dictated reply is sent automatically.
+  static let autoSendDelay: Duration = .milliseconds(1500)
+
+  /// Brings the captured terminal to the front and confirms it actually became
+  /// frontmost. macOS 14 activation is cooperative — a plain `activate()` from a
+  /// background app (Hex's panel is non-activating) is often silently declined, so
+  /// retry and escalate to relaunching the app bundle, which reliably activates.
+  @MainActor
+  private static func activateTargetApp(pid: pid_t?, bundleID: String?) async -> Bool {
+    guard let app = pid.flatMap({ NSRunningApplication(processIdentifier: $0) })
+      ?? bundleID.flatMap({ NSRunningApplication.runningApplications(withBundleIdentifier: $0).first })
+    else { return false }
+
+    func isFrontmost() -> Bool {
+      NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier
+    }
+    if isFrontmost() { return true }
+
+    for attempt in 0 ..< 8 {
+      if #available(macOS 14.0, *) {
+        NSApp.yieldActivation(to: app)
+        app.activate()
+      } else {
+        app.activate(options: [.activateIgnoringOtherApps])
+      }
+      // Halfway through, escalate: openApplication on a running app just activates
+      // it, and is honored even when cooperative activation is declined.
+      if attempt == 3, let url = app.bundleURL {
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        try? await NSWorkspace.shared.openApplication(at: url, configuration: config)
+      }
+      try? await Task.sleep(for: .milliseconds(120))
+      if isFrontmost() { return true }
+    }
+    return isFrontmost()
+  }
+
+  // MARK: Speech
+
+  /// The voice for the current card: its assigned voice if it has one, otherwise the user's
+  /// chosen default.
+  private func voiceIdentifier(for state: State) -> String? {
+    state.current?.voice ?? state.hexSettings.agentVoiceIdentifier
+  }
+
+  /// Resolves the voice for a session, assigning and remembering one on first sight when the
+  /// "distinct session voices" setting is on. Returns nil — meaning "use the default" — when
+  /// the setting is off or there's no session id (e.g. a manually-summoned card).
+  private func sessionVoice(_ state: inout State, for sessionID: String?) -> String? {
+    guard state.hexSettings.agentDistinctSessionVoices, let sessionID else { return nil }
+    if let remembered = state.sessionVoices[sessionID] { return remembered }
+    // Voices already claimed by any remembered session (keep new ones globally distinct),
+    // and the subset still on screen / queued (never collide with a concurrent card).
+    let used = Set(state.sessionVoices.values)
+    let active = Set(state.requests.compactMap { $0.sessionID.flatMap { state.sessionVoices[$0] } })
+    let voice = Self.pickSessionVoice(
+      for: sessionID,
+      default: state.hexSettings.agentVoiceIdentifier,
+      used: used,
+      active: active
+    )
+    state.sessionVoices[sessionID] = voice
+    return voice
+  }
+
+  /// Picks a stable, distinct voice for a new session. The first session keeps the user's
+  /// chosen default; later sessions get a voice no other session has taken (falling back to
+  /// any non-default voice once the pool is exhausted), seeded by the session id so the
+  /// choice is deterministic, and never colliding with a currently-active session.
+  static func pickSessionVoice(for sessionID: String, default userDefault: String?, used: Set<String>, active: Set<String>) -> String {
+    let resolvedDefault = KokoroVoice.voiceName(fromIdentifier: userDefault)
+    let pool = KokoroVoice.voices
+    guard !pool.isEmpty else { return resolvedDefault }
+    // First/primary session keeps the user's chosen default voice.
+    if !used.contains(resolvedDefault) { return resolvedDefault }
+    let others = pool.filter { $0 != resolvedDefault }
+    guard !others.isEmpty else { return resolvedDefault }
+    let unclaimed = others.filter { !used.contains($0) }
+    let candidates = unclaimed.isEmpty ? others : unclaimed
+    let start = stableHash(sessionID) % candidates.count
+    for offset in 0 ..< candidates.count {
+      let candidate = candidates[(start + offset) % candidates.count]
+      if !active.contains(candidate) { return candidate }
+    }
+    return candidates[start]
+  }
+
+  /// FNV-1a — a stable, launch-independent hash so a session always maps to the same voice.
+  static func stableHash(_ string: String) -> Int {
+    var hash: UInt64 = 14695981039346656037
+    for byte in string.utf8 {
+      hash ^= UInt64(byte)
+      hash = hash &* 1099511628211
+    }
+    return Int(hash % UInt64(Int.max))
+  }
+
+  /// Reads the current prompt aloud when the user has speech output enabled.
+  private func speakIfEnabled(_ state: State) -> Effect<Action> {
+    guard state.hexSettings.agentSpeakOutput else { return .none }
+    let text = Self.spokenText(for: state.prompt)
+    guard !text.isEmpty else { return .none }
+    let voice = voiceIdentifier(for: state)
+    return .run { _ in await speechSynthesizer.speak(text, voice) }
+  }
+
+  /// Starts reading the prompt, then reveals the panel once audio playback has begun
+  /// (speak returns when sound starts) — or after `revealCap`, whichever comes first.
+  /// If the panel is already visible (or there is nothing to say), it just speaks.
+  private func speakThenReveal(_ state: State) -> Effect<Action> {
+    guard !state.isVisible else { return speakIfEnabled(state) }
+    let text = Self.spokenText(for: state.prompt)
+    guard state.hexSettings.agentSpeakOutput, !text.isEmpty else { return .send(.revealPanel) }
+    let voice = voiceIdentifier(for: state)
+    return .run { send in
+      // Unstructured so the cap firing doesn't cancel synthesis — audio still plays
+      // whenever it's ready; we just stop holding the panel for it.
+      let speakTask = Task { await speechSynthesizer.speak(text, voice) }
+      await withTaskGroup(of: Void.self) { group in
+        group.addTask { await speakTask.value }
+        group.addTask { try? await Task.sleep(for: Self.revealCap) }
+        await group.next()
+        group.cancelAll()
+      }
+      await send(.revealPanel)
+    }
+  }
+
+  static func spokenText(for prompt: AgentPrompt) -> String {
+    switch prompt {
+    case let .message(text):
+      return SpokenText.spoken(from: text)
+    case let .question(question):
+      let options = question.options.map(\.label).joined(separator: ". ")
+      let q = SpokenText.spoken(from: question.question)
+      return q + (options.isEmpty ? "" : " Options: \(options)")
+    case let .permission(permission):
+      return "Claude wants to use \(permission.tool)"
+    }
+  }
+}

--- a/Hex/Features/Agent/AgentHookResponder.swift
+++ b/Hex/Features/Agent/AgentHookResponder.swift
@@ -1,0 +1,88 @@
+//
+//  AgentHookResponder.swift
+//  Hex
+//
+//  Answers a blocked Claude Code hook in-band. The hook script polls for
+//  `<payload>.response`; we write the complete hook-output JSON there and the script
+//  relays it on stdout. An empty file means "user dismissed — yield to the terminal UI".
+//
+//  Output shapes (mirrors what superwhisper's agent-hook emits):
+//  - Stop:               {"decision":"block","reason":"<user's text>"} — Claude Code
+//                        treats the reason as the user's next instruction.
+//  - AskUserQuestion:    PreToolUse hookSpecificOutput, permissionDecision=allow,
+//                        updatedInput with an `answers` map keyed by question text.
+//  - PermissionRequest:  hookSpecificOutput decision behavior allow/deny.
+//
+
+import Foundation
+import HexCore
+
+private let responderLogger = HexLog.app
+
+enum AgentHookResponder {
+  /// Writes the response file. `json == nil` writes an empty file (dismiss/yield).
+  static func respond(payloadPath: String, json: [String: Any]?) {
+    let responsePath = payloadPath + ".response"
+    let data: Data
+    if let json {
+      guard let encoded = try? JSONSerialization.data(withJSONObject: json) else {
+        responderLogger.error("Agent hook response failed to encode; yielding to TUI")
+        try? Data().write(to: URL(fileURLWithPath: responsePath), options: .atomic)
+        return
+      }
+      data = encoded
+    } else {
+      data = Data()
+    }
+    do {
+      try data.write(to: URL(fileURLWithPath: responsePath), options: .atomic)
+      responderLogger.notice("Agent hook response written (\(data.count) bytes)")
+    } catch {
+      responderLogger.error("Agent hook response write failed: \(error.localizedDescription)")
+    }
+  }
+
+  /// Answers a question (AskUserQuestion) or a turn-end message (Stop) with free text
+  /// or a chosen option label.
+  static func respondAnswer(payloadPath: String, prompt: AgentPrompt, answer: String) {
+    switch prompt {
+    case let .question(question):
+      var input = hookPayload(payloadPath)?["tool_input"] as? [String: Any] ?? [:]
+      var answers = input["answers"] as? [String: String] ?? [:]
+      answers[question.question] = answer
+      input["answers"] = answers
+      respond(payloadPath: payloadPath, json: [
+        "hookSpecificOutput": [
+          "hookEventName": "PreToolUse",
+          "permissionDecision": "allow",
+          "updatedInput": input,
+        ],
+      ])
+    case .message, .permission:
+      // Stop hook (or anything free-text): a blocked Stop's reason is delivered to
+      // Claude as the user's follow-up instruction.
+      respond(payloadPath: payloadPath, json: [
+        "decision": "block",
+        "reason": answer,
+      ])
+    }
+  }
+
+  /// Answers a PermissionRequest hook with allow/deny.
+  static func respondPermission(payloadPath: String, allow: Bool) {
+    let decision: [String: Any] = allow
+      ? ["behavior": "allow", "updatedInput": hookPayload(payloadPath)?["tool_input"] as? [String: Any] ?? [:]]
+      : ["behavior": "deny", "message": "The user denied this request in Hex."]
+    respond(payloadPath: payloadPath, json: [
+      "hookSpecificOutput": [
+        "hookEventName": "PermissionRequest",
+        "decision": decision,
+      ],
+    ])
+  }
+
+  private static func hookPayload(_ path: String) -> [String: Any]? {
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+    return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+  }
+}

--- a/Hex/Features/Agent/AgentView.swift
+++ b/Hex/Features/Agent/AgentView.swift
@@ -1,0 +1,362 @@
+//
+//  AgentView.swift
+//  Hex
+//
+//  The floating voice window shown when Claude Code pings Hex. Mirrors superwhisper:
+//  two separate floating cards — a markdown output card on top, a gap, then a detached
+//  input card below for dictating/typing the reply.
+//
+
+import ComposableArchitecture
+import HexCore
+import MarkdownUI
+import SwiftUI
+
+struct AgentView: View {
+  @Bindable var store: StoreOf<AgentFeature>
+  @FocusState private var replyFocused: Bool
+  @State private var spokenExpanded = true
+
+  private let cardWidth: CGFloat = 480
+
+  var body: some View {
+    VStack(spacing: 10) {
+      if hasOutput {
+        outputCard
+      }
+      inputCard
+    }
+    .frame(width: cardWidth)
+    .padding(16) // breathing room so each card's shadow isn't clipped by the window
+    .onAppear { DispatchQueue.main.async { replyFocused = true } }
+    .onExitCommand { store.send(.dismiss) }
+  }
+
+  private var hasOutput: Bool {
+    switch store.prompt {
+    case let .message(text): return !text.isEmpty
+    case .question, .permission: return true
+    }
+  }
+
+  // MARK: Output card (message / question / permission)
+
+  private var outputCard: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 12) {
+        cardHeader
+        switch store.prompt {
+        case let .message(text):
+          markdown(SpokenText.displayText(from: text))
+        case let .question(question):
+          questionView(question)
+        case let .permission(permission):
+          permissionView(permission)
+        }
+        if let spoken = spokenForDisplay {
+          spokenSection(spoken)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .frame(maxHeight: 420)
+    .fixedSize(horizontal: false, vertical: true)
+    .padding(14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .modifier(FloatingCard())
+  }
+
+  /// The exact text read aloud, shown only when the spoken version actually differs from
+  /// the full reply (explicit `Spoken:` line, or a condensed heuristic). Nil for short
+  /// messages where they'd be identical.
+  private var spokenForDisplay: String? {
+    guard case let .message(text) = store.prompt else { return nil }
+    let spoken = SpokenText.spoken(from: text)
+    guard !spoken.isEmpty else { return nil }
+    if SpokenText.summary(from: text) != nil { return spoken }
+    return spoken == SpokenText.displayText(from: text) ? nil : spoken
+  }
+
+  /// Collapsible "Spoken" extension at the foot of the output card — divider + header that
+  /// toggles the read-aloud text, so it reads as part of the primary card, not a new box.
+  private func spokenSection(_ text: String) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Divider().overlay(.white.opacity(0.08))
+      Button {
+        withAnimation(.snappy(duration: 0.2)) { spokenExpanded.toggle() }
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: "speaker.wave.2.fill")
+            .font(.caption)
+            .foregroundStyle(Color.accentColor)
+          Text("Spoken")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+          Spacer(minLength: 0)
+          Image(systemName: spokenExpanded ? "chevron.up" : "chevron.down")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+        }
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+
+      if spokenExpanded {
+        Text(text)
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+    .padding(.top, 2)
+  }
+
+  /// Identifies which session this card belongs to — project (cwd basename) + host app —
+  /// with a passive "n / N" position indicator when several sessions are queued.
+  @ViewBuilder
+  private var cardHeader: some View {
+    let project = store.projectName
+    let app = store.sourceAppName
+    if project != nil || app != nil || store.queueCount > 1 {
+      HStack(spacing: 6) {
+        if let project {
+          Image(systemName: "folder.fill")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+          Text(project)
+            .font(.caption.weight(.semibold))
+        }
+        if let app {
+          Text("·").foregroundStyle(.tertiary)
+          Text(app)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        Spacer(minLength: 0)
+        if store.queueCount > 1 {
+          Text("\(store.queuePosition) / \(store.queueCount)")
+            .font(.caption.weight(.medium).monospacedDigit())
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.white.opacity(0.1), in: Capsule())
+        }
+      }
+      .lineLimit(1)
+      .padding(.bottom, 2)
+    }
+  }
+
+  private func markdown(_ text: String) -> some View {
+    Markdown(text)
+      .markdownTextStyle { FontSize(13) }
+      .textSelection(.enabled)
+  }
+
+  private func tag(_ text: String) -> some View {
+    Text(text)
+      .font(.caption2.weight(.bold))
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 6)
+      .padding(.vertical, 2)
+      .background(.white.opacity(0.1), in: Capsule())
+  }
+
+  // MARK: Question
+
+  @ViewBuilder
+  private func questionView(_ q: AgentQuestion) -> some View {
+    if !q.header.isEmpty { tag(q.header.uppercased()) }
+    markdown(q.question)
+    VStack(spacing: 6) {
+      ForEach(q.options) { option in
+        optionRow(option, multiSelect: q.multiSelect)
+      }
+    }
+    if q.multiSelect {
+      Text("Select one or more, then Send.")
+        .font(.caption).foregroundStyle(.tertiary)
+    }
+  }
+
+  private func optionRow(_ option: AgentOption, multiSelect: Bool) -> some View {
+    let selected = store.selectedOptions.contains(option.label)
+    return Button {
+      store.send(multiSelect ? .toggleOption(option) : .selectOption(option))
+    } label: {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Image(systemName: multiSelect
+          ? (selected ? "checkmark.square.fill" : "square")
+          : "circle")
+          .foregroundStyle(selected ? Color.accentColor : .secondary)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(option.label).font(.body.weight(.medium))
+          if !option.detail.isEmpty {
+            Text(option.detail).font(.caption).foregroundStyle(.secondary)
+          }
+        }
+        Spacer(minLength: 0)
+      }
+      .padding(8)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .fill(selected ? Color.accentColor.opacity(0.15) : Color.white.opacity(0.05))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+          .strokeBorder(selected ? Color.accentColor.opacity(0.5) : .white.opacity(0.08))
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: Permission
+
+  @ViewBuilder
+  private func permissionView(_ p: AgentPermission) -> some View {
+    tag("PERMISSION")
+    Text("Claude wants to use \(p.tool)")
+      .font(.body.weight(.medium))
+    if !p.summary.isEmpty {
+      Text(p.summary)
+        .font(.system(.caption, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(.black.opacity(0.18)))
+    }
+    HStack(spacing: 8) {
+      Button("Allow") { store.send(.respondPermission(allow: true)) }
+        .buttonStyle(.borderedProminent)
+      Button("Deny", role: .destructive) { store.send(.respondPermission(allow: false)) }
+        .buttonStyle(.bordered)
+    }
+  }
+
+  // MARK: Input card (separate, below)
+
+  private var inputCard: some View {
+    VStack(spacing: 8) {
+      // A vertical-axis TextField grows with its content (one line by default, up to a
+      // few before it scrolls) instead of reserving a tall fixed box.
+      TextField(
+        "Type or hold your hotkey to dictate a reply.",
+        text: Binding(
+          get: { store.draftReply },
+          set: { store.send(.draftChanged($0)) }
+        ),
+        axis: .vertical
+      )
+      .textFieldStyle(.plain)
+      .focused($replyFocused)
+      .font(.body)
+      .lineLimit(1 ... 6)
+      // Plain Return submits; multi-line replies are rare and still reachable via ⌥Return.
+      .onSubmit { store.send(.send) }
+      // Shift+Return would normally insert a newline — make it send too.
+      .onKeyPress(.return, phases: .down) { press in
+        guard press.modifiers.contains(.shift) else { return .ignored }
+        store.send(.send)
+        return .handled
+      }
+
+      if let progress = store.autoSendProgress {
+        autoSendBar(progress)
+      }
+
+      HStack(spacing: 10) {
+        speakToggle
+
+        Spacer()
+
+        hint("Dismiss", key: "esc") { store.send(.dismiss) }
+        hint("Send", key: "⏎") { store.send(.send) }
+          .disabled(store.draftReply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+    }
+    .padding(12)
+    .modifier(FloatingCard())
+  }
+
+  /// Thin countdown shown after a paste/dictation lands in the field; the reply sends
+  /// itself when the bar fills. Clicking (or typing) cancels.
+  private func autoSendBar(_ progress: Double) -> some View {
+    Button {
+      store.send(.cancelAutoSend)
+    } label: {
+      HStack(spacing: 8) {
+        GeometryReader { geo in
+          ZStack(alignment: .leading) {
+            Capsule().fill(.white.opacity(0.12))
+            Capsule()
+              .fill(Color.accentColor)
+              .frame(width: geo.size.width * progress)
+              .animation(.linear(duration: 0.06), value: progress)
+          }
+        }
+        .frame(height: 3)
+        Text("Sending — click to cancel")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .fixedSize()
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  private var speakToggle: some View {
+    let enabled = store.hexSettings.agentSpeakOutput
+    return Button {
+      store.send(.toggleSpeakOutput)
+    } label: {
+      // A solid backing circle so the glyph reads clearly over the translucent card —
+      // the `.circle.fill` symbol's cutout would otherwise show the terminal through it.
+      Image(systemName: enabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.white)
+        .frame(width: 20, height: 20)
+        .background(
+          Circle().fill(enabled ? Color.accentColor : Color.secondary.opacity(0.7))
+        )
+    }
+    .buttonStyle(.plain)
+    .help(enabled ? "Stop reading output aloud" : "Read output aloud")
+  }
+
+  private func hint(_ title: String, key: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      HStack(spacing: 5) {
+        Text(title).font(.callout)
+        Text(key)
+          .font(.caption.weight(.medium))
+          .padding(.horizontal, 5)
+          .padding(.vertical, 1)
+          .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+      }
+      .foregroundStyle(.secondary)
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+/// Shared look for the two floating cards: translucent material, rounded, soft shadow.
+private struct FloatingCard: ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      // Translucent frosted glass: the blur keeps text legible while the terminal
+      // shows through behind it (vs. the near-opaque .ultraThickMaterial).
+      .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .strokeBorder(.white.opacity(0.08))
+      )
+      // Flatten so the shadow follows the rounded shape instead of a hard rectangle.
+      .compositingGroup()
+      .shadow(color: .black.opacity(0.20), radius: 12, x: 0, y: 4)
+  }
+}

--- a/Hex/Features/Agent/ClaudeTerminalLocator.swift
+++ b/Hex/Features/Agent/ClaudeTerminalLocator.swift
@@ -1,0 +1,108 @@
+//
+//  ClaudeTerminalLocator.swift
+//  Hex
+//
+//  Finds the GUI app hosting a running `claude` CLI session so the summoned agent
+//  window can send replies to it without the terminal being frontmost. We list all
+//  processes via sysctl, pick the newest one named "claude", then walk its parent
+//  chain (claude → shell → terminal emulator / IDE helper → app) until we hit a
+//  process that NSWorkspace knows as a running application.
+//
+
+import AppKit
+import Darwin
+import HexCore
+
+enum ClaudeTerminalLocator {
+  private static let logger = HexLog.app
+
+  /// Bundle-ID fragments of IDEs whose integrated terminals can host claude. These are
+  /// deprioritized: an agent session in VS Code (e.g. the one driving Hex development)
+  /// is usually newer than the terminal session the user actually wants to talk to.
+  static let ideBundleFragments = ["vscode", "vscodium", "cursor", "windsurf"]
+
+  /// The app hosting a running `claude` process, or nil if none. Prefers claudes in
+  /// dedicated terminal apps over IDE-integrated ones; newest first within each group.
+  @MainActor
+  static func locate() -> NSRunningApplication? {
+    let processes = allProcesses()
+    // The native-installer binary reports its comm as "claude.exe"; npm installs as
+    // "claude" — match the prefix. (p_comm is 16 chars, so long names truncate anyway.)
+    let claudes = processes.values
+      .filter { $0.name.hasPrefix("claude") }
+      .sorted { $0.startTime > $1.startTime }
+    guard !claudes.isEmpty else {
+      logger.notice("No running claude process found")
+      return nil
+    }
+
+    let appsByPID = Dictionary(
+      NSWorkspace.shared.runningApplications.map { ($0.processIdentifier, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
+
+    var ideFallback: NSRunningApplication?
+    for claude in claudes {
+      var pid = claude.ppid
+      var hops = 0
+      while pid > 1, hops < 16 {
+        if let app = appsByPID[pid] {
+          let bundle = (app.bundleIdentifier ?? "").lowercased()
+          if ideBundleFragments.contains(where: { bundle.contains($0) }) {
+            if ideFallback == nil { ideFallback = app }
+          } else {
+            logger.notice("Located claude session (pid \(claude.pid)) in \(app.localizedName ?? "?", privacy: .public)")
+            return app
+          }
+          break
+        }
+        guard let parent = processes[pid] else { break }
+        pid = parent.ppid
+        hops += 1
+      }
+    }
+    if let ide = ideFallback {
+      logger.notice("Located claude session only in IDE host \(ide.localizedName ?? "?", privacy: .public)")
+      return ide
+    }
+    logger.notice("Found claude process(es) but no owning GUI app")
+    return nil
+  }
+
+  private struct ProcessInfoLite {
+    var pid: pid_t
+    var ppid: pid_t
+    var name: String
+    var startTime: TimeInterval
+  }
+
+  private static func allProcesses() -> [pid_t: ProcessInfoLite] {
+    var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
+    var size = 0
+    guard sysctl(&mib, UInt32(mib.count), nil, &size, nil, 0) == 0, size > 0 else { return [:] }
+    // Headroom in case the process table grows between the two calls.
+    size += size / 8
+    var buffer = [UInt8](repeating: 0, count: size)
+    guard sysctl(&mib, UInt32(mib.count), &buffer, &size, nil, 0) == 0 else { return [:] }
+
+    let count = size / MemoryLayout<kinfo_proc>.stride
+    var result: [pid_t: ProcessInfoLite] = [:]
+    buffer.withUnsafeBytes { raw in
+      let procs = raw.bindMemory(to: kinfo_proc.self)
+      for i in 0 ..< count {
+        var proc = procs[i]
+        let name = withUnsafeBytes(of: &proc.kp_proc.p_comm) { bytes in
+          String(decoding: bytes.prefix(while: { $0 != 0 }), as: UTF8.self)
+        }
+        let start = proc.kp_proc.p_starttime
+        result[proc.kp_proc.p_pid] = ProcessInfoLite(
+          pid: proc.kp_proc.p_pid,
+          ppid: proc.kp_eproc.e_ppid,
+          name: name,
+          startTime: TimeInterval(start.tv_sec) + TimeInterval(start.tv_usec) / 1_000_000
+        )
+      }
+    }
+    return result
+  }
+}

--- a/Hex/Features/Agent/SpokenText.swift
+++ b/Hex/Features/Agent/SpokenText.swift
@@ -1,0 +1,146 @@
+//
+//  SpokenText.swift
+//  Hex
+//
+//  Turns an assistant's markdown reply into something worth reading ALOUD — short and
+//  actionable — distinct from what the panel shows on screen. Three layers, in order:
+//
+//  1. Explicit marker: if the reply contains a `Spoken: …` line, that line IS the spoken
+//     text (authoritative — the model wrote a TTS-ready summary itself). It's stripped
+//     from the on-screen text via `displayText`.
+//  2. Markdown filter: drop code blocks entirely, reduce `[label](url)` to its label,
+//     drop bare URLs, and strip formatting punctuation the synthesizer would stumble on.
+//  3. Heuristic condense: when there's no marker, speak the first sentence plus any
+//     trailing question/imperative, so long explanations become a short action cycle.
+//
+
+import Foundation
+
+enum SpokenText {
+  /// The text to READ ALOUD for a message body.
+  static func spoken(from raw: String) -> String {
+    if let marker = markerLine(in: raw) { return marker }
+    let filtered = filterMarkdown(raw)
+    return condense(filtered)
+  }
+
+  /// The `Spoken: …` summary line, if the reply has one — shown as a highlighted banner.
+  static func summary(from raw: String) -> String? {
+    markerLine(in: raw)
+  }
+
+  /// The text to SHOW in the panel body — same markdown, minus any `Spoken:` marker line.
+  static func displayText(from raw: String) -> String {
+    guard markerLine(in: raw) != nil else { return raw }
+    let kept = raw
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { !isMarker($0) }
+    return kept.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  // MARK: 1. Spoken marker
+
+  private static func isMarker(_ line: Substring) -> Bool {
+    line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix("spoken:")
+  }
+
+  /// The content of the first `Spoken: …` line, if any.
+  private static func markerLine(in raw: String) -> String? {
+    for line in raw.split(separator: "\n", omittingEmptySubsequences: true) where isMarker(line) {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      let content = trimmed.dropFirst("spoken:".count).trimmingCharacters(in: .whitespaces)
+      if !content.isEmpty { return content }
+    }
+    return nil
+  }
+
+  // MARK: 2. Markdown → speech
+
+  private static func filterMarkdown(_ text: String) -> String {
+    var s = text
+    // Fenced code blocks: drop entirely (don't read code aloud).
+    s = replace(s, #"(?ms)^```.*?```\s*"#, with: "")
+    // Images: ![alt](url) → drop (before links so the leading ! is consumed).
+    s = replace(s, #"!\[[^\]]*\]\([^)]*\)"#, with: "")
+    // Links: [label](url) → label.
+    s = replace(s, #"\[([^\]]+)\]\([^)]*\)"#, with: "$1")
+    // Autolinks / bare URLs → drop.
+    s = replace(s, #"<https?://[^>]+>"#, with: "")
+    s = replace(s, #"https?://[^\s)]+"#, with: "")
+    // Inline code: keep the inner text, drop the backticks.
+    s = replace(s, "`+", with: "")
+    // Heading hashes, blockquote markers, list bullets at line starts.
+    s = replace(s, #"(?m)^\s{0,3}#{1,6}\s+"#, with: "")
+    s = replace(s, #"(?m)^\s{0,3}>\s?"#, with: "")
+    s = replace(s, #"(?m)^\s*[-*+]\s+"#, with: "")
+    s = replace(s, #"(?m)^\s*\d+\.\s+"#, with: "")
+    // Emphasis / strikethrough markers.
+    s = replace(s, #"[*_~]{1,3}"#, with: "")
+    // Collapse whitespace.
+    s = replace(s, #"\s+"#, with: " ")
+    return s.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  // MARK: 3. Heuristic condense
+
+  /// Roughly the first 60% of the reply by length (whole sentences), always keeping a
+  /// trailing question so the "what's next" ask survives. Condenses long explanations
+  /// without collapsing them to a single micro-sentence.
+  private static let retainFraction = 0.6
+
+  private static func condense(_ text: String) -> String {
+    let sentences = splitSentences(text)
+    guard sentences.count > 1 else { return sentences.first ?? text }
+
+    let total = sentences.reduce(0) { $0 + $1.count }
+    let target = Double(total) * retainFraction
+    var kept: [String] = []
+    var acc = 0
+    for sentence in sentences {
+      kept.append(sentence)
+      acc += sentence.count
+      if Double(acc) >= target { break }
+    }
+
+    // Always include a trailing question (the actionable ask), even if it fell past 60%.
+    if let last = sentences.last, last.hasSuffix("?"), kept.last != last {
+      kept.append(last)
+    }
+    return kept.joined(separator: " ")
+  }
+
+  // Kept deliberately short: an abbreviation like "al." would also match "material.",
+  // suppressing real sentence breaks, so only include unambiguous multi-dot forms.
+  private static let abbreviations = ["e.g.", "i.e.", "etc.", "vs."]
+
+  private static func splitSentences(_ text: String) -> [String] {
+    var sentences: [String] = []
+    var current = ""
+    let chars = Array(text)
+    for (i, ch) in chars.enumerated() {
+      current.append(ch)
+      guard ch == "." || ch == "!" || ch == "?" else { continue }
+      // Only a real boundary if the next character is whitespace or the end — so dots
+      // inside "AgentView.swift" or "e.g." don't split a sentence mid-word.
+      let next = i + 1 < chars.count ? chars[i + 1] : nil
+      guard next == nil || next!.isWhitespace else { continue }
+      // Don't split after a common abbreviation ("e.g.", "i.e.", "etc.").
+      let lower = current.trimmingCharacters(in: .whitespaces).lowercased()
+      if ch == ".", abbreviations.contains(where: { lower.hasSuffix($0) }) { continue }
+      let trimmed = current.trimmingCharacters(in: .whitespaces)
+      if !trimmed.isEmpty { sentences.append(trimmed) }
+      current = ""
+    }
+    let tail = current.trimmingCharacters(in: .whitespaces)
+    if !tail.isEmpty { sentences.append(tail) }
+    return sentences
+  }
+
+  // MARK: Helper
+
+  private static func replace(_ text: String, _ pattern: String, with template: String) -> String {
+    guard let re = try? NSRegularExpression(pattern: pattern) else { return text }
+    let range = NSRange(text.startIndex..., in: text)
+    return re.stringByReplacingMatches(in: text, range: range, withTemplate: template)
+  }
+}

--- a/Hex/Features/App/AppFeature.swift
+++ b/Hex/Features/App/AppFeature.swift
@@ -17,6 +17,7 @@ struct AppFeature {
     case settings
     case remappings
     case history
+    case agentPlugins
     case about
   }
 
@@ -25,6 +26,7 @@ struct AppFeature {
 		var transcription: TranscriptionFeature.State = .init()
 		var settings: SettingsFeature.State = .init()
 		var history: HistoryFeature.State = .init()
+		var agent: AgentFeature.State = .init()
 		var activeTab: ActiveTab = .settings
 		@Shared(.hexSettings) var hexSettings: HexSettings
 		@Shared(.modelBootstrapState) var modelBootstrapState: ModelBootstrapState
@@ -40,6 +42,7 @@ struct AppFeature {
     case transcription(TranscriptionFeature.Action)
     case settings(SettingsFeature.Action)
     case history(HistoryFeature.Action)
+    case agent(AgentFeature.Action)
     case setActiveTab(ActiveTab)
     case task
     case pasteLastTranscript
@@ -71,9 +74,16 @@ struct AppFeature {
       HistoryFeature()
     }
 
+    Scope(state: \.agent, action: \.agent) {
+      AgentFeature()
+    }
+
     Reduce { state, action in
       switch action {
       case .binding:
+        return .none
+
+      case .agent:
         return .none
         
       case .task:
@@ -175,25 +185,37 @@ struct AppFeature {
       @Shared(.isSettingPasteLastTranscriptHotkey) var isSettingPasteLastTranscriptHotkey: Bool
       @Shared(.hexSettings) var hexSettings: HexSettings
 
+      @Shared(.isSettingAgentWindowHotkey) var isSettingAgentWindowHotkey: Bool
+
       let token = keyEventMonitor.handleKeyEvent { keyEvent in
         // Skip if user is setting a hotkey
-        if isSettingPasteLastTranscriptHotkey {
+        if isSettingPasteLastTranscriptHotkey || isSettingAgentWindowHotkey {
           return false
         }
 
-        // Check if this matches the paste last transcript hotkey
-        guard let pasteHotkey = hexSettings.pasteLastTranscriptHotkey,
-              let key = keyEvent.key,
-              key == pasteHotkey.key,
-              keyEvent.modifiers.matchesExactly(pasteHotkey.modifiers) else {
-          return false
+        guard let key = keyEvent.key else { return false }
+
+        // Paste last transcript hotkey
+        if let pasteHotkey = hexSettings.pasteLastTranscriptHotkey,
+           key == pasteHotkey.key,
+           keyEvent.modifiers.matchesExactly(pasteHotkey.modifiers) {
+          MainActor.assumeIsolated {
+            send(.pasteLastTranscript)
+          }
+          return true // Intercept the key event
         }
 
-        // Trigger paste action - use MainActor to avoid escaping send
-        MainActor.assumeIsolated {
-          send(.pasteLastTranscript)
+        // Summon-the-agent-window hotkey
+        if let agentHotkey = hexSettings.agentWindowHotkey,
+           key == agentHotkey.key,
+           keyEvent.modifiers.matchesExactly(agentHotkey.modifiers) {
+          MainActor.assumeIsolated {
+            send(.agent(.openManually))
+          }
+          return true
         }
-        return true // Intercept the key event
+
+        return false
       }
 
       defer { token.cancel() }
@@ -284,6 +306,14 @@ struct AppView: View {
         .tag(AppFeature.ActiveTab.history)
 
         Button {
+          store.send(.setActiveTab(.agentPlugins))
+        } label: {
+          Label("Agent Plugins", systemImage: "terminal")
+        }
+        .buttonStyle(.plain)
+        .tag(AppFeature.ActiveTab.agentPlugins)
+
+        Button {
           store.send(.setActiveTab(.about))
         } label: {
           Label("About", systemImage: "info.circle")
@@ -307,6 +337,9 @@ struct AppView: View {
       case .history:
         HistoryView(store: store.scope(state: \.history, action: \.history))
           .navigationTitle("History")
+      case .agentPlugins:
+        AgentPluginsSettingsView(store: store.scope(state: \.settings, action: \.settings))
+          .navigationTitle("Agent Plugins")
       case .about:
         AboutView(store: store.scope(state: \.settings, action: \.settings))
           .navigationTitle("About")

--- a/Hex/Features/Settings/AgentPluginsSectionView.swift
+++ b/Hex/Features/Settings/AgentPluginsSectionView.swift
@@ -1,0 +1,220 @@
+import ComposableArchitecture
+import HexCore
+import Inject
+import SwiftUI
+
+/// Standalone tab wrapper so "Agent Plugins" can appear as its own sidebar section.
+struct AgentPluginsSettingsView: View {
+	@ObserveInjection var inject
+	@Bindable var store: StoreOf<SettingsFeature>
+
+	var body: some View {
+		Form {
+			AgentPluginsSectionView(store: store)
+		}
+		.formStyle(.grouped)
+		.task {
+			await store.send(.task).finish()
+		}
+		.enableInjection()
+	}
+}
+
+struct AgentPluginsSectionView: View {
+	@ObserveInjection var inject
+	@Bindable var store: StoreOf<SettingsFeature>
+
+	var body: some View {
+		Section {
+			Label {
+				Toggle(
+					"Enable Agent Plugins",
+					isOn: Binding(
+						get: { store.hexSettings.agentPluginsEnabled },
+						set: { store.send(.toggleAgentPluginsEnabled($0)) }
+					)
+				)
+				Text("Pop a voice window when an installed agent finishes a turn or asks a question, so you can speak your reply.")
+			} icon: {
+				Image(systemName: "waveform.badge.mic")
+			}
+
+			Label {
+				Toggle(
+					"Submit on Send",
+					isOn: Binding(
+						get: { store.hexSettings.agentAutoSubmit },
+						set: { store.send(.setAgentAutoSubmit($0)) }
+					)
+				)
+				Text("Press Return after pasting your reply into the terminal. Turn off to paste without submitting.")
+			} icon: {
+				Image(systemName: "return")
+			}
+
+			Label {
+				HStack {
+					Picker(
+						"Read-Aloud Voice",
+						selection: Binding(
+							get: { String?.some(KokoroVoice.voiceName(fromIdentifier: store.hexSettings.agentVoiceIdentifier)) },
+							set: { store.send(.setAgentVoice($0)) }
+						)
+					) {
+						ForEach(KokoroVoice.voices, id: \.self) { name in
+							Text(KokoroVoice.label(forVoiceName: name)).tag(String?.some(name))
+						}
+					}
+					Button {
+						store.send(.previewAgentVoice)
+					} label: {
+						Image(systemName: "play.circle")
+					}
+					.buttonStyle(.plain)
+					.help("Preview the selected voice")
+					.disabled(store.kokoroDownloadProgress != nil)
+				}
+				if let progress = store.kokoroDownloadProgress {
+					HStack(spacing: 8) {
+						ProgressView(value: progress)
+							.progressViewStyle(.linear)
+						Text("Downloading Kokoro model… \(Int(progress * 100))%")
+							.font(.caption)
+							.foregroundStyle(.secondary)
+							.fixedSize()
+					}
+				}
+				Text("Kokoro voice used when the agent window reads output aloud. The model (~300 MB) downloads on first use.")
+			} icon: {
+				Image(systemName: "speaker.wave.2")
+			}
+
+			Label {
+				Toggle(
+					"Distinct Voice per Project",
+					isOn: Binding(
+						get: { store.hexSettings.agentDistinctSessionVoices },
+						set: { store.send(.setAgentDistinctSessionVoices($0)) }
+					)
+				)
+				Text("Give each concurrent Claude session its own consistent voice so you can tell projects apart by ear. Your first session keeps the voice above; others get distinct voices. Enabling this preloads the model.")
+			} icon: {
+				Image(systemName: "person.2.wave.2")
+			}
+
+			AgentWindowHotkeyRow(store: store)
+		} header: {
+			Text("Agent Plugins")
+		}
+
+		Section {
+			pluginRow(
+				name: "Claude Code",
+				systemImage: "chevron.left.forwardslash.chevron.right",
+				installed: store.agentPluginInstalled,
+				install: { store.send(.installAgentPlugin) },
+				uninstall: { store.send(.uninstallAgentPlugin) }
+			)
+
+			// Codex support is planned — shown disabled to mirror the competitor UI.
+			Label {
+				HStack {
+					Text("Codex")
+					Spacer()
+					Text("Coming soon").settingsCaption()
+				}
+			} icon: {
+				Image(systemName: "cpu")
+			}
+			.disabled(true)
+		} header: {
+			Text("Integrations")
+		} footer: {
+			Text("Installing writes a hook to ~/.claude so Claude Code can open Hex. Uninstalling removes it.")
+				.settingsCaption()
+		}
+		.enableInjection()
+	}
+
+	@ViewBuilder
+	private func pluginRow(
+		name: String,
+		systemImage: String,
+		installed: Bool,
+		install: @escaping () -> Void,
+		uninstall: @escaping () -> Void
+	) -> some View {
+		Label {
+			HStack {
+				Text(name)
+				Spacer()
+				if installed {
+					Text("Installed").settingsCaption()
+					Button("Uninstall", role: .destructive, action: uninstall)
+				} else {
+					Button("Install", action: install)
+						.buttonStyle(.borderedProminent)
+				}
+			}
+		} icon: {
+			Image(systemName: systemImage)
+		}
+	}
+}
+
+private struct AgentWindowHotkeyRow: View {
+	@ObserveInjection var inject
+	@Bindable var store: StoreOf<SettingsFeature>
+
+	var body: some View {
+		let hotkey = store.hexSettings.agentWindowHotkey
+
+		VStack(alignment: .leading, spacing: 12) {
+			Label {
+				VStack(alignment: .leading, spacing: 2) {
+					Text("Summon Agent Window")
+						.font(.subheadline.weight(.semibold))
+					Text("Assign a shortcut (modifier + key) to open the agent window from anywhere and talk to Claude.")
+						.settingsCaption()
+				}
+			} icon: {
+				Image(systemName: "bubble.left.and.text.bubble.right")
+			}
+
+			let key = store.isSettingAgentWindowHotkey ? nil : hotkey?.key
+			let modifiers = store.isSettingAgentWindowHotkey ? store.currentAgentWindowModifiers : (hotkey?.modifiers ?? .init(modifiers: []))
+
+			HStack {
+				Spacer()
+				ZStack {
+					HotKeyView(modifiers: modifiers, key: key, isActive: store.isSettingAgentWindowHotkey)
+
+					if !store.isSettingAgentWindowHotkey, hotkey == nil {
+						Text("Not set")
+							.settingsCaption()
+					}
+				}
+				.contentShape(Rectangle())
+				.onTapGesture {
+					store.send(.startSettingAgentWindowHotkey)
+				}
+				Spacer()
+			}
+
+			if store.isSettingAgentWindowHotkey {
+				Text("Use at least one modifier (⌘, ⌥, ⇧, ⌃) plus a key.")
+					.settingsCaption()
+			} else if hotkey != nil {
+				Button {
+					store.send(.clearAgentWindowHotkey)
+				} label: {
+					Label("Clear shortcut", systemImage: "xmark.circle")
+				}
+				.buttonStyle(.borderless)
+				.font(.caption)
+				.foregroundStyle(.secondary)
+			}
+		}
+		.enableInjection()
+	}
+}

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -15,6 +15,7 @@ private typealias SettingsAudioPropertyListenerBlock = @convention(block) (UInt3
 private enum HotKeyCaptureTarget {
   case recording
   case pasteLastTranscript
+  case agentWindow
 }
 
 extension SharedReaderKey
@@ -26,6 +27,10 @@ extension SharedReaderKey
   
   static var isSettingPasteLastTranscriptHotkey: Self {
     Self[.inMemory("isSettingPasteLastTranscriptHotkey"), default: false]
+  }
+
+  static var isSettingAgentWindowHotkey: Self {
+    Self[.inMemory("isSettingAgentWindowHotkey"), default: false]
   }
 
   static var isRemappingScratchpadFocused: Self {
@@ -42,6 +47,7 @@ struct SettingsFeature {
     @Shared(.hexSettings) var hexSettings: HexSettings
     @Shared(.isSettingHotKey) var isSettingHotKey: Bool = false
     @Shared(.isSettingPasteLastTranscriptHotkey) var isSettingPasteLastTranscriptHotkey: Bool = false
+    @Shared(.isSettingAgentWindowHotkey) var isSettingAgentWindowHotkey: Bool = false
     @Shared(.isRemappingScratchpadFocused) var isRemappingScratchpadFocused: Bool = false
     @Shared(.transcriptionHistory) var transcriptionHistory: TranscriptionHistory
     @Shared(.hotkeyPermissionState) var hotkeyPermissionState: HotkeyPermissionState
@@ -49,6 +55,7 @@ struct SettingsFeature {
     var languages: IdentifiedArrayOf<Language> = []
     var currentModifiers: Modifiers = .init(modifiers: [])
     var currentPasteLastModifiers: Modifiers = .init(modifiers: [])
+    var currentAgentWindowModifiers: Modifiers = .init(modifiers: [])
     var remappingScratchpadText: String = ""
     
     // Available microphones
@@ -58,6 +65,12 @@ struct SettingsFeature {
     // Model Management
     var modelDownload = ModelDownloadFeature.State()
     var shouldFlashModelSection = false
+
+    // Agent Plugins
+    var agentPluginInstalled = false
+    /// Non-nil while the Kokoro TTS model is downloading (0...1).
+    var kokoroDownloadProgress: Double?
+    var kokoroReady = false
 
   }
 
@@ -101,6 +114,21 @@ struct SettingsFeature {
     case toggleSaveTranscriptionHistory(Bool)
     case setMaxHistoryEntries(Int?)
 
+    // Agent Plugins
+    case toggleAgentPluginsEnabled(Bool)
+    case setAgentAutoSubmit(Bool)
+    case setAgentVoice(String?)
+    case setAgentDistinctSessionVoices(Bool)
+    case previewAgentVoice
+    case startSettingAgentWindowHotkey
+    case clearAgentWindowHotkey
+    case prepareKokoro
+    case kokoroPrepareProgress(Double)
+    case kokoroPrepared(success: Bool)
+    case installAgentPlugin
+    case uninstallAgentPlugin
+    case agentPluginStatusLoaded(Bool)
+
     // Modifier configuration
     case setModifierSide(Modifier.Kind, Modifier.Side)
 
@@ -120,6 +148,8 @@ struct SettingsFeature {
   @Dependency(\.recording) var recording
   @Dependency(\.soundEffects) var soundEffects
   @Dependency(\.transcriptPersistence) var transcriptPersistence
+  @Dependency(\.claudePlugin) var claudePlugin
+  @Dependency(\.speechSynthesizer) var speechSynthesizer
 
   private func deleteAudioEffect(for transcripts: [Transcript]) -> Effect<Action> {
     .run { [transcriptPersistence] _ in
@@ -137,6 +167,9 @@ struct SettingsFeature {
     case .pasteLastTranscript:
       state.$isSettingPasteLastTranscriptHotkey.withLock { $0 = true }
       state.currentPasteLastModifiers = .init(modifiers: [])
+    case .agentWindow:
+      state.$isSettingAgentWindowHotkey.withLock { $0 = true }
+      state.currentAgentWindowModifiers = .init(modifiers: [])
     }
   }
 
@@ -148,6 +181,9 @@ struct SettingsFeature {
     case .pasteLastTranscript:
       state.$isSettingPasteLastTranscriptHotkey.withLock { $0 = false }
       state.currentPasteLastModifiers = .init(modifiers: [])
+    case .agentWindow:
+      state.$isSettingAgentWindowHotkey.withLock { $0 = false }
+      state.currentAgentWindowModifiers = .init(modifiers: [])
     }
   }
 
@@ -157,6 +193,8 @@ struct SettingsFeature {
       state.currentModifiers
     case .pasteLastTranscript:
       state.currentPasteLastModifiers
+    case .agentWindow:
+      state.currentAgentWindowModifiers
     }
   }
 
@@ -166,6 +204,8 @@ struct SettingsFeature {
       state.currentModifiers = modifiers
     case .pasteLastTranscript:
       state.currentPasteLastModifiers = modifiers
+    case .agentWindow:
+      state.currentAgentWindowModifiers = modifiers
     }
   }
 
@@ -181,6 +221,11 @@ struct SettingsFeature {
       state.$hexSettings.withLock {
         $0.pasteLastTranscriptHotkey = HotKey(key: key, modifiers: modifiers.erasingSides())
       }
+    case .agentWindow:
+      guard let key else { return }
+      state.$hexSettings.withLock {
+        $0.agentWindowHotkey = HotKey(key: key, modifiers: modifiers.erasingSides())
+      }
     }
   }
 
@@ -193,7 +238,7 @@ struct SettingsFeature {
     let updatedModifiers = keyEvent.modifiers.union(captureModifiers(for: target, state: state))
     updateCaptureModifiers(updatedModifiers, for: target, state: &state)
 
-    if target == .pasteLastTranscript, keyEvent.key != nil, updatedModifiers.isEmpty {
+    if target != .recording, keyEvent.key != nil, updatedModifiers.isEmpty {
       return .none
     }
 
@@ -256,6 +301,9 @@ struct SettingsFeature {
 
           await send(.modelDownload(.fetchModels))
           await send(.loadAvailableInputDevices)
+          // Self-heal an out-of-date hook script (e.g. after an app update) before reporting status.
+          await claudePlugin.refreshIfStale()
+          await send(.agentPluginStatusLoaded(await claudePlugin.isInstalled()))
 
           // Listen for device connection/disconnection notifications
           // Using a simpler debounced approach with a single task
@@ -404,12 +452,23 @@ struct SettingsFeature {
       case .startSettingPasteLastTranscriptHotkey:
         beginCapture(.pasteLastTranscript, state: &state)
         return .none
-        
+
       case .clearPasteLastTranscriptHotkey:
         state.$hexSettings.withLock { $0.pasteLastTranscriptHotkey = nil }
         return .none
 
+      case .startSettingAgentWindowHotkey:
+        beginCapture(.agentWindow, state: &state)
+        return .none
+
+      case .clearAgentWindowHotkey:
+        state.$hexSettings.withLock { $0.agentWindowHotkey = nil }
+        return .none
+
       case let .keyEvent(keyEvent):
+        if state.isSettingAgentWindowHotkey {
+          return handleCapture(keyEvent, for: .agentWindow, state: &state)
+        }
         if state.isSettingPasteLastTranscriptHotkey {
           return handleCapture(keyEvent, for: .pasteLastTranscript, state: &state)
         }
@@ -562,6 +621,82 @@ struct SettingsFeature {
 
       case let .setWordRemovalsEnabled(enabled):
         state.$hexSettings.withLock { $0.wordRemovalsEnabled = enabled }
+        return .none
+
+      // MARK: - Agent Plugins
+
+      case let .toggleAgentPluginsEnabled(enabled):
+        state.$hexSettings.withLock { $0.agentPluginsEnabled = enabled }
+        return .none
+
+      case let .setAgentAutoSubmit(enabled):
+        state.$hexSettings.withLock { $0.agentAutoSubmit = enabled }
+        return .none
+
+      case let .setAgentVoice(identifier):
+        state.$hexSettings.withLock { $0.agentVoiceIdentifier = identifier }
+        return .send(.previewAgentVoice)
+
+      case let .setAgentDistinctSessionVoices(enabled):
+        state.$hexSettings.withLock { $0.agentDistinctSessionVoices = enabled }
+        // Warm the Kokoro model so the extra voices are ready the first time a second
+        // project speaks (one model covers every voice, so this preloads them all).
+        return enabled && !state.kokoroReady ? .send(.prepareKokoro) : .none
+
+      case .previewAgentVoice:
+        // The Kokoro model must be downloaded before it can make a sound.
+        guard state.kokoroReady else { return .send(.prepareKokoro) }
+        let voice = state.hexSettings.agentVoiceIdentifier
+        return .run { _ in
+          await speechSynthesizer.speak("Hi! This is how Hex will read agent output aloud.", voice)
+        }
+
+      case .prepareKokoro:
+        guard state.kokoroDownloadProgress == nil else { return .none } // already downloading
+        state.kokoroDownloadProgress = 0
+        return .run { send in
+          do {
+            try await speechSynthesizer.prepareKokoro { progress in
+              Task { await send(.kokoroPrepareProgress(progress)) }
+            }
+            await send(.kokoroPrepared(success: true))
+          } catch {
+            settingsLogger.error("Kokoro model download failed: \(error.localizedDescription)")
+            await send(.kokoroPrepared(success: false))
+          }
+        }
+
+      case let .kokoroPrepareProgress(progress):
+        state.kokoroDownloadProgress = progress
+        return .none
+
+      case let .kokoroPrepared(success):
+        state.kokoroDownloadProgress = nil
+        state.kokoroReady = success
+        return success ? .send(.previewAgentVoice) : .none
+
+      case .installAgentPlugin:
+        return .run { send in
+          do {
+            try await claudePlugin.install()
+          } catch {
+            settingsLogger.error("Failed to install Claude Code plugin: \(error.localizedDescription)")
+          }
+          await send(.agentPluginStatusLoaded(await claudePlugin.isInstalled()))
+        }
+
+      case .uninstallAgentPlugin:
+        return .run { send in
+          do {
+            try await claudePlugin.uninstall()
+          } catch {
+            settingsLogger.error("Failed to uninstall Claude Code plugin: \(error.localizedDescription)")
+          }
+          await send(.agentPluginStatusLoaded(await claudePlugin.isInstalled()))
+        }
+
+      case let .agentPluginStatusLoaded(installed):
+        state.agentPluginInstalled = installed
         return .none
 
       }

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -72,6 +72,7 @@ struct TranscriptionFeature {
   @Dependency(\.sleepManagement) var sleepManagement
   @Dependency(\.date.now) var now
   @Dependency(\.transcriptPersistence) var transcriptPersistence
+  @Dependency(\.speechSynthesizer) var speechSynthesizer
 
   var body: some ReducerOf<Self> {
     Reduce { state, action in
@@ -302,6 +303,8 @@ private extension TranscriptionFeature {
     // Prevent system sleep during recording
     return .merge(
       .cancel(id: CancelID.recordingCleanup),
+      // Silence the agent read-aloud voice so it doesn't talk over (or into) the mic.
+      .run { _ in await speechSynthesizer.stop() },
       .run { [sleepManagement, preventSleep = state.hexSettings.preventSystemSleep] _ in
         // Play sound immediately for instant feedback
         soundEffect.play(.startRecording)

--- a/Hex/Hex.entitlements
+++ b/Hex/Hex.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/Hex/Info.plist
+++ b/Hex/Info.plist
@@ -8,6 +8,17 @@
 	<string>AppIcon</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.kitlangton.Hex.agent</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>hex</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleShortVersionString</key>
 	<string>0.7.6</string>
 	<key>CFBundleVersion</key>

--- a/Hex/Views/AgentPanel.swift
+++ b/Hex/Views/AgentPanel.swift
@@ -1,0 +1,73 @@
+//
+//  AgentPanel.swift
+//  Hex
+//
+//  An interactive, non-activating floating panel used by the Agent Plugins feature.
+//
+//  Unlike `InvisibleWindow` (which ignores the mouse and never becomes key), this panel
+//  hosts an editable text field and buttons. `.nonactivatingPanel` + `becomesKeyOnlyIfNeeded`
+//  let the text field receive keystrokes WITHOUT making Hex the active application, so the
+//  terminal running `claude` stays frontmost and we can paste back into it.
+//
+
+import AppKit
+import SwiftUI
+
+final class AgentPanel: NSPanel {
+  // Must become key so the SwiftUI TextField can receive typed characters.
+  override var canBecomeKey: Bool { true }
+  // Never become "main" — we don't want to masquerade as the active app's main window.
+  override var canBecomeMain: Bool { false }
+
+  init() {
+    super.init(
+      contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+      styleMask: [.titled, .fullSizeContentView, .nonactivatingPanel, .closable, .resizable],
+      backing: .buffered,
+      defer: false
+    )
+
+    isFloatingPanel = true
+    becomesKeyOnlyIfNeeded = true   // only grabs key focus when a control needs it
+    level = .floating               // above normal windows (incl. the terminal)
+    titleVisibility = .hidden
+    titlebarAppearsTransparent = true
+    standardWindowButton(.closeButton)?.isHidden = true
+    standardWindowButton(.miniaturizeButton)?.isHidden = true
+    standardWindowButton(.zoomButton)?.isHidden = true
+    isMovableByWindowBackground = true
+    backgroundColor = .clear
+    isOpaque = false
+    // Each SwiftUI card draws its own shadow, so the window itself must not.
+    hasShadow = false
+    hidesOnDeactivate = false        // we control dismissal explicitly
+    isReleasedWhenClosed = false
+    animationBehavior = .utilityWindow
+    // Note: .canJoinAllSpaces and .moveToActiveSpace are mutually exclusive — combining
+    // them trips an NSWindow assertion. Use canJoinAllSpaces so the panel follows the user.
+    collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+  }
+
+  static func fromView<V: View>(_ view: V) -> AgentPanel {
+    let panel = AgentPanel()
+    // A hosting CONTROLLER (not view) makes the window size itself to the SwiftUI
+    // content. `.preferredContentSize` is what keeps the window tracking the content
+    // as it changes height — without it the fixed 320pt window clips a growing input.
+    let host = NSHostingController(rootView: view)
+    host.sizingOptions = [.preferredContentSize]
+    panel.contentViewController = host
+    return panel
+  }
+
+  /// Place the panel near the mouse (which is over the terminal), clamped on-screen.
+  func positionNearMouse() {
+    let mouse = NSEvent.mouseLocation
+    let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main
+    guard let screen else { return }
+    let vf = screen.visibleFrame
+    var origin = NSPoint(x: mouse.x - frame.width / 2, y: mouse.y - frame.height - 24)
+    origin.x = min(max(origin.x, vf.minX + 8), vf.maxX - frame.width - 8)
+    origin.y = min(max(origin.y, vf.minY + 8), vf.maxY - frame.height - 8)
+    setFrameOrigin(origin)
+  }
+}

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -47,6 +47,21 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var wordRemovalsEnabled: Bool
 	public var wordRemovals: [WordRemoval]
 	public var wordRemappings: [WordRemapping]
+	/// Enables the Agent Plugins voice window for Claude Code (and future agents).
+	public var agentPluginsEnabled: Bool
+	/// When true, sending a reply also presses Return so it submits immediately.
+	public var agentAutoSubmit: Bool
+	/// When true, the agent window reads its output aloud via text-to-speech.
+	public var agentSpeakOutput: Bool
+	/// Kokoro voice name for reading output aloud (e.g. "af_heart"); nil = default voice.
+	public var agentVoiceIdentifier: String?
+	/// When true, each Claude session is read aloud in its own consistent voice — so
+	/// concurrent projects are distinguishable by ear and each project keeps the same voice
+	/// across turns. The first/primary session keeps the chosen default voice; additional
+	/// sessions get distinct voices. When false, every session uses the default voice.
+	public var agentDistinctSessionVoices: Bool
+	/// Global hotkey that summons the agent window from anywhere; nil = not set.
+	public var agentWindowHotkey: HotKey?
 
 	private mutating func normalizeDoubleTapSettings() {
 		if !doubleTapLockEnabled {
@@ -78,7 +93,13 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		hasCompletedStorageMigration: Bool = false,
 		wordRemovalsEnabled: Bool = false,
 		wordRemovals: [WordRemoval] = HexSettings.defaultWordRemovals,
-		wordRemappings: [WordRemapping] = []
+		wordRemappings: [WordRemapping] = [],
+		agentPluginsEnabled: Bool = false,
+		agentAutoSubmit: Bool = true,
+		agentSpeakOutput: Bool = false,
+		agentVoiceIdentifier: String? = nil,
+		agentDistinctSessionVoices: Bool = true,
+		agentWindowHotkey: HotKey? = nil
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
 		self.soundEffectsVolume = soundEffectsVolume
@@ -104,6 +125,12 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.wordRemovalsEnabled = wordRemovalsEnabled
 		self.wordRemovals = wordRemovals
 		self.wordRemappings = wordRemappings
+		self.agentPluginsEnabled = agentPluginsEnabled
+		self.agentAutoSubmit = agentAutoSubmit
+		self.agentSpeakOutput = agentSpeakOutput
+		self.agentVoiceIdentifier = agentVoiceIdentifier
+		self.agentDistinctSessionVoices = agentDistinctSessionVoices
+		self.agentWindowHotkey = agentWindowHotkey
 		normalizeDoubleTapSettings()
 	}
 
@@ -152,6 +179,12 @@ private enum HexSettingKey: String, CodingKey, CaseIterable {
 	case wordRemovalsEnabled
 	case wordRemovals
 	case wordRemappings
+	case agentPluginsEnabled
+	case agentAutoSubmit
+	case agentSpeakOutput
+	case agentVoiceIdentifier
+	case agentDistinctSessionVoices
+	case agentWindowHotkey
 }
 
 private struct SettingsField<Value: Codable & Sendable> {
@@ -284,6 +317,26 @@ private enum HexSettingsSchema {
 			.wordRemappings,
 			keyPath: \.wordRemappings,
 			default: defaults.wordRemappings
+		).eraseToAny(),
+		SettingsField(.agentPluginsEnabled, keyPath: \.agentPluginsEnabled, default: defaults.agentPluginsEnabled).eraseToAny(),
+		SettingsField(.agentAutoSubmit, keyPath: \.agentAutoSubmit, default: defaults.agentAutoSubmit).eraseToAny(),
+		SettingsField(.agentSpeakOutput, keyPath: \.agentSpeakOutput, default: defaults.agentSpeakOutput).eraseToAny(),
+		SettingsField(
+			.agentVoiceIdentifier,
+			keyPath: \.agentVoiceIdentifier,
+			default: defaults.agentVoiceIdentifier,
+			encode: { container, key, value in
+				try container.encodeIfPresent(value, forKey: key)
+			}
+		).eraseToAny(),
+		SettingsField(.agentDistinctSessionVoices, keyPath: \.agentDistinctSessionVoices, default: defaults.agentDistinctSessionVoices).eraseToAny(),
+		SettingsField(
+			.agentWindowHotkey,
+			keyPath: \.agentWindowHotkey,
+			default: defaults.agentWindowHotkey,
+			encode: { container, key, value in
+				try container.encodeIfPresent(value, forKey: key)
+			}
 		).eraseToAny()
 	]
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "build": "bun run tools/scripts/build-app.ts",
+    "build:run": "bun run tools/scripts/build-app.ts --run",
     "release": "cd tools && bun run build",
     "changeset": "changeset",
     "changeset:add": "changeset",

--- a/tools/scripts/build-app.ts
+++ b/tools/scripts/build-app.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/**
+ * Build the Hex macOS app from the command line.
+ *
+ * Usage:
+ *   bun run build              # Debug build into build/DerivedData
+ *   bun run build --release    # Release configuration
+ *   bun run build --run        # build, then (re)launch the app
+ *
+ * Notes:
+ *  - `-skipMacroValidation` is required: the SPM macro plugins (TCA, Dependencies,
+ *    CasePaths, Perception) are otherwise rejected as "must be enabled" on the CLI.
+ *  - `-allowProvisioningUpdates` lets xcodebuild resolve the signing identity from the
+ *    project's DEVELOPMENT_TEAM without manual provisioning.
+ *  - A project-local derivedDataPath keeps the signed .app next to the repo and avoids
+ *    the "Hex Debug 2/3.app" duplicates LaunchServices spawns in the shared DerivedData.
+ */
+
+import { spawnSync } from "child_process";
+import { existsSync, rmSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, "..", "..");
+const args = process.argv.slice(2);
+const release = args.includes("--release");
+const run = args.includes("--run");
+const configuration = release ? "Release" : "Debug";
+const derivedData = join(repoRoot, "build", "DerivedData");
+const productsDir = join(derivedData, "Build", "Products", configuration);
+
+function sh(cmd: string, cmdArgs: string[]): void {
+  const res = spawnSync(cmd, cmdArgs, { cwd: repoRoot, stdio: "inherit" });
+  if (res.status !== 0) process.exit(res.status ?? 1);
+}
+
+// Stale numbered copies fragment TCC grants (Input Monitoring etc.) — clear them first.
+for (const suffix of [" 2", " 3", " 4"]) {
+  const dup = join(productsDir, `Hex Debug${suffix}.app`);
+  if (existsSync(dup)) rmSync(dup, { recursive: true, force: true });
+}
+
+console.log(`Building Hex (${configuration})…`);
+sh("xcodebuild", [
+  "-project", "Hex.xcodeproj",
+  "-scheme", "Hex",
+  "-configuration", configuration,
+  "-derivedDataPath", derivedData,
+  "-skipMacroValidation",
+  "-allowProvisioningUpdates",
+  "build",
+]);
+
+const appName = release ? "Hex.app" : "Hex Debug.app";
+const appPath = join(productsDir, appName);
+console.log(`\n✅ Built ${appPath}`);
+
+if (run) {
+  console.log("Relaunching…");
+  spawnSync("pkill", ["-f", appName.replace(".app", "")], { stdio: "ignore" });
+  sh("open", [appPath]);
+}


### PR DESCRIPTION
Adds an opt-in **Agent Plugins** integration: a floating voice window that pops up whenever Claude Code finishes a turn, asks a multiple-choice question, or requests a permission — so you can answer by voice, typing, or tapping an option without leaving your editor. It mirrors the superwhisper-style flow but is fully on-device and local.

### How it works
Installing the Claude Code integration (Settings → Agent Plugins) writes a small hook script under `~/.claude` and registers `Stop` / `PreToolUse` (AskUserQuestion) / `PermissionRequest` / `UserPromptSubmit` hooks — no marketplace, everything stays on the user's machine. The hook blocks, hands the current prompt to Hex through a `hex://` deeplink, and polls for a response file. Hex writes the complete hook-output JSON to `<payload>.response` and the script relays it to Claude Code on stdout, so the answer travels **in-band to the exact session** — no window focusing, no synthetic keystrokes, and the answer can never land in the wrong window. (Typing into the terminal remains only as a legacy fallback when no payload file is available.)

### What you get
- **Concurrent sessions.** A FIFO queue holds one card per blocked project; the oldest is shown, newcomers wait their turn, and answering/dismissing advances to the next. Every teardown — answer, dismiss, supersede, even app quit — writes a response, so a session never hangs on its hook timeout. The card header shows the project + host app and an `n / N` position when several are waiting.
- **Single-instance delivery.** The installed hook targets the specific Hex that installed it (by bundle id, then exact app path) rather than letting the `hex://` scheme launch any registered Hex, so multiple terminals all talk to one window instead of spawning extra instances. Out-of-date hook scripts self-heal on launch.
- **Read-aloud output** via on-device Kokoro TTS (FluidAudio). Replies can include an explicit `Spoken:` summary line, and long replies are condensed by a heuristic (code blocks dropped, link labels read instead of URLs).
- **Distinct voice per project.** Each session keeps a consistent voice for the run — the first session keeps your chosen default, concurrent ones diverge — so you can tell projects apart by ear.
- **Quality-of-life:** auto-send a dictated/pasted reply after a short cancelable countdown; submit on Return / Shift+Return; single-select options answer immediately while multi-select accumulates; a global hotkey summons the window from anywhere and locates the hosting Claude terminal.

### Notes for review
- Requires the app to be **unsandboxed** (to read/write `~/.claude`) and adds the `hex://` URL scheme; `Hex.entitlements` and `Info.plist` are updated accordingly.
- All behavior is **opt-in and off by default**, configured under Settings → Agent Plugins.
- New code is isolated under `Hex/Features/Agent/*` plus three dependency clients (`ClaudePluginClient`, `AgentTranscriptClient`, `SpeechSynthesizerClient`); changesets are included.
- There are **no automated tests yet** — a TCA `TestStore` suite around the queue, in-band hook responses, and voice assignment is the natural follow-up, and I'm happy to add it.

Opened as a **draft** for feedback on the approach (the hook contract and unsandboxing in particular) before polishing.
