### PR TITLE
Add lowercase and punctuation paste transforms

### DIFF
--- a/.changeset/b80ca233.md
+++ b/.changeset/b80ca233.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add lowercase and punctuation-removal paste transforms

--- a/.changeset/b80ca233.md
+++ b/.changeset/b80ca233.md
@@ -2,4 +2,4 @@
 "hex-app": minor
 ---
 
-Add lowercase and punctuation-removal paste transforms
+Add lowercase and punctuation-removal paste transforms (#253)

--- a/Hex/Features/Remappings/WordRemappingsView.swift
+++ b/Hex/Features/Remappings/WordRemappingsView.swift
@@ -79,43 +79,75 @@ struct WordRemappingsView: View {
 	}
 
 	private var removalsSection: some View {
-		GroupBox {
-			VStack(alignment: .leading, spacing: 10) {
-				Toggle(
-					"Enable Word Removals",
-					isOn: Binding(
-						get: { store.hexSettings.wordRemovalsEnabled },
-						set: { store.send(.setWordRemovalsEnabled($0)) }
+		VStack(alignment: .leading, spacing: 16) {
+			GroupBox {
+				VStack(alignment: .leading, spacing: 10) {
+					Toggle(
+						"Enable Word Removals",
+						isOn: Binding(
+							get: { store.hexSettings.wordRemovalsEnabled },
+							set: { store.send(.setWordRemovalsEnabled($0)) }
+						)
 					)
-				)
-					.toggleStyle(.checkbox)
+						.toggleStyle(.checkbox)
 
-				removalsColumnHeaders
+					removalsColumnHeaders
 
-				LazyVStack(alignment: .leading, spacing: 6) {
-					ForEach(store.hexSettings.wordRemovals) { removal in
-						RemovalRow(removal: removalBinding(for: removal)) {
-							store.send(.removeWordRemoval(removal.id))
+					LazyVStack(alignment: .leading, spacing: 6) {
+						ForEach(store.hexSettings.wordRemovals) { removal in
+							RemovalRow(removal: removalBinding(for: removal)) {
+								store.send(.removeWordRemoval(removal.id))
+							}
 						}
 					}
-				}
 
-				HStack {
-					Button {
-						store.send(.addWordRemoval)
-					} label: {
-						Label("Add Removal", systemImage: "plus")
+					HStack {
+						Button {
+							store.send(.addWordRemoval)
+						} label: {
+							Label("Add Removal", systemImage: "plus")
+						}
+						Spacer()
 					}
-					Spacer()
+				}
+				.padding(.vertical, 4)
+			} label: {
+				VStack(alignment: .leading, spacing: 4) {
+					Text("Word Removals")
+						.font(.headline)
+					Text("Remove filler words using case-insensitive regex patterns.")
+						.settingsCaption()
 				}
 			}
-			.padding(.vertical, 4)
-		} label: {
-			VStack(alignment: .leading, spacing: 4) {
-				Text("Word Removals")
-					.font(.headline)
-				Text("Remove filler words using case-insensitive regex patterns.")
-					.settingsCaption()
+
+			GroupBox {
+				VStack(alignment: .leading, spacing: 10) {
+					Toggle(
+						"Lowercase Everything",
+						isOn: Binding(
+							get: { store.hexSettings.lowercaseTranscripts },
+							set: { store.send(.setLowercaseTranscripts($0)) }
+						)
+					)
+					.toggleStyle(.checkbox)
+
+					Toggle(
+						"Remove All Punctuation",
+						isOn: Binding(
+							get: { store.hexSettings.removePunctuation },
+							set: { store.send(.setRemovePunctuation($0)) }
+						)
+					)
+					.toggleStyle(.checkbox)
+				}
+				.padding(.vertical, 4)
+			} label: {
+				VStack(alignment: .leading, spacing: 4) {
+					Text("Paste Formatting")
+						.font(.headline)
+					Text("Change capitalization and punctuation before each transcript is pasted.")
+						.settingsCaption()
+				}
 			}
 		}
 	}
@@ -209,6 +241,11 @@ struct WordRemappingsView: View {
 			output = WordRemovalApplier.apply(output, removals: store.hexSettings.wordRemovals)
 		}
 		output = WordRemappingApplier.apply(output, remappings: store.hexSettings.wordRemappings)
+		output = TranscriptFormattingApplier.apply(
+			output,
+			lowercase: store.hexSettings.lowercaseTranscripts,
+			removePunctuation: store.hexSettings.removePunctuation
+		)
 		return output
 	}
 }

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -113,6 +113,8 @@ struct SettingsFeature {
     case updateWordRemapping(WordRemapping)
     case removeWordRemapping(UUID)
     case setRemappingScratchpadFocused(Bool)
+    case setLowercaseTranscripts(Bool)
+    case setRemovePunctuation(Bool)
   }
 
   @Dependency(\.keyEventMonitor) var keyEventMonitor
@@ -399,6 +401,14 @@ struct SettingsFeature {
 
       case let .setRemappingScratchpadFocused(isFocused):
         state.$isRemappingScratchpadFocused.withLock { $0 = isFocused }
+        return .none
+
+      case let .setLowercaseTranscripts(enabled):
+        state.$hexSettings.withLock { $0.lowercaseTranscripts = enabled }
+        return .none
+
+      case let .setRemovePunctuation(enabled):
+        state.$hexSettings.withLock { $0.removePunctuation = enabled }
         return .none
 
       case .startSettingPasteLastTranscriptHotkey:

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -453,7 +453,15 @@ private extension TranscriptionFeature {
       if remappedResult != output {
         transcriptionFeatureLogger.info("Applied \(remappings.count) word remapping(s)")
       }
-      modifiedResult = remappedResult
+      let formattedResult = TranscriptFormattingApplier.apply(
+        remappedResult,
+        lowercase: state.hexSettings.lowercaseTranscripts,
+        removePunctuation: state.hexSettings.removePunctuation
+      )
+      if formattedResult != remappedResult {
+        transcriptionFeatureLogger.info("Applied paste formatting")
+      }
+      modifiedResult = formattedResult
     }
 
     guard !modifiedResult.isEmpty else {

--- a/HexCore/Sources/HexCore/Models/TranscriptFormatting.swift
+++ b/HexCore/Sources/HexCore/Models/TranscriptFormatting.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum TranscriptFormattingApplier {
+	public static func apply(
+		_ text: String,
+		lowercase: Bool,
+		removePunctuation: Bool
+	) -> String {
+		var output = lowercase ? text.lowercased() : text
+		if removePunctuation {
+			output = output.components(separatedBy: .punctuationCharacters).joined()
+		}
+		return output
+	}
+}

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -47,6 +47,8 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var wordRemovalsEnabled: Bool
 	public var wordRemovals: [WordRemoval]
 	public var wordRemappings: [WordRemapping]
+	public var lowercaseTranscripts: Bool
+	public var removePunctuation: Bool
 
 	private mutating func normalizeDoubleTapSettings() {
 		if !doubleTapLockEnabled {
@@ -78,7 +80,9 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		hasCompletedStorageMigration: Bool = false,
 		wordRemovalsEnabled: Bool = false,
 		wordRemovals: [WordRemoval] = HexSettings.defaultWordRemovals,
-		wordRemappings: [WordRemapping] = []
+		wordRemappings: [WordRemapping] = [],
+		lowercaseTranscripts: Bool = false,
+		removePunctuation: Bool = false
 	) {
 		self.soundEffectsEnabled = soundEffectsEnabled
 		self.soundEffectsVolume = soundEffectsVolume
@@ -104,6 +108,8 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.wordRemovalsEnabled = wordRemovalsEnabled
 		self.wordRemovals = wordRemovals
 		self.wordRemappings = wordRemappings
+		self.lowercaseTranscripts = lowercaseTranscripts
+		self.removePunctuation = removePunctuation
 		normalizeDoubleTapSettings()
 	}
 
@@ -152,6 +158,8 @@ private enum HexSettingKey: String, CodingKey, CaseIterable {
 	case wordRemovalsEnabled
 	case wordRemovals
 	case wordRemappings
+	case lowercaseTranscripts
+	case removePunctuation
 }
 
 private struct SettingsField<Value: Codable & Sendable> {
@@ -284,6 +292,8 @@ private enum HexSettingsSchema {
 			.wordRemappings,
 			keyPath: \.wordRemappings,
 			default: defaults.wordRemappings
-		).eraseToAny()
+		).eraseToAny(),
+		SettingsField(.lowercaseTranscripts, keyPath: \.lowercaseTranscripts, default: defaults.lowercaseTranscripts).eraseToAny(),
+		SettingsField(.removePunctuation, keyPath: \.removePunctuation, default: defaults.removePunctuation).eraseToAny()
 	]
 }

--- a/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
+++ b/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
@@ -25,6 +25,8 @@ final class HexSettingsMigrationTests: XCTestCase {
 		XCTAssertEqual(decoded.maxHistoryEntries, 10)
 		XCTAssertEqual(decoded.hasCompletedModelBootstrap, true)
 		XCTAssertEqual(decoded.hasCompletedStorageMigration, true)
+		XCTAssertFalse(decoded.lowercaseTranscripts)
+		XCTAssertFalse(decoded.removePunctuation)
 	}
 
 	func testEncodeDecodeRoundTripPreservesDefaults() throws {

--- a/HexCore/Tests/HexCoreTests/TranscriptFormattingTests.swift
+++ b/HexCore/Tests/HexCoreTests/TranscriptFormattingTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import HexCore
+
+struct TranscriptFormattingTests {
+	@Test
+	func lowercasesTranscript() {
+		let result = TranscriptFormattingApplier.apply(
+			"Hello WORLD!",
+			lowercase: true,
+			removePunctuation: false
+		)
+
+		#expect(result == "hello world!")
+	}
+
+	@Test
+	func removesUnicodePunctuation() {
+		let result = TranscriptFormattingApplier.apply(
+			"Hello, world! It’s well-known — really.",
+			lowercase: false,
+			removePunctuation: true
+		)
+
+		#expect(result == "Hello world Its wellknown  really")
+	}
+
+	@Test
+	func appliesBothOptionsIndependently() {
+		let result = TranscriptFormattingApplier.apply(
+			"Hello, WORLD!",
+			lowercase: true,
+			removePunctuation: true
+		)
+
+		#expect(result == "hello world")
+	}
+
+	@Test
+	func leavesTranscriptUnchangedWhenDisabled() {
+		let input = "Hello, WORLD!"
+		let result = TranscriptFormattingApplier.apply(
+			input,
+			lowercase: false,
+			removePunctuation: false
+		)
+
+		#expect(result == input)
+	}
+}


### PR DESCRIPTION
## Summary
- add independent toggles to lowercase transcripts and remove punctuation
- persist both options and apply them after word removals/remappings before paste
- show the final formatting in the transforms scratchpad preview

## Testing
- `swift test --filter TranscriptFormattingTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme Hex -configuration Debug build CODE_SIGNING_ALLOWED=NO -skipMacroValidation`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new paste-formatting options: lowercase text and remove punctuation.
  * These options are available in settings and reflected in transcript previews and pasted transcription output.
* **Bug Fixes**
  * Transcript formatting now applies consistently after word remapping, so previewed and pasted text match the selected settings.
* **Tests**
  * Added coverage for formatting behavior and updated settings migration checks for the new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->