### PR TITLE
Prevent KeyEventMonitor launch crash

### DIFF
--- a/.changeset/390b8def.md
+++ b/.changeset/390b8def.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Prevent Hex from crashing on launch when Input Monitoring permission is denied or stale (#254)

--- a/Hex/Clients/KeyEventMonitorClient.swift
+++ b/Hex/Clients/KeyEventMonitorClient.swift
@@ -10,6 +10,7 @@ import HexCore
 import IOKit
 import IOKit.hidsystem
 import Sauce
+import os
 
 private let logger = HexLog.keyEvent
 
@@ -92,6 +93,9 @@ extension DependencyValues {
 }
 
 class KeyEventMonitorClientLive {
+  private let accessibilityTrustCheck: @Sendable () -> Bool
+  private let accessibilityTrustPrompt: @Sendable () -> Bool
+  private let inputMonitoringTrustCheck: @Sendable () -> Bool
   private var eventTapPort: CFMachPort?
   private var runLoopSource: CFRunLoopSource?
   private var continuations: [UUID: @Sendable (KeyEvent) -> Bool] = [:]
@@ -103,7 +107,7 @@ class KeyEventMonitorClientLive {
   private var inputMonitoringTrusted = false
   /// Set when key events are observed arriving at the tap. Key events only flow when Input
   /// Monitoring is genuinely granted, so this overrides stale `IOHIDCheckAccess` denials (#250).
-  private var inputMonitoringProvenByEvents = false
+  private let inputMonitoringProof = OSAllocatedUnfairLock(initialState: false)
   private var trustMonitorTask: Task<Void, Never>?
   private var systemEventObservers: [NSObjectProtocol] = []
   private var isFnPressed = false
@@ -112,7 +116,22 @@ class KeyEventMonitorClientLive {
 
   private let trustCheckIntervalNanoseconds: UInt64 = 100_000_000 // 100ms
 
-  init() {
+  init(
+    accessibilityTrustCheck: @escaping @Sendable () -> Bool = {
+      let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+      return AXIsProcessTrustedWithOptions([promptKey: false] as CFDictionary)
+    },
+    accessibilityTrustPrompt: @escaping @Sendable () -> Bool = {
+      let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+      return AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary)
+    },
+    inputMonitoringTrustCheck: @escaping @Sendable () -> Bool = {
+      IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
+    }
+  ) {
+    self.accessibilityTrustCheck = accessibilityTrustCheck
+    self.accessibilityTrustPrompt = accessibilityTrustPrompt
+    self.inputMonitoringTrustCheck = inputMonitoringTrustCheck
     logger.info("Initializing HotKeyClient with CGEvent tap.")
     registerSystemEventObservers()
   }
@@ -468,8 +487,8 @@ class KeyEventMonitorClientLive {
   }
 
   private func clearInputMonitoringProof() {
-    queue.async(flags: .barrier) { [weak self] in
-      self?.inputMonitoringProvenByEvents = false
+    inputMonitoringProof.withLock { proof in
+      proof = false
     }
   }
 
@@ -504,10 +523,12 @@ class KeyEventMonitorClientLive {
   /// Monitoring is genuinely granted even when `IOHIDCheckAccess` reports otherwise (#250).
   fileprivate func noteEventDelivered(type: CGEventType) {
     guard type == .keyDown || type == .keyUp else { return }
-    let alreadyProven = queue.sync { inputMonitoringProvenByEvents }
+    let alreadyProven = inputMonitoringProof.withLock { proof in
+      defer { proof = true }
+      return proof
+    }
     guard !alreadyProven else { return }
     queue.async(flags: .barrier) { [weak self] in
-      self?.inputMonitoringProvenByEvents = true
       self?.inputMonitoringTrusted = true
     }
     if IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) != kIOHIDAccessTypeGranted {
@@ -562,22 +583,20 @@ extension KeyEventMonitorClientLive {
   }
 
   private func currentAccessibilityTrust() -> Bool {
-    let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-    return AXIsProcessTrustedWithOptions([promptKey: false] as CFDictionary)
+    accessibilityTrustCheck()
   }
 
   private func requestAccessibilityTrustPrompt() -> Bool {
-    let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-    return AXIsProcessTrustedWithOptions([promptKey: true] as CFDictionary)
+    accessibilityTrustPrompt()
   }
 
   private func currentInputMonitoringTrust() -> Bool {
-    if IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted {
+    if inputMonitoringTrustCheck() {
       return true
     }
     // A stale TCC cache can report denied while key events demonstrably flow (#250);
     // trust the events over the check so the watchdog and settings UI stay honest.
-    return queue.sync { inputMonitoringProvenByEvents }
+    return inputMonitoringProof.withLock { $0 }
   }
 
   // Intentionally no request helper: creating the event tap prompts macOS 15+ for Input Monitoring

--- a/HexTests/KeyEventMonitorClientTests.swift
+++ b/HexTests/KeyEventMonitorClientTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+
+@testable import Hex
+
+final class KeyEventMonitorClientTests: XCTestCase {
+  func testStartingInputMonitoringWithDeniedPermissionsDoesNotReenterStateQueue() async throws {
+    let monitor = KeyEventMonitorClientLive(
+      accessibilityTrustCheck: { false },
+      accessibilityTrustPrompt: { false },
+      inputMonitoringTrustCheck: { false }
+    )
+
+    let token = monitor.handleInputEvent { _ in false }
+    try await Task.sleep(for: .milliseconds(100))
+    token.cancel()
+  }
+}


### PR DESCRIPTION
## Summary

- prevent Hex from synchronously re-entering its `KeyEventMonitor` queue when Input Monitoring is denied or reported stale
- protect the event-proven Input Monitoring flag with a dedicated lock
- add deterministic denied-permission regression coverage and a patch changeset

## Root cause

`handleInputEvent` registers its first handler inside a barrier block on `com.kitlangton.Hex.KeyEventMonitor` and calls `startMonitoring`. When `IOHIDCheckAccess` reports denied, `currentInputMonitoringTrust()` synchronously dispatched back onto that same queue. Libdispatch terminates the app with `SIGTRAP` instead of allowing the self-sync.

The permission-proof flag now uses its own lock, so callers can safely read it from either inside or outside the state queue while preserving the stale-TCC recovery introduced for #250.

## Validation

- regression test reproduced the original `BUG IN CLIENT OF LIBDISPATCH: dispatch_sync called on queue already owned by current thread` failure before the fix
- full Xcode test suite passes, including `KeyEventMonitorClientTests`
- `HexCore` test suite passes: 67 tests
- optimized Release build succeeds
- fixed Release app remained alive through a 15-second launch smoke test and generated no crash report

Fixes #254
