### PR TITLE
fix(audio): preserve late frames at the recording cutoff

### DIFF
--- a/.changeset/0b4a55dc.md
+++ b/.changeset/0b4a55dc.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Add configurable transcription stop delay

--- a/.changeset/c1a097d5.md
+++ b/.changeset/c1a097d5.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Preserve final microphone audio when recordings stop

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -69,6 +69,7 @@ enum IgnoredRecordingStopReason: Equatable {
 
 enum RecordingFailure: Error, Equatable {
   case captureWriteFailed(String)
+  case captureFinalizationTimedOut
   case fallbackExportFailed(String)
   case noCapturedAudio
 }
@@ -78,6 +79,8 @@ extension RecordingFailure: LocalizedError {
     switch self {
     case let .captureWriteFailed(message):
       "Failed to write captured audio: \(message)"
+    case .captureFinalizationTimedOut:
+      "The microphone did not finish delivering the final audio. Please try again."
     case let .fallbackExportFailed(message):
       "Failed to export recorded audio: \(message)"
     case .noCapturedAudio:
@@ -1248,6 +1251,14 @@ actor RecordingClientLive {
     mediaControlTask?.cancel()
     mediaControlTask = nil
 
+    // `stopRecording()` awaits capture finalization and therefore releases this actor. Do not
+    // let a rapid next hotkey press replace the file that is still draining final PCM frames.
+    await captureController.waitForPendingFinish()
+    guard !Task.isCancelled, recordingSessionID == sessionID else {
+      recordingLogger.notice("Ignoring recording start superseded while finalizing prior capture")
+      return
+    }
+
     // Handle audio behavior based on user preference
     switch hexSettings.recordingAudioBehavior {
     case .pauseMedia:
@@ -1355,23 +1366,23 @@ actor RecordingClientLive {
     let stopSessionID = recordingSessionID
     let activeSession = activeRecordingSession
 
-    if activeSession?.backend == .captureEngine || captureController.isRecording {
-      let stopTimingEstimate = captureController.stopTimingEstimate
-      recordingLogger.debug(
-        "Waiting \(self.formatDuration(stopTimingEstimate.gracePeriod)) before finalizing capture-engine recording callbackInterval=\(self.formatDuration(stopTimingEstimate.callbackInterval)) bufferDuration=\(self.formatDuration(stopTimingEstimate.bufferDuration))"
-      )
-      try? await Task.sleep(for: .milliseconds(Int((stopTimingEstimate.gracePeriod * 1000).rounded())))
+    let captureFinishResult = await captureController.finishRecording(
+      clearBuffer: currentCaptureMode() == .superFast
+    )
 
-      if Self.shouldIgnoreStopRequest(
-        snapshotSessionID: stopSessionID,
-        currentSessionID: recordingSessionID
-      ) {
-        recordingLogger.notice("Ignoring stale stop request after a newer recording session started")
-        return .ignored(.staleSession)
-      }
+    if Self.shouldIgnoreStopRequest(
+      snapshotSessionID: stopSessionID,
+      currentSessionID: recordingSessionID
+    ) {
+      recordingLogger.notice("Ignoring stale stop request after a newer recording session started")
+      return .ignored(.staleSession)
     }
 
-    switch captureController.finishRecording(clearBuffer: currentCaptureMode() == .superFast) {
+    switch captureFinishResult {
+    case .finalizing:
+      recordingLogger.notice("Ignoring duplicate stop while capture engine finalization is already in progress")
+      return .ignored(.staleSession)
+
     case let .captured(captureURL):
       let stoppedAt = Date()
       let session = activeSession ?? ActiveRecordingSession(

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -1367,7 +1367,8 @@ actor RecordingClientLive {
     let activeSession = activeRecordingSession
 
     let captureFinishResult = await captureController.finishRecording(
-      clearBuffer: currentCaptureMode() == .superFast
+      clearBuffer: currentCaptureMode() == .superFast,
+      postRollDuration: Double(hexSettings.stopDelayMilliseconds) / 1_000
     )
 
     if Self.shouldIgnoreStopRequest(

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -58,7 +58,6 @@ private struct SuperFastCaptureConstants {
   static let ringBufferDuration: TimeInterval = 1.0
   static let defaultPreRollDuration: TimeInterval = 0.45
   static let tapBufferSize: AVAudioFrameCount = 2_048
-  static let stopPostRollDuration: TimeInterval = 0.15
   static let stopDrainTimeout: TimeInterval = 2
 }
 
@@ -90,6 +89,7 @@ final class SuperFastCaptureController {
 
   private struct PendingFinish {
     let targetHostTime: UInt64
+    let postRollDuration: TimeInterval
     let clearBuffer: Bool
     let continuation: CheckedContinuation<FinishRecordingResult, Never>
   }
@@ -350,9 +350,13 @@ final class SuperFastCaptureController {
   /// Finalizes at an audio-clock boundary rather than after a wall-clock delay. The hotkey
   /// event supplies the boundary in host time; tap timestamps let us retain every PCM frame
   /// through that point even when Core Audio delivers the final buffer late.
-  func finishRecording(clearBuffer: Bool = true) async -> FinishRecordingResult {
+  func finishRecording(
+    clearBuffer: Bool = true,
+    postRollDuration: TimeInterval = 0
+  ) async -> FinishRecordingResult {
+    let postRollDuration = max(0, postRollDuration)
     let targetHostTime = mach_absolute_time() + AVAudioTime.hostTime(
-      forSeconds: SuperFastCaptureConstants.stopPostRollDuration
+      forSeconds: postRollDuration
     )
     guard requestStopBoundary(targetHostTime) else {
       return .finalizing
@@ -373,6 +377,7 @@ final class SuperFastCaptureController {
 
         self.pendingFinish = PendingFinish(
           targetHostTime: targetHostTime,
+          postRollDuration: postRollDuration,
           clearBuffer: clearBuffer,
           continuation: continuation
         )
@@ -459,12 +464,9 @@ final class SuperFastCaptureController {
          )
       {
         markStopBoundaryReached(stopBoundary.targetHostTime)
-        if pendingFinish != nil {
-          let postRollDuration = String(
-            format: "%.3f",
-            SuperFastCaptureConstants.stopPostRollDuration
-          )
-          logger.notice("Capture engine finalizing at audio boundary postRoll=\(postRollDuration)s")
+        if let pendingFinish {
+          let postRollDescription = String(format: "%.3f", pendingFinish.postRollDuration)
+          logger.notice("Capture engine finalizing at audio boundary postRoll=\(postRollDescription)s")
           resolvePendingFinish(with: .captured(recording.url))
         }
       }

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Darwin
 import Foundation
 import HexCore
 
@@ -57,11 +58,8 @@ private struct SuperFastCaptureConstants {
   static let ringBufferDuration: TimeInterval = 1.0
   static let defaultPreRollDuration: TimeInterval = 0.45
   static let tapBufferSize: AVAudioFrameCount = 2_048
-  static let fallbackStopGracePeriod: TimeInterval = 0.05
-  static let minimumStopGracePeriod: TimeInterval = 0.02
-  static let maximumStopGracePeriod: TimeInterval = 0.08
-  static let stopGraceSafetyMargin: TimeInterval = 0.008
-  static let callbackTimingWindowSize = 8
+  static let stopPostRollDuration: TimeInterval = 0.15
+  static let stopDrainTimeout: TimeInterval = 2
 }
 
 enum CaptureRecordingMode: String {
@@ -86,13 +84,19 @@ final class SuperFastCaptureController {
   enum FinishRecordingResult {
     case captured(URL)
     case failed(RecordingFailure)
+    case finalizing
     case idle
   }
 
-  struct StopTimingEstimate {
-    let gracePeriod: TimeInterval
-    let callbackInterval: TimeInterval
-    let bufferDuration: TimeInterval
+  private struct PendingFinish {
+    let targetHostTime: UInt64
+    let clearBuffer: Bool
+    let continuation: CheckedContinuation<FinishRecordingResult, Never>
+  }
+
+  private struct StopBoundary {
+    let targetHostTime: UInt64
+    var hasReachedTarget = false
   }
 
   private struct ActiveRecording {
@@ -105,6 +109,7 @@ final class SuperFastCaptureController {
 
   private let logger = HexLog.recording
   private let processingQueue = DispatchQueue(label: "com.kitlangton.Hex.SuperFastCapture")
+  private let stopBoundaryLock = NSLock()
   private let meterContinuation: AsyncStream<Meter>.Continuation
   private let ringBuffer = FloatRingBuffer(
     capacity: Int(SuperFastCaptureConstants.sampleRate * SuperFastCaptureConstants.ringBufferDuration)
@@ -123,9 +128,10 @@ final class SuperFastCaptureController {
   private var captureGeneration = 0
   private var recordingFailure: RecordingFailure?
   private var keepWarmBuffer = false
-  private var lastProcessedBufferAt: Date?
-  private var recentCallbackIntervals: [TimeInterval] = []
-  private var recentBufferDurations: [TimeInterval] = []
+  private var stopBoundary: StopBoundary?
+  private var pendingFinish: PendingFinish?
+  private var pendingFinishWaiters: [CheckedContinuation<Void, Never>] = []
+  private var stopDrainTimeoutTask: Task<Void, Never>?
   private let onEngineConfigurationChange: @Sendable (Int) -> Void
 
   init(
@@ -148,28 +154,6 @@ final class SuperFastCaptureController {
     processingQueue.sync { activeRecording != nil }
   }
 
-  var stopTimingEstimate: StopTimingEstimate {
-    processingQueue.sync {
-      let callbackInterval = recentCallbackIntervals.max() ?? 0
-      let bufferDuration = recentBufferDurations.max() ?? 0
-      let observedCadence = max(callbackInterval, bufferDuration)
-      let gracePeriod = min(
-        max(
-          observedCadence > 0
-            ? observedCadence + SuperFastCaptureConstants.stopGraceSafetyMargin
-            : SuperFastCaptureConstants.fallbackStopGracePeriod,
-          SuperFastCaptureConstants.minimumStopGracePeriod
-        ),
-        SuperFastCaptureConstants.maximumStopGracePeriod
-      )
-      return StopTimingEstimate(
-        gracePeriod: gracePeriod,
-        callbackInterval: callbackInterval,
-        bufferDuration: bufferDuration
-      )
-    }
-  }
-
   func startIfNeeded(reason: String = "unknown", keepWarmBuffer: Bool = false) throws {
     processingQueue.sync {
       let didDisableWarmBuffer = self.keepWarmBuffer && !keepWarmBuffer
@@ -190,7 +174,7 @@ final class SuperFastCaptureController {
 
   /// Tears down and recreates the engine while keeping the active recording file open, so
   /// capture resumes onto the same file after a device/route change mid-recording
-  /// (#251, #252, #218, #226). The ring buffer, timing metrics, and active recording survive;
+  /// (#251, #252, #218, #226). The ring buffer and active recording survive;
   /// only the engine, tap, and converter are rebuilt.
   func restartPreservingRecording(reason: String) throws {
     logger.notice("Restarting capture engine preserving active recording reason=\(reason)")
@@ -221,8 +205,8 @@ final class SuperFastCaptureController {
     }
 
     inputNode.installTap(onBus: 0, bufferSize: SuperFastCaptureConstants.tapBufferSize, format: inputFormat) {
-      [weak self] buffer, _ in
-      self?.enqueue(buffer, generation: generation)
+      [weak self] buffer, time in
+      self?.enqueue(buffer, time: time, generation: generation)
     }
 
     engine.prepare()
@@ -272,12 +256,11 @@ final class SuperFastCaptureController {
       captureGeneration += 1
       converter = nil
       if clearingRecordingState {
+        resolvePendingFinish(with: .idle)
+        clearStopBoundary()
         activeRecording = nil
         recordingFailure = nil
         ringBuffer.clear()
-        lastProcessedBufferAt = nil
-        recentCallbackIntervals.removeAll(keepingCapacity: false)
-        recentBufferDurations.removeAll(keepingCapacity: false)
       }
     }
     engine?.stop()
@@ -350,42 +333,69 @@ final class SuperFastCaptureController {
     }
   }
 
-  func finishRecording(clearBuffer: Bool = true) -> FinishRecordingResult {
-    processingQueue.sync {
-      let result: FinishRecordingResult
-      if let recordingFailure {
-        result = .failed(recordingFailure)
-      } else if let url = activeRecording?.url {
-        result = .captured(url)
-      } else {
-        result = .idle
+  /// Prevents a new capture file from replacing one that is still draining its final PCM
+  /// frames. RecordingClient awaits this before it opens a new session.
+  func waitForPendingFinish() async {
+    await withCheckedContinuation { continuation in
+      processingQueue.async { [weak self] in
+        guard let self, self.pendingFinish != nil || self.currentStopBoundary() != nil else {
+          continuation.resume()
+          return
+        }
+        self.pendingFinishWaiters.append(continuation)
       }
-      activeRecording = nil
-      recordingFailure = nil
-      if clearBuffer {
-        ringBuffer.clear()
-      }
-      return result
     }
   }
 
-  private func enqueue(_ buffer: AVAudioPCMBuffer, generation: Int) {
+  /// Finalizes at an audio-clock boundary rather than after a wall-clock delay. The hotkey
+  /// event supplies the boundary in host time; tap timestamps let us retain every PCM frame
+  /// through that point even when Core Audio delivers the final buffer late.
+  func finishRecording(clearBuffer: Bool = true) async -> FinishRecordingResult {
+    let targetHostTime = mach_absolute_time() + AVAudioTime.hostTime(
+      forSeconds: SuperFastCaptureConstants.stopPostRollDuration
+    )
+    guard requestStopBoundary(targetHostTime) else {
+      return .finalizing
+    }
+
+    return await withCheckedContinuation { continuation in
+      processingQueue.async { [weak self] in
+        guard let self else {
+          continuation.resume(returning: .idle)
+          return
+        }
+        guard self.activeRecording != nil else {
+          self.clearStopBoundary()
+          continuation.resume(returning: self.finishResult())
+          self.resumePendingFinishWaiters()
+          return
+        }
+
+        self.pendingFinish = PendingFinish(
+          targetHostTime: targetHostTime,
+          clearBuffer: clearBuffer,
+          continuation: continuation
+        )
+        if self.hasReachedStopBoundary(targetHostTime) {
+          self.resolvePendingFinish(with: self.finishResult())
+          return
+        }
+        self.scheduleStopDrainTimeout()
+      }
+    }
+  }
+
+  private func enqueue(_ buffer: AVAudioPCMBuffer, time: AVAudioTime, generation: Int) {
     guard let copy = clone(buffer) else { return }
     processingQueue.async { [weak self] in
-      self?.process(copy, generation: generation)
+      self?.process(copy, time: time, generation: generation)
     }
   }
 
-  private func process(_ buffer: AVAudioPCMBuffer, generation: Int) {
+  private func process(_ buffer: AVAudioPCMBuffer, time: AVAudioTime, generation: Int) {
     guard Self.shouldProcessCallback(callbackGeneration: generation, currentGeneration: captureGeneration) else {
       return
     }
-    let now = Date()
-    if let lastProcessedBufferAt {
-      appendRecentMetric(now.timeIntervalSince(lastProcessedBufferAt), to: &recentCallbackIntervals)
-    }
-    lastProcessedBufferAt = now
-    appendRecentMetric(Double(buffer.frameLength) / buffer.format.sampleRate, to: &recentBufferDurations)
 
     guard let converted = convert(buffer),
           converted.frameLength > 0,
@@ -413,14 +423,184 @@ final class SuperFastCaptureController {
       activeRecording = recording
     }
 
+    let stopBoundary = currentStopBoundary()
+    let inputFramesToWrite: Int
+    if let stopBoundary,
+       time.isHostTimeValid
+    {
+      inputFramesToWrite = Self.inputFramesToWrite(
+        bufferStartHostTime: time.hostTime,
+        inputSampleRate: buffer.format.sampleRate,
+        inputFrameCount: Int(buffer.frameLength),
+        targetHostTime: stopBoundary.targetHostTime
+      )
+    } else {
+      inputFramesToWrite = Int(buffer.frameLength)
+    }
+
+    let outputFramesToWrite = Self.outputFramesToWrite(
+      convertedFrameCount: Int(converted.frameLength),
+      inputFrameCount: Int(buffer.frameLength),
+      inputFramesToWrite: inputFramesToWrite
+    )
+
     do {
-      try recording.file.write(from: converted)
+      if outputFramesToWrite > 0 {
+        converted.frameLength = AVAudioFrameCount(outputFramesToWrite)
+        try recording.file.write(from: converted)
+      }
+      if let stopBoundary,
+         time.isHostTimeValid,
+         Self.bufferReachesTarget(
+           bufferStartHostTime: time.hostTime,
+           inputSampleRate: buffer.format.sampleRate,
+           inputFrameCount: Int(buffer.frameLength),
+           targetHostTime: stopBoundary.targetHostTime
+         )
+      {
+        markStopBoundaryReached(stopBoundary.targetHostTime)
+        if pendingFinish != nil {
+          let postRollDuration = String(
+            format: "%.3f",
+            SuperFastCaptureConstants.stopPostRollDuration
+          )
+          logger.notice("Capture engine finalizing at audio boundary postRoll=\(postRollDuration)s")
+          resolvePendingFinish(with: .captured(recording.url))
+        }
+      }
     } catch {
       logger.error("Failed to write capture engine audio: \(error.localizedDescription)")
       activeRecording = nil
       recordingFailure = .captureWriteFailed(error.localizedDescription)
       FileManager.default.removeItemIfExists(at: recording.url)
+      resolvePendingFinish(with: .failed(.captureWriteFailed(error.localizedDescription)))
     }
+  }
+
+  /// Maps the desired host-clock boundary onto the buffer's PCM timeline. This uses Core
+  /// Audio's timestamp rather than queue or wall-clock timing, so delayed callbacks do not
+  /// discard samples that were captured before the stop boundary.
+  static func inputFramesToWrite(
+    bufferStartHostTime: UInt64,
+    inputSampleRate: Double,
+    inputFrameCount: Int,
+    targetHostTime: UInt64
+  ) -> Int {
+    guard inputSampleRate > 0, inputFrameCount > 0, targetHostTime > bufferStartHostTime else {
+      return 0
+    }
+    let secondsToTarget = AVAudioTime.seconds(forHostTime: targetHostTime - bufferStartHostTime)
+    let frameCount = Int((secondsToTarget * inputSampleRate).rounded(.down))
+    return min(max(frameCount, 0), inputFrameCount)
+  }
+
+  static func outputFramesToWrite(
+    convertedFrameCount: Int,
+    inputFrameCount: Int,
+    inputFramesToWrite: Int
+  ) -> Int {
+    guard convertedFrameCount > 0, inputFrameCount > 0, inputFramesToWrite > 0 else {
+      return 0
+    }
+    let ratio = Double(inputFramesToWrite) / Double(inputFrameCount)
+    return min(
+      convertedFrameCount,
+      max(1, Int((Double(convertedFrameCount) * ratio).rounded(.down)))
+    )
+  }
+
+  static func bufferReachesTarget(
+    bufferStartHostTime: UInt64,
+    inputSampleRate: Double,
+    inputFrameCount: Int,
+    targetHostTime: UInt64
+  ) -> Bool {
+    guard inputSampleRate > 0, inputFrameCount > 0 else { return false }
+    let bufferDurationHostTime = AVAudioTime.hostTime(
+      forSeconds: Double(inputFrameCount) / inputSampleRate
+    )
+    return targetHostTime <= bufferStartHostTime + bufferDurationHostTime
+  }
+
+  private func requestStopBoundary(_ targetHostTime: UInt64) -> Bool {
+    stopBoundaryLock.lock()
+    defer { stopBoundaryLock.unlock() }
+    guard stopBoundary == nil else { return false }
+    stopBoundary = StopBoundary(targetHostTime: targetHostTime)
+    return true
+  }
+
+  private func currentStopBoundary() -> StopBoundary? {
+    stopBoundaryLock.lock()
+    defer { stopBoundaryLock.unlock() }
+    return stopBoundary
+  }
+
+  private func markStopBoundaryReached(_ targetHostTime: UInt64) {
+    stopBoundaryLock.lock()
+    defer { stopBoundaryLock.unlock() }
+    guard stopBoundary?.targetHostTime == targetHostTime else { return }
+    stopBoundary?.hasReachedTarget = true
+  }
+
+  private func hasReachedStopBoundary(_ targetHostTime: UInt64) -> Bool {
+    stopBoundaryLock.lock()
+    defer { stopBoundaryLock.unlock() }
+    return stopBoundary?.targetHostTime == targetHostTime && stopBoundary?.hasReachedTarget == true
+  }
+
+  private func clearStopBoundary() {
+    stopBoundaryLock.lock()
+    defer { stopBoundaryLock.unlock() }
+    stopBoundary = nil
+  }
+
+  private func scheduleStopDrainTimeout() {
+    stopDrainTimeoutTask?.cancel()
+    stopDrainTimeoutTask = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(SuperFastCaptureConstants.stopDrainTimeout))
+      guard !Task.isCancelled else { return }
+      self?.processingQueue.async { [weak self] in
+        guard let self, self.pendingFinish != nil else { return }
+        self.logger.error("Timed out waiting for capture engine to reach the stop audio boundary")
+        let failure = RecordingFailure.captureFinalizationTimedOut
+        if let url = self.activeRecording?.url {
+          FileManager.default.removeItemIfExists(at: url)
+        }
+        self.resolvePendingFinish(with: .failed(failure))
+      }
+    }
+  }
+
+  private func finishResult() -> FinishRecordingResult {
+    if let recordingFailure {
+      return .failed(recordingFailure)
+    }
+    if let url = activeRecording?.url {
+      return .captured(url)
+    }
+    return .idle
+  }
+
+  private func resolvePendingFinish(with result: FinishRecordingResult) {
+    guard let pendingFinish else { return }
+    self.pendingFinish = nil
+    clearStopBoundary()
+    stopDrainTimeoutTask?.cancel()
+    stopDrainTimeoutTask = nil
+    activeRecording = nil
+    recordingFailure = nil
+    if pendingFinish.clearBuffer {
+      ringBuffer.clear()
+    }
+    pendingFinish.continuation.resume(returning: result)
+    resumePendingFinishWaiters()
+  }
+
+  private func resumePendingFinishWaiters() {
+    let waiters = pendingFinishWaiters
+    pendingFinishWaiters.removeAll(keepingCapacity: false)
+    waiters.forEach { $0.resume() }
   }
 
   private func convert(_ inputBuffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
@@ -517,11 +697,4 @@ final class SuperFastCaptureController {
     return copy
   }
 
-  private func appendRecentMetric(_ value: TimeInterval, to metrics: inout [TimeInterval]) {
-    guard value.isFinite, value > 0 else { return }
-    metrics.append(value)
-    if metrics.count > SuperFastCaptureConstants.callbackTimingWindowSize {
-      metrics.removeFirst(metrics.count - SuperFastCaptureConstants.callbackTimingWindowSize)
-    }
-  }
 }

--- a/Hex/Features/Settings/HotKeySectionView.swift
+++ b/Hex/Features/Settings/HotKeySectionView.swift
@@ -88,20 +88,26 @@ struct HotKeySectionView: View {
 
             LabeledContent {
                 TextField(
-                    "Stop delay in ms",
+                    "",
                     value: Binding(
                         get: { store.hexSettings.stopDelayMilliseconds },
                         set: { store.send(.setStopDelayMilliseconds($0)) }
                     ),
                     format: .number
                 )
+                .labelsHidden()
+                .accessibilityLabel("Stop delay in milliseconds")
                 .frame(width: 64)
                 .multilineTextAlignment(.trailing)
             } label: {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Stop delay in ms")
-                    Text("Grace period to include audio in transcription after stop button is pressed")
-                        .settingsCaption()
+                Label {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Stop delay in ms")
+                        Text("Grace period to include audio in transcription after stop button is pressed")
+                            .settingsCaption()
+                    }
+                } icon: {
+                    Image(systemName: "timer")
                 }
             }
         }

--- a/Hex/Features/Settings/HotKeySectionView.swift
+++ b/Hex/Features/Settings/HotKeySectionView.swift
@@ -85,6 +85,25 @@ struct HotKeySectionView: View {
                     Image(systemName: "clock")
                 }
             }
+
+            LabeledContent {
+                TextField(
+                    "Stop delay in ms",
+                    value: Binding(
+                        get: { store.hexSettings.stopDelayMilliseconds },
+                        set: { store.send(.setStopDelayMilliseconds($0)) }
+                    ),
+                    format: .number
+                )
+                .frame(width: 64)
+                .multilineTextAlignment(.trailing)
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Stop delay in ms")
+                    Text("Grace period to include audio in transcription after stop button is pressed")
+                        .settingsCaption()
+                }
+            }
         }
         .enableInjection()
     }

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -80,6 +80,7 @@ struct SettingsFeature {
     case setDoubleTapLockEnabled(Bool)
     case setUseDoubleTapOnly(Bool)
     case setMinimumKeyTime(Double)
+    case setStopDelayMilliseconds(Int)
     case setOutputLanguage(String?)
     case setSelectedMicrophoneID(String?)
     case setSoundEffectsEnabled(Bool)
@@ -484,6 +485,10 @@ struct SettingsFeature {
 
       case let .setMinimumKeyTime(value):
         state.$hexSettings.withLock { $0.minimumKeyTime = value }
+        return .none
+
+      case let .setStopDelayMilliseconds(value):
+        state.$hexSettings.withLock { $0.stopDelayMilliseconds = max(0, value) }
         return .none
 
       case let .setOutputLanguage(language):

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -33,6 +33,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 	public var preventSystemSleep: Bool
 	public var recordingAudioBehavior: RecordingAudioBehavior
 	public var minimumKeyTime: Double
+	public var stopDelayMilliseconds: Int
 	public var copyToClipboard: Bool
 	public var superFastModeEnabled: Bool
 	public var useDoubleTapOnly: Bool
@@ -67,6 +68,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		preventSystemSleep: Bool = true,
 		recordingAudioBehavior: RecordingAudioBehavior = .doNothing,
 		minimumKeyTime: Double = HexCoreConstants.defaultMinimumKeyTime,
+		stopDelayMilliseconds: Int = 0,
 		copyToClipboard: Bool = false,
 		superFastModeEnabled: Bool = true,
 		useDoubleTapOnly: Bool = false,
@@ -94,6 +96,7 @@ public struct HexSettings: Codable, Equatable, Sendable {
 		self.preventSystemSleep = preventSystemSleep
 		self.recordingAudioBehavior = recordingAudioBehavior
 		self.minimumKeyTime = minimumKeyTime
+		self.stopDelayMilliseconds = max(0, stopDelayMilliseconds)
 		self.copyToClipboard = copyToClipboard
 		self.superFastModeEnabled = superFastModeEnabled
 		self.useDoubleTapOnly = useDoubleTapOnly
@@ -144,6 +147,7 @@ private enum HexSettingKey: String, CodingKey, CaseIterable {
 	case recordingAudioBehavior
 	case pauseMediaOnRecord // Legacy
 	case minimumKeyTime
+	case stopDelayMilliseconds
 	case copyToClipboard
 	case superFastModeEnabled
 	case useDoubleTapOnly
@@ -243,6 +247,7 @@ private enum HexSettingsSchema {
 			}
 		).eraseToAny(),
 		SettingsField(.minimumKeyTime, keyPath: \.minimumKeyTime, default: defaults.minimumKeyTime).eraseToAny(),
+		SettingsField(.stopDelayMilliseconds, keyPath: \.stopDelayMilliseconds, default: defaults.stopDelayMilliseconds).eraseToAny(),
 		SettingsField(.copyToClipboard, keyPath: \.copyToClipboard, default: defaults.copyToClipboard).eraseToAny(),
 		SettingsField(.superFastModeEnabled, keyPath: \.superFastModeEnabled, default: defaults.superFastModeEnabled).eraseToAny(),
 		SettingsField(.useDoubleTapOnly, keyPath: \.useDoubleTapOnly, default: defaults.useDoubleTapOnly).eraseToAny(),

--- a/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
+++ b/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
@@ -15,6 +15,7 @@ final class HexSettingsMigrationTests: XCTestCase {
 		XCTAssertEqual(decoded.useClipboardPaste, false)
 		XCTAssertEqual(decoded.preventSystemSleep, true)
 		XCTAssertEqual(decoded.minimumKeyTime, 0.25)
+		XCTAssertEqual(decoded.stopDelayMilliseconds, 0)
 		XCTAssertEqual(decoded.copyToClipboard, true)
 		XCTAssertTrue(decoded.superFastModeEnabled)
 		XCTAssertEqual(decoded.useDoubleTapOnly, true)
@@ -38,6 +39,7 @@ final class HexSettingsMigrationTests: XCTestCase {
 
 	func testNewSettingsEnableSuperFastModeByDefault() {
 		XCTAssertTrue(HexSettings().superFastModeEnabled)
+		XCTAssertEqual(HexSettings().stopDelayMilliseconds, 0)
 	}
 
 	func testInitNormalizesDoubleTapOnlyWhenLockDisabled() {

--- a/HexTests/RecordingRaceTests.swift
+++ b/HexTests/RecordingRaceTests.swift
@@ -1,5 +1,7 @@
 import AppKit
+import AVFoundation
 import ComposableArchitecture
+import Darwin
 import Foundation
 import HexCore
 import XCTest
@@ -99,6 +101,62 @@ final class RecordingRaceTests: XCTestCase {
       SuperFastCaptureController.shouldProcessCallback(
         callbackGeneration: 1,
         currentGeneration: 2
+      )
+    )
+  }
+
+  func testCaptureStopBoundaryKeepsOnlyPCMFramesBeforeCutoff() {
+    let sampleRate = 16_000.0
+    let inputFrames = 1_600 // 100 ms
+    let convertedFrames = 1_600
+    let bufferStart = mach_absolute_time()
+    let target = bufferStart + AVAudioTime.hostTime(forSeconds: 0.075)
+
+    let inputFramesToWrite = SuperFastCaptureController.inputFramesToWrite(
+      bufferStartHostTime: bufferStart,
+      inputSampleRate: sampleRate,
+      inputFrameCount: inputFrames,
+      targetHostTime: target
+    )
+    let outputFramesToWrite = SuperFastCaptureController.outputFramesToWrite(
+      convertedFrameCount: convertedFrames,
+      inputFrameCount: inputFrames,
+      inputFramesToWrite: inputFramesToWrite
+    )
+
+    XCTAssertTrue((1_199 ... 1_200).contains(inputFramesToWrite))
+    XCTAssertTrue((1_199 ... 1_200).contains(outputFramesToWrite))
+    XCTAssertTrue(
+      SuperFastCaptureController.bufferReachesTarget(
+        bufferStartHostTime: bufferStart,
+        inputSampleRate: sampleRate,
+        inputFrameCount: inputFrames,
+        targetHostTime: target
+      )
+    )
+  }
+
+  func testCaptureStopBoundaryExcludesLaterPCMBuffer() {
+    let sampleRate = 16_000.0
+    let inputFrames = 1_600 // 100 ms
+    let target = mach_absolute_time()
+    let laterBufferStart = target + AVAudioTime.hostTime(forSeconds: 0.1)
+
+    XCTAssertEqual(
+      SuperFastCaptureController.inputFramesToWrite(
+        bufferStartHostTime: laterBufferStart,
+        inputSampleRate: sampleRate,
+        inputFrameCount: inputFrames,
+        targetHostTime: target
+      ),
+      0
+    )
+    XCTAssertTrue(
+      SuperFastCaptureController.bufferReachesTarget(
+        bufferStartHostTime: laterBufferStart,
+        inputSampleRate: sampleRate,
+        inputFrameCount: inputFrames,
+        targetHostTime: target
       )
     )
   }


### PR DESCRIPTION
## Summary

- Finalize recording at a Core Audio timestamp boundary, retaining late-arriving PCM frames recorded before the stop hotkey and trimming the final buffer exactly at that boundary.
- Replace the hardcoded post-stop grace period with a **Stop delay in ms** control in the Hot Key settings. It defaults to `0`, so recording stops exactly at the hotkey boundary unless a user deliberately requests a tail.
- Reject incomplete finalization rather than transcribing a known-truncated recording, and protect rapid stop/start transitions.

## Problem

The recorder previously closed its file after a fixed wall-clock delay. On some hardware, a Core Audio callback containing audio captured before the hotkey release can arrive after that delay, clipping the final word. Waiting longer is not a sound fix: it introduces an arbitrary tail and is still device-dependent.

This change uses the capture clock itself as the cutoff. The recorder waits until a buffer reaches that boundary, keeps only the included frames, and then finalizes. The optional setting controls only an intentional post-stop inclusion delay.

## Validation

- `xcodebuild -scheme Hex -configuration Debug -skipMacroValidation -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build`
- Added targeted cutoff-math and settings-migration coverage.
- Tests were not run, following this repository's opt-in test policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable “Stop delay in ms” setting for transcription grace after stopping.
  * Persisted and restored the stop delay automatically across sessions.
* **Bug Fixes**
  * Improved recording stop/finalization to better preserve final microphone audio, including rapid start/stop scenarios.
  * Enhanced handling and messaging for cases where microphone capture finalization times out.
* **Tests**
  * Added capture boundary race tests to verify correct frame inclusion/exclusion around the stop target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->