### PR TITLE
Preserve Bluetooth playback quality during recording

### DIFF
--- a/.changeset/calm-airpods-routing.md
+++ b/.changeset/calm-airpods-routing.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Keep Bluetooth playback in high-quality mode when Hex records from another microphone, and restore normal quality promptly after recording and sound effects finish.

--- a/.changeset/calm-airpods-routing.md
+++ b/.changeset/calm-airpods-routing.md
@@ -2,4 +2,4 @@
 "hex-app": patch
 ---
 
-Keep Bluetooth playback in high-quality mode when Hex records from another microphone, and restore normal quality promptly after recording and sound effects finish.
+Keep Bluetooth playback in high-quality mode when Hex records from another microphone, and restore normal quality promptly after recording and sound effects finish (#267).

--- a/Hex/Clients/InputOnlyCaptureController.swift
+++ b/Hex/Clients/InputOnlyCaptureController.swift
@@ -1,0 +1,480 @@
+import AVFoundation
+import AudioToolbox
+import CoreAudio
+import Foundation
+import HexCore
+
+/// On-demand recording through an input Audio Queue.
+///
+/// Unlike `AVAudioEngine`, an input Audio Queue has no output graph. Binding the queue directly
+/// to the selected microphone prevents capture from opening the default output device as part
+/// of a duplex graph (which can switch Bluetooth headphones to their call profile), and avoids
+/// changing macOS's global default input device.
+final class InputOnlyCaptureController {
+  enum FinishRecordingResult {
+    case captured(URL)
+    case failed(RecordingFailure)
+    case idle
+  }
+
+  struct StopTimingEstimate {
+    let gracePeriod: TimeInterval
+    let callbackInterval: TimeInterval
+    let bufferDuration: TimeInterval
+  }
+
+  private struct ActiveRecording {
+    let url: URL
+    let file: AVAudioFile
+    let requestedAt: Date
+    var didLogFirstBuffer: Bool
+  }
+
+  private static let sampleRate: Double = 16_000
+  private static let fallbackStopGracePeriod: TimeInterval = 0.05
+  private static let minimumStopGracePeriod: TimeInterval = 0.02
+  private static let maximumStopGracePeriod: TimeInterval = 0.08
+  private static let stopGraceSafetyMargin: TimeInterval = 0.008
+  private static let timingWindowSize = 8
+  private static let queueBufferDuration: TimeInterval = 0.05
+  private static let queueBufferCount = 3
+
+  private let logger = HexLog.recording
+  private let processingQueue = DispatchQueue(label: "com.kitlangton.Hex.InputOnlyCapture")
+  private let meterContinuation: AsyncStream<Meter>.Continuation
+  // Audio Queue requires interleaved linear PCM. With one channel this only affects the
+  // buffer layout; conversion below writes Hex's existing non-interleaved file format.
+  private let queueFormat = AVAudioFormat(
+    commonFormat: .pcmFormatFloat32,
+    sampleRate: InputOnlyCaptureController.sampleRate,
+    channels: 1,
+    interleaved: true
+  )!
+  private let targetFormat = AVAudioFormat(
+    commonFormat: .pcmFormatFloat32,
+    sampleRate: InputOnlyCaptureController.sampleRate,
+    channels: 1,
+    interleaved: false
+  )!
+
+  private var audioQueue: AudioQueueRef?
+  private var converter: AVAudioConverter?
+  private var activeRecording: ActiveRecording?
+  private var recordingFailure: RecordingFailure?
+  private var captureGeneration = 0
+  private var lastProcessedBufferAt: Date?
+  private var recentCallbackIntervals: [TimeInterval] = []
+  private var recentBufferDurations: [TimeInterval] = []
+  private var didLogConversionFailure = false
+
+  init(meterContinuation: AsyncStream<Meter>.Continuation) {
+    self.meterContinuation = meterContinuation
+  }
+
+  deinit {
+    detachAudioQueue()
+  }
+
+  var isRunning: Bool {
+    audioQueue != nil
+  }
+
+  var isRecording: Bool {
+    processingQueue.sync { activeRecording != nil }
+  }
+
+  var stopTimingEstimate: StopTimingEstimate {
+    processingQueue.sync {
+      let callbackInterval = recentCallbackIntervals.max() ?? 0
+      let bufferDuration = recentBufferDurations.max() ?? 0
+      let observedCadence = max(callbackInterval, bufferDuration)
+      let gracePeriod = min(
+        max(
+          observedCadence > 0
+            ? observedCadence + Self.stopGraceSafetyMargin
+            : Self.fallbackStopGracePeriod,
+          Self.minimumStopGracePeriod
+        ),
+        Self.maximumStopGracePeriod
+      )
+      return StopTimingEstimate(
+        gracePeriod: gracePeriod,
+        callbackInterval: callbackInterval,
+        bufferDuration: bufferDuration
+      )
+    }
+  }
+
+  func beginRecording(to url: URL, deviceID: AudioDeviceID, requestedAt: Date = Date()) throws {
+    stop(reason: "restart-before-recording")
+
+    let file = try AVAudioFile(
+      forWriting: url,
+      settings: [
+        AVFormatIDKey: Int(kAudioFormatLinearPCM),
+        AVSampleRateKey: Self.sampleRate,
+        AVNumberOfChannelsKey: 1,
+        AVLinearPCMBitDepthKey: 32,
+        AVLinearPCMIsFloatKey: true,
+        AVLinearPCMIsBigEndianKey: false,
+        AVLinearPCMIsNonInterleaved: true,
+      ],
+      commonFormat: .pcmFormatFloat32,
+      interleaved: false
+    )
+
+    processingQueue.sync {
+      activeRecording = ActiveRecording(
+        url: url,
+        file: file,
+        requestedAt: requestedAt,
+        didLogFirstBuffer: false
+      )
+      recordingFailure = nil
+      didLogConversionFailure = false
+    }
+
+    do {
+      try startAudioQueue(deviceID: deviceID, reason: "begin-recording")
+    } catch {
+      processingQueue.sync {
+        activeRecording = nil
+        recordingFailure = nil
+      }
+      try? FileManager.default.removeItem(at: url)
+      throw error
+    }
+  }
+
+  /// Rebinds input after an input-device/configuration change while retaining the open file.
+  func restartPreservingRecording(deviceID: AudioDeviceID, reason: String) throws {
+    logger.notice("Restarting input-only capture preserving recording reason=\(reason)")
+    detachAudioQueue()
+    try startAudioQueue(deviceID: deviceID, reason: reason)
+  }
+
+  func finishRecording() -> FinishRecordingResult {
+    detachAudioQueue()
+    return processingQueue.sync {
+      let result: FinishRecordingResult
+      if let recordingFailure {
+        result = .failed(recordingFailure)
+      } else if let recording = activeRecording {
+        if recording.didLogFirstBuffer {
+          result = .captured(recording.url)
+        } else {
+          logger.error("Input-only capture stopped without receiving usable audio")
+          try? FileManager.default.removeItem(at: recording.url)
+          result = .failed(.noCapturedAudio)
+        }
+      } else {
+        result = .idle
+      }
+      activeRecording = nil
+      recordingFailure = nil
+      lastProcessedBufferAt = nil
+      recentCallbackIntervals.removeAll(keepingCapacity: false)
+      recentBufferDurations.removeAll(keepingCapacity: false)
+      didLogConversionFailure = false
+      return result
+    }
+  }
+
+  func stop(reason: String) {
+    if audioQueue != nil {
+      logger.notice("Input-only capture stopped reason=\(reason)")
+    }
+    detachAudioQueue()
+    processingQueue.sync {
+      activeRecording = nil
+      recordingFailure = nil
+      lastProcessedBufferAt = nil
+      recentCallbackIntervals.removeAll(keepingCapacity: false)
+      recentBufferDurations.removeAll(keepingCapacity: false)
+      didLogConversionFailure = false
+    }
+  }
+
+  private func startAudioQueue(deviceID: AudioDeviceID, reason: String) throws {
+    var streamDescription = queueFormat.streamDescription.pointee
+    let generation = processingQueue.sync {
+      captureGeneration += 1
+      return captureGeneration
+    }
+    var newAudioQueue: AudioQueueRef?
+    try check(
+      AudioQueueNewInputWithDispatchQueue(
+        &newAudioQueue,
+        &streamDescription,
+        0,
+        processingQueue
+      ) { [weak self] queue, buffer, _, _, _ in
+        self?.processAudioQueueBuffer(
+          queue,
+          buffer: buffer,
+          generation: generation
+        )
+      },
+      operation: "create input Audio Queue"
+    )
+    guard let newAudioQueue else {
+      throw makeError(operation: "create input Audio Queue", status: kAudio_ParamError)
+    }
+
+    do {
+      var uid = try deviceUID(for: deviceID)
+      try check(
+        AudioQueueSetProperty(
+          newAudioQueue,
+          kAudioQueueProperty_CurrentDevice,
+          &uid,
+          UInt32(MemoryLayout<CFString>.size)
+        ),
+        operation: "bind input Audio Queue device"
+      )
+
+      guard let converter = AVAudioConverter(from: queueFormat, to: targetFormat) else {
+        throw makeError(operation: "create input format converter", status: kAudio_ParamError)
+      }
+      processingQueue.sync {
+        self.converter = converter
+      }
+
+      let framesPerBuffer = max(
+        1,
+        UInt32((Self.sampleRate * Self.queueBufferDuration).rounded())
+      )
+      let bufferByteSize = framesPerBuffer * streamDescription.mBytesPerFrame
+      for _ in 0..<Self.queueBufferCount {
+        var buffer: AudioQueueBufferRef?
+        try check(
+          AudioQueueAllocateBuffer(newAudioQueue, bufferByteSize, &buffer),
+          operation: "allocate input Audio Queue buffer"
+        )
+        guard let buffer else {
+          throw makeError(operation: "allocate input Audio Queue buffer", status: kAudio_MemFullError)
+        }
+        try check(
+          AudioQueueEnqueueBuffer(newAudioQueue, buffer, 0, nil),
+          operation: "enqueue input Audio Queue buffer"
+        )
+      }
+
+      audioQueue = newAudioQueue
+      try check(AudioQueueStart(newAudioQueue, nil), operation: "start input Audio Queue")
+      logger.notice(
+        "Input-only Audio Queue started reason=\(reason) device=\(deviceID, privacy: .public) sampleRate=\(Self.sampleRate, privacy: .public)Hz outputGraph=none"
+      )
+    } catch {
+      AudioQueueDispose(newAudioQueue, true)
+      audioQueue = nil
+      processingQueue.sync {
+        self.converter = nil
+      }
+      throw error
+    }
+  }
+
+  private func detachAudioQueue() {
+    processingQueue.sync {
+      captureGeneration += 1
+    }
+    guard let audioQueue else { return }
+    AudioQueueStop(audioQueue, true)
+    AudioQueueDispose(audioQueue, true)
+    self.audioQueue = nil
+    processingQueue.sync {
+      converter = nil
+    }
+  }
+
+  private func processAudioQueueBuffer(
+    _ queue: AudioQueueRef,
+    buffer: AudioQueueBufferRef,
+    generation: Int
+  ) {
+    guard Self.shouldProcessCallback(
+      callbackGeneration: generation,
+      currentGeneration: captureGeneration
+    ) else { return }
+    defer {
+      if Self.shouldProcessCallback(
+        callbackGeneration: generation,
+        currentGeneration: captureGeneration
+      ) {
+        let status = AudioQueueEnqueueBuffer(queue, buffer, 0, nil)
+        if status != noErr {
+          logger.error(
+            "Failed to re-enqueue input Audio Queue buffer status=\(status, privacy: .public)"
+          )
+        }
+      }
+    }
+
+    let byteCount = Int(buffer.pointee.mAudioDataByteSize)
+    let bytesPerFrame = Int(queueFormat.streamDescription.pointee.mBytesPerFrame)
+    guard byteCount > 0, bytesPerFrame > 0 else { return }
+    let source = buffer.pointee.mAudioData
+    let frameCount = AVAudioFrameCount(byteCount / bytesPerFrame)
+    guard frameCount > 0,
+      let inputBuffer = AVAudioPCMBuffer(pcmFormat: queueFormat, frameCapacity: frameCount)
+    else { return }
+    inputBuffer.frameLength = frameCount
+    let destination = inputBuffer.mutableAudioBufferList.pointee.mBuffers.mData
+    memcpy(destination, source, byteCount)
+    process(inputBuffer, generation: generation)
+  }
+
+  private func process(_ inputBuffer: AVAudioPCMBuffer, generation: Int) {
+    guard Self.shouldProcessCallback(
+      callbackGeneration: generation,
+      currentGeneration: captureGeneration
+    ) else { return }
+    guard let converted = convert(inputBuffer) else {
+      if !didLogConversionFailure {
+        logger.error(
+          "Input-only capture received Audio Queue data but conversion produced no output"
+        )
+        didLogConversionFailure = true
+      }
+      return
+    }
+    guard converted.frameLength > 0, let samplePointer = converted.floatChannelData?[0] else {
+      return
+    }
+    let sampleCount = Int(converted.frameLength)
+
+    let now = Date()
+    if let lastProcessedBufferAt {
+      appendRecentMetric(now.timeIntervalSince(lastProcessedBufferAt), to: &recentCallbackIntervals)
+    }
+    lastProcessedBufferAt = now
+    appendRecentMetric(
+      Double(inputBuffer.frameLength) / inputBuffer.format.sampleRate,
+      to: &recentBufferDurations
+    )
+
+    meterContinuation.yield(meter(for: samplePointer, count: sampleCount))
+    guard var recording = activeRecording else { return }
+    if !recording.didLogFirstBuffer {
+      logger.notice(
+        "Input-only capture first buffer latency=\(String(format: "%.3f", Date().timeIntervalSince(recording.requestedAt)))s frames=\(sampleCount)"
+      )
+      recording.didLogFirstBuffer = true
+      activeRecording = recording
+    }
+
+    do {
+      try recording.file.write(from: converted)
+    } catch {
+      logger.error("Failed to write input-only capture audio: \(error.localizedDescription)")
+      activeRecording = nil
+      recordingFailure = .captureWriteFailed(error.localizedDescription)
+      try? FileManager.default.removeItem(at: recording.url)
+    }
+  }
+
+  private func convert(_ inputBuffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+    guard let converter else { return nil }
+    let sampleRateRatio = targetFormat.sampleRate / inputBuffer.format.sampleRate
+    let frameCapacity = AVAudioFrameCount(
+      max(1, (Double(inputBuffer.frameLength) * sampleRateRatio).rounded(.up) + 32)
+    )
+    guard
+      let outputBuffer = AVAudioPCMBuffer(
+        pcmFormat: targetFormat,
+        frameCapacity: frameCapacity
+      )
+    else { return nil }
+
+    var error: NSError?
+    var consumedInput = false
+    let status = converter.convert(to: outputBuffer, error: &error) { _, outStatus in
+      if consumedInput {
+        outStatus.pointee = .noDataNow
+        return nil
+      }
+      consumedInput = true
+      outStatus.pointee = .haveData
+      return inputBuffer
+    }
+    if let error {
+      logger.error("Failed to convert input-only capture audio: \(error.localizedDescription)")
+      return nil
+    }
+    switch status {
+    case .haveData, .inputRanDry, .endOfStream:
+      return outputBuffer.frameLength > 0 ? outputBuffer : nil
+    case .error:
+      return nil
+    @unknown default:
+      return nil
+    }
+  }
+
+  nonisolated static func shouldProcessCallback(
+    callbackGeneration: Int,
+    currentGeneration: Int
+  ) -> Bool {
+    callbackGeneration == currentGeneration
+  }
+
+  private func deviceUID(for deviceID: AudioDeviceID) throws -> CFString {
+    var address = AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyDeviceUID,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    var uid: CFString?
+    var size = UInt32(MemoryLayout<CFString?>.size)
+    let status = withUnsafeMutablePointer(to: &uid) { pointer in
+      AudioObjectGetPropertyData(
+        deviceID,
+        &address,
+        0,
+        nil,
+        &size,
+        pointer
+      )
+    }
+    try check(status, operation: "read input device UID")
+    guard let uid else {
+      throw makeError(operation: "read input device UID", status: kAudio_ParamError)
+    }
+    return uid
+  }
+
+  private func meter(for samples: UnsafePointer<Float>, count: Int) -> Meter {
+    guard count > 0 else { return Meter(averagePower: 0, peakPower: 0) }
+    var sumOfSquares: Float = 0
+    var peak: Float = 0
+    for index in 0..<count {
+      let sample = samples[index]
+      sumOfSquares += sample * sample
+      peak = max(peak, abs(sample))
+    }
+    return Meter(
+      averagePower: Double(sqrt(sumOfSquares / Float(count))),
+      peakPower: Double(peak)
+    )
+  }
+
+  private func appendRecentMetric(_ value: TimeInterval, to metrics: inout [TimeInterval]) {
+    metrics.append(value)
+    if metrics.count > Self.timingWindowSize {
+      metrics.removeFirst(metrics.count - Self.timingWindowSize)
+    }
+  }
+
+  private func check(_ status: OSStatus, operation: String) throws {
+    guard status == noErr else { throw makeError(operation: operation, status: status) }
+  }
+
+  private func makeError(operation: String, status: OSStatus) -> NSError {
+    NSError(
+      domain: "InputOnlyCapture",
+      code: Int(status),
+      userInfo: [NSLocalizedDescriptionKey: "Failed to \(operation) (Core Audio status \(status))."]
+    )
+  }
+}

--- a/Hex/Clients/RecordingClient.swift
+++ b/Hex/Clients/RecordingClient.swift
@@ -362,6 +362,7 @@ actor RecordingClientLive {
   }
 
   private enum RecordingBackend: String {
+    case inputOnly = "input-only"
     case captureEngine = "capture-engine"
     case recorderFallback = "recorder-fallback"
   }
@@ -393,6 +394,10 @@ actor RecordingClientLive {
   ]
   private let (meterStream, meterContinuation) = AsyncStream<Meter>.makeStream()
   private var meterTask: Task<Void, Never>?
+  private lazy var inputOnlyCaptureController = InputOnlyCaptureController(
+    meterContinuation: meterContinuation
+  )
+  private var inputOnlyCaptureDeviceID: AudioDeviceID?
   private lazy var captureController = SuperFastCaptureController(
     meterContinuation: meterContinuation,
     onEngineConfigurationChange: { [weak self] generation in
@@ -648,17 +653,47 @@ actor RecordingClientLive {
     let currentInputDevice = getDefaultInputDevice()
     let currentOutputDevice = getDefaultOutputDevice()
     let isRecorderRecording = recorder?.isRecording == true
+    let isInputOnlyRecording = inputOnlyCaptureController.isRecording
     let isEngineRecording = captureController.isRecording
-    let isRecordingActive = isRecorderRecording || isEngineRecording
+    let isRecordingActive = isRecorderRecording || isInputOnlyRecording || isEngineRecording
 
     recordingLogger.notice(
-      "Capture environment changed reason=\(reason) activeRecording=\(isRecordingActive) input=\(self.describeDevice(currentInputDevice)) output=\(self.describeDevice(currentOutputDevice)) captureEngineArmed=\(self.captureController.isRunning) primed=\(self.isRecorderPrimedForNextSession)"
+      "Capture environment changed reason=\(reason) activeRecording=\(isRecordingActive) input=\(self.describeDevice(currentInputDevice)) output=\(self.describeDevice(currentOutputDevice)) inputOnlyRunning=\(self.inputOnlyCaptureController.isRunning) captureEngineArmed=\(self.captureController.isRunning) primed=\(self.isRecorderPrimedForNextSession)"
     )
 
     if isRecordingActive {
       invalidatePrimedState()
+      if isInputOnlyRecording {
+        guard let activeInputDevice = resolveCaptureInputDevice() else {
+          deferredCaptureRestartReason = reason
+          recordingLogger.error("No input device available while rebuilding input-only capture")
+          return
+        }
+        let inputChanged = activeInputDevice != inputOnlyCaptureDeviceID
+        let captureDisrupted = !inputOnlyCaptureController.isRunning
+        guard inputChanged || captureDisrupted else {
+          recordingLogger.debug("Environment change does not affect input-only capture; ignoring reason=\(reason)")
+          return
+        }
+        do {
+          try inputOnlyCaptureController.restartPreservingRecording(
+            deviceID: activeInputDevice,
+            reason: reason
+          )
+          inputOnlyCaptureDeviceID = activeInputDevice
+          deferredCaptureRestartReason = nil
+          recordingLogger.notice(
+            "Rebuilt input-only capture mid-recording reason=\(reason) input=\(self.describeDevice(activeInputDevice))"
+          )
+          return
+        } catch {
+          recordingLogger.error(
+            "Mid-recording input-only capture rebuild failed reason=\(reason): \(error.localizedDescription); deferring restart"
+          )
+        }
+      }
       if isEngineRecording {
-        let activeInputDevice = applyPreferredInputDevice()
+        let activeInputDevice = resolveCaptureInputDevice()
         // Only disturb an active recording when its capture path is actually affected:
         // the input device changed, or the engine already died (configuration change).
         // Output-only changes (plugging in headphones) must not cause an audio gap.
@@ -672,7 +707,10 @@ actor RecordingClientLive {
         // stale engine "running" against the old route silently captured nothing for the
         // rest of the recording (#251, #252, #218, #226).
         do {
-          try captureController.restartPreservingRecording(reason: reason)
+          try captureController.restartPreservingRecording(
+            deviceID: activeInputDevice,
+            reason: reason
+          )
           captureControllerDeviceID = activeInputDevice
           captureControllerNeedsRestartReason = nil
           deferredCaptureRestartReason = nil
@@ -701,7 +739,7 @@ actor RecordingClientLive {
 
     if hexSettings.superFastModeEnabled {
       releaseRecorder(reason: "environment-change-\(reason)")
-      let activeInputDevice = applyPreferredInputDevice()
+      let activeInputDevice = resolveCaptureInputDevice()
       // Skip the rebuild when nothing that matters changed. Device events arrive in
       // bursts (a Bluetooth connect fires devices-changed, default-input-changed,
       // default-output-changed, and more over 1-2s); once the first event settles the
@@ -736,10 +774,11 @@ actor RecordingClientLive {
       return
     }
 
-    _ = applyPreferredInputDevice()
+    inputOnlyCaptureController.stop(reason: "environment-change-\(reason)")
+    inputOnlyCaptureDeviceID = nil
     stopCaptureController(reason: reason)
     releaseRecorder(reason: "environment-change-\(reason)")
-    recordingLogger.debug("Standard mode uses on-demand capture startup after reason=\(reason)")
+    recordingLogger.debug("Standard mode uses on-demand input-only capture after reason=\(reason)")
   }
 
   /// Records that a lock/sleep transition happened and tears down the warm engine unless a
@@ -747,7 +786,10 @@ actor RecordingClientLive {
   /// via finalizeCaptureStateAfterRecording).
   private func suspendWarmCapture(source: CaptureSuspensionSource) {
     guard captureSuspensionSources.insert(source).inserted else { return }
-    guard recorder?.isRecording != true, !captureController.isRecording else {
+    guard recorder?.isRecording != true,
+          !inputOnlyCaptureController.isRecording,
+          !captureController.isRecording
+    else {
       recordingLogger.notice("Lock/sleep during active recording; capture continues, suspending after stop source=\(source.rawValue)")
       return
     }
@@ -768,7 +810,9 @@ actor RecordingClientLive {
 
   private func tearDownWarmCapture(reason: String) {
     captureControllerNeedsRestartReason = reason
-    guard captureController.isRunning || recorder != nil else { return }
+    guard captureController.isRunning || inputOnlyCaptureController.isRunning || recorder != nil else { return }
+    inputOnlyCaptureController.stop(reason: reason)
+    inputOnlyCaptureDeviceID = nil
     stopCaptureController(reason: reason)
     releaseRecorder(reason: reason)
   }
@@ -908,28 +952,6 @@ actor RecordingClientLive {
     return buffersPointer.reduce(0) { $0 + Int($1.mNumberChannels) } > 0
   }
   
-  /// Set device as the default input device
-  private func setInputDevice(deviceID: AudioDeviceID) {
-    var device = deviceID
-    let size = UInt32(MemoryLayout<AudioDeviceID>.size)
-    var address = audioPropertyAddress(kAudioHardwarePropertyDefaultInputDevice)
-    
-    let status = AudioObjectSetPropertyData(
-      AudioObjectID(kAudioObjectSystemObject),
-      &address,
-      0,
-      nil,
-      size,
-      &device
-    )
-    
-    if status != 0 {
-      recordingLogger.error("Failed to set default input device: \(status)")
-    } else {
-      recordingLogger.notice("Selected input device set to \(deviceID)")
-    }
-  }
-
   func requestMicrophoneAccess() async -> Bool {
     await AVCaptureDevice.requestAccess(for: .audio)
   }
@@ -976,23 +998,13 @@ actor RecordingClientLive {
   }
 
   private func getDeviceID(uid: String) -> AudioDeviceID? {
-    var address = audioPropertyAddress(kAudioHardwarePropertyDeviceForUID)
-    var deviceUID = uid as CFString
-    var deviceID = AudioDeviceID(0)
-    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-    let status = withUnsafePointer(to: &deviceUID) { pointer in
-      AudioObjectGetPropertyData(
-        AudioObjectID(kAudioObjectSystemObject),
-        &address,
-        UInt32(MemoryLayout<CFString>.size),
-        pointer,
-        &size,
-        &deviceID
-      )
+    // Core Audio device IDs are ephemeral, while the UID stored in settings is stable.
+    // Resolve it against the current device list instead of using
+    // kAudioHardwarePropertyDeviceForUID, whose value is an AudioValueTranslation rather
+    // than qualifier data and previously caused every persisted selection to miss.
+    getAllAudioDevices().first { deviceID in
+      getDeviceUID(deviceID: deviceID) == uid
     }
-
-    guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
-    return deviceID
   }
 
   private func formatDuration(_ duration: TimeInterval?) -> String {
@@ -1012,7 +1024,7 @@ actor RecordingClientLive {
     let idleDuration = lastRecordingEndedAt.map { Date().timeIntervalSince($0) }
     let outputDeviceID = getDefaultOutputDevice()
     recordingLogger.notice(
-      "Recording requested mode=\(mode.rawValue) idle=\(self.formatDuration(idleDuration)) input=\(self.describeDevice(inputDeviceID)) output=\(self.describeDevice(outputDeviceID)) fallbackPrimed=\(self.isRecorderPrimedForNextSession)"
+      "Recording requested mode=\(mode.rawValue, privacy: .public) idle=\(self.formatDuration(idleDuration), privacy: .public) input=\(self.describeDevice(inputDeviceID), privacy: .public) output=\(self.describeDevice(outputDeviceID), privacy: .public) fallbackPrimed=\(self.isRecorderPrimedForNextSession, privacy: .public)"
     )
   }
 
@@ -1020,29 +1032,19 @@ actor RecordingClientLive {
     hexSettings.superFastModeEnabled ? .superFast : .standard
   }
 
-  @discardableResult
-  private func applyPreferredInputDevice() -> AudioDeviceID? {
-    let targetDeviceID = resolvePreferredInputDevice()
-    let currentDefaultDevice = getDefaultInputDevice()
+  /// Resolves the microphone Hex should bind to without changing the system-wide default.
+  private func resolveCaptureInputDevice() -> AudioDeviceID? {
+    Self.captureDeviceID(
+      preferredDeviceID: resolvePreferredInputDevice(),
+      systemDefaultDeviceID: getDefaultInputDevice()
+    )
+  }
 
-    if let primedDevice = lastPrimedDeviceID, primedDevice != currentDefaultDevice {
-      recordingLogger.notice("Default input changed from \(primedDevice) to \(currentDefaultDevice ?? 0); invalidating primed state")
-      invalidatePrimedState()
-    }
-
-    if let targetDeviceID {
-      if targetDeviceID != currentDefaultDevice {
-        recordingLogger.notice("Switching input device from \(currentDefaultDevice ?? 0) to \(targetDeviceID)")
-        setInputDevice(deviceID: targetDeviceID)
-        invalidatePrimedState()
-      } else {
-        recordingLogger.debug("Device \(targetDeviceID) already set as default, skipping setInputDevice()")
-      }
-    } else {
-      recordingLogger.debug("Using system default microphone")
-    }
-
-    return getDefaultInputDevice()
+  nonisolated static func captureDeviceID(
+    preferredDeviceID: AudioDeviceID?,
+    systemDefaultDeviceID: AudioDeviceID?
+  ) -> AudioDeviceID? {
+    preferredDeviceID ?? systemDefaultDeviceID
   }
 
   private func makeCaptureRecordingURL() -> URL {
@@ -1070,6 +1072,7 @@ actor RecordingClientLive {
     }
 
     try captureController.startIfNeeded(
+      deviceID: deviceID,
       reason: reason,
       keepWarmBuffer: currentCaptureMode().keepsWarmBuffer
     )
@@ -1139,8 +1142,8 @@ actor RecordingClientLive {
   }
 
   /// Checks and fixes muted input device before recording
-  private func ensureInputDeviceUnmuted() {
-    guard let deviceID = getDefaultInputDevice() else { return }
+  private func ensureInputDeviceUnmuted(_ deviceID: AudioDeviceID?) {
+    guard let deviceID else { return }
     if isInputDeviceMuted(deviceID) {
       recordingLogger.error("⚠️ Input device \(deviceID) is MUTED at Core Audio level! This causes silent recordings.")
       unmuteInputDevice(deviceID)
@@ -1300,17 +1303,54 @@ actor RecordingClientLive {
       break
     }
 
-    let activeInputDevice = applyPreferredInputDevice()
-    // Check the actual active device after applying the user's preferred input.
-    ensureInputDeviceUnmuted()
+    let activeInputDevice = resolveCaptureInputDevice()
+    ensureInputDeviceUnmuted(activeInputDevice)
     let mode = currentCaptureMode()
     logRecordingStartRequest(mode: mode, inputDeviceID: activeInputDevice)
     let startRequestAt = Date()
 
+    if mode == .standard {
+      guard let activeInputDevice else {
+        recordingLogger.error("Failed to start input-only recording: no input device is available")
+        endRecordingSession()
+        return
+      }
+      do {
+        let recordingURL = makeCaptureRecordingURL()
+        try inputOnlyCaptureController.beginRecording(
+          to: recordingURL,
+          deviceID: activeInputDevice,
+          requestedAt: startRequestAt
+        )
+        inputOnlyCaptureDeviceID = activeInputDevice
+        let startedAt = Date()
+        activeRecordingSession = ActiveRecordingSession(
+          startedAt: startedAt,
+          mode: mode,
+          backend: .inputOnly
+        )
+        recordingLogger.notice(
+          "Recording started mode=\(mode.rawValue) backend=\(RecordingBackend.inputOnly.rawValue) startup=\(self.formatDuration(startedAt.timeIntervalSince(startRequestAt)))"
+        )
+      } catch {
+        inputOnlyCaptureController.stop(reason: "input-only-start-failed")
+        inputOnlyCaptureDeviceID = nil
+        recordingLogger.error("Failed to start input-only recording: \(error.localizedDescription)")
+        clearActiveRecordingMetadata()
+        endRecordingSession()
+      }
+      return
+    }
+
     do {
       try ensureCaptureControllerReadyAfterDeferredRestart(for: activeInputDevice, reason: "startRecording")
       let recordingURL = makeCaptureRecordingURL()
-      try captureController.beginRecording(to: recordingURL, requestedAt: startRequestAt, mode: mode)
+      try captureController.beginRecording(
+        to: recordingURL,
+        deviceID: activeInputDevice,
+        requestedAt: startRequestAt,
+        mode: mode
+      )
       let startedAt = Date()
       activeRecordingSession = ActiveRecordingSession(
         startedAt: startedAt,
@@ -1354,6 +1394,50 @@ actor RecordingClientLive {
   func stopRecording() async -> RecordingStopResult {
     let stopSessionID = recordingSessionID
     let activeSession = activeRecordingSession
+
+    if activeSession?.backend == .inputOnly || inputOnlyCaptureController.isRecording {
+      let stopTimingEstimate = inputOnlyCaptureController.stopTimingEstimate
+      recordingLogger.debug(
+        "Waiting \(self.formatDuration(stopTimingEstimate.gracePeriod)) before finalizing input-only recording callbackInterval=\(self.formatDuration(stopTimingEstimate.callbackInterval)) bufferDuration=\(self.formatDuration(stopTimingEstimate.bufferDuration))"
+      )
+      try? await Task.sleep(
+        for: .milliseconds(Int((stopTimingEstimate.gracePeriod * 1000).rounded()))
+      )
+
+      if Self.shouldIgnoreStopRequest(
+        snapshotSessionID: stopSessionID,
+        currentSessionID: recordingSessionID
+      ) {
+        recordingLogger.notice("Ignoring stale input-only stop request after a newer recording session started")
+        return .ignored(.staleSession)
+      }
+
+      let stoppedAt = Date()
+      let session = activeSession ?? ActiveRecordingSession(
+        startedAt: stoppedAt,
+        mode: .standard,
+        backend: .inputOnly
+      )
+      let result = inputOnlyCaptureController.finishRecording()
+      inputOnlyCaptureDeviceID = nil
+      endRecordingSession()
+      clearActiveRecordingMetadata()
+      lastRecordingEndedAt = stoppedAt
+      recordingLogger.notice(
+        "Recording stopped mode=\(session.mode.rawValue) backend=\(session.backend.rawValue) duration=\(self.formatDuration(stoppedAt.timeIntervalSince(session.startedAt)))"
+      )
+      finalizeCaptureStateAfterRecording()
+      await resumeMediaIfNeeded()
+
+      switch result {
+      case let .captured(url):
+        return .captured(url)
+      case let .failed(error):
+        return .failed(error)
+      case .idle:
+        return .ignored(.noActiveRecording)
+      }
+    }
 
     if activeSession?.backend == .captureEngine || captureController.isRecording {
       let stopTimingEstimate = captureController.stopTimingEstimate
@@ -1657,7 +1741,11 @@ actor RecordingClientLive {
   }
 
   func warmUpRecorder() async {
-    guard activeRecordingSession == nil, recorder?.isRecording != true, !captureController.isRecording else {
+    guard activeRecordingSession == nil,
+          recorder?.isRecording != true,
+          !inputOnlyCaptureController.isRecording,
+          !captureController.isRecording
+    else {
       recordingLogger.notice("Skipping recorder warm-up while recording is active")
       return
     }
@@ -1665,7 +1753,7 @@ actor RecordingClientLive {
       recordingLogger.notice("Skipping recorder warm-up while capture is suspended (screen locked/asleep)")
       return
     }
-    let activeInputDevice = applyPreferredInputDevice()
+    let activeInputDevice = resolveCaptureInputDevice()
 
     if hexSettings.superFastModeEnabled {
       releaseRecorder(reason: "warm-up-super-fast")
@@ -1678,8 +1766,10 @@ actor RecordingClientLive {
     }
 
     stopCaptureController(reason: "warm-up-standard")
+    inputOnlyCaptureController.stop(reason: "warm-up-standard")
+    inputOnlyCaptureDeviceID = nil
     releaseRecorder(reason: "warm-up-standard")
-    recordingLogger.debug("Standard mode uses on-demand capture engine startup; skipping idle recorder priming")
+    recordingLogger.debug("Standard mode uses on-demand input-only capture; skipping idle recorder priming")
   }
 
   /// Release recorder resources. Call on app termination.
@@ -1687,6 +1777,8 @@ actor RecordingClientLive {
     endRecordingSession()
     await resumeMediaIfNeeded()
     stopObservingSystemChanges()
+    inputOnlyCaptureController.stop(reason: "cleanup")
+    inputOnlyCaptureDeviceID = nil
     stopCaptureController(reason: "cleanup")
     releaseRecorder(reason: "cleanup")
     recordingLogger.notice("RecordingClient cleaned up")

--- a/Hex/Clients/SoundEffect.swift
+++ b/Hex/Clients/SoundEffect.swift
@@ -76,10 +76,8 @@ actor SoundEffectsClientLive {
   @Shared(.hexSettings) var hexSettings: HexSettings
   private var playerNodes: [SoundEffect: AVAudioPlayerNode] = [:]
   private var audioBuffers: [SoundEffect: AVAudioPCMBuffer] = [:]
-  private var idleShutdownTask: Task<Void, Never>?
-  /// Comfortably longer than any sound effect, short enough that an idle Hex doesn't keep
-  /// an output IOProc (and coreaudiod) running around the clock (#209).
-  private static let idleShutdownDelay: Duration = .seconds(10)
+  private var activePlaybackTokens: [SoundEffect: UUID] = [:]
+  private var playbackTimeoutTasks: [SoundEffect: Task<Void, Never>] = [:]
 
   func play(_ soundEffect: SoundEffect) {
     guard hexSettings.soundEffectsEnabled else { return }
@@ -90,29 +88,59 @@ actor SoundEffectsClientLive {
     prepareEngineIfNeeded()
     let clampedVolume = min(max(hexSettings.soundEffectsVolume, 0), baselineVolume)
     player.volume = Float(clampedVolume)
+    let playbackToken = UUID()
+    activePlaybackTokens[soundEffect] = playbackToken
     player.stop()
-    player.scheduleBuffer(buffer, at: nil, options: [], completionHandler: nil)
+    player.scheduleBuffer(
+      buffer,
+      at: nil,
+      options: [],
+      completionCallbackType: .dataPlayedBack
+    ) { [weak self] _ in
+      Task {
+        await self?.playbackFinished(soundEffect, token: playbackToken)
+      }
+    }
     player.play()
-    scheduleIdleShutdown()
+
+    // The played-back callback is the normal shutdown path. Keep a short duration-based
+    // fallback in case a route change prevents AVAudioPlayerNode from delivering it.
+    playbackTimeoutTasks[soundEffect]?.cancel()
+    let playbackDuration = Double(buffer.frameLength) / buffer.format.sampleRate
+    playbackTimeoutTasks[soundEffect] = Task { [weak self] in
+      try? await Task.sleep(for: .seconds(playbackDuration + 0.5))
+      guard !Task.isCancelled else { return }
+      await self?.playbackFinished(soundEffect, token: playbackToken)
+    }
   }
 
-  /// Stops the output engine shortly after playback so it doesn't run while idle.
-  /// Restarting it on the next play costs only a few milliseconds.
-  private func scheduleIdleShutdown() {
-    idleShutdownTask?.cancel()
-    idleShutdownTask = Task {
-      try? await Task.sleep(for: Self.idleShutdownDelay)
-      guard !Task.isCancelled else { return }
+  private func playbackFinished(_ soundEffect: SoundEffect, token: UUID) {
+    guard activePlaybackTokens[soundEffect] == token else { return }
+    playbackTimeoutTasks[soundEffect]?.cancel()
+    playbackTimeoutTasks[soundEffect] = nil
+    activePlaybackTokens[soundEffect] = nil
+    playerNodes[soundEffect]?.stop()
+    if activePlaybackTokens.isEmpty {
       stopEngineIfNeeded()
     }
   }
 
   func stop(_ soundEffect: SoundEffect) {
     playerNodes[soundEffect]?.stop()
+    playbackTimeoutTasks[soundEffect]?.cancel()
+    playbackTimeoutTasks[soundEffect] = nil
+    activePlaybackTokens[soundEffect] = nil
+    if activePlaybackTokens.isEmpty {
+      stopEngineIfNeeded()
+    }
   }
 
   func stopAll() {
     playerNodes.values.forEach { $0.stop() }
+    playbackTimeoutTasks.values.forEach { $0.cancel() }
+    playbackTimeoutTasks.removeAll()
+    activePlaybackTokens.removeAll()
+    stopEngineIfNeeded()
   }
 
   func preloadSounds() async {
@@ -128,12 +156,10 @@ actor SoundEffectsClientLive {
   func setEnabled(_: Bool) async {
     await preloadSounds()
 
-    // No prewarm on enable: play() starts the engine lazily, and an idle prewarm would
-    // just be shut down again by the idle timer.
+    // No prewarm on enable: play() starts the engine lazily and playback completion
+    // releases the output route again.
     if !hexSettings.soundEffectsEnabled {
       stopAll()
-      idleShutdownTask?.cancel()
-      stopEngineIfNeeded()
     }
   }
 

--- a/Hex/Clients/SuperFastCaptureController.swift
+++ b/Hex/Clients/SuperFastCaptureController.swift
@@ -1,4 +1,6 @@
 import AVFoundation
+import AudioToolbox
+import CoreAudio
 import Foundation
 import HexCore
 
@@ -117,6 +119,7 @@ final class SuperFastCaptureController {
   )!
 
   private var engine: AVAudioEngine?
+  private var configuredDeviceID: AudioDeviceID?
   private var converter: AVAudioConverter?
   private var configurationChangeObserver: NSObjectProtocol?
   private var activeRecording: ActiveRecording?
@@ -170,7 +173,11 @@ final class SuperFastCaptureController {
     }
   }
 
-  func startIfNeeded(reason: String = "unknown", keepWarmBuffer: Bool = false) throws {
+  func startIfNeeded(
+    deviceID: AudioDeviceID?,
+    reason: String = "unknown",
+    keepWarmBuffer: Bool = false
+  ) throws {
     processingQueue.sync {
       let didDisableWarmBuffer = self.keepWarmBuffer && !keepWarmBuffer
       self.keepWarmBuffer = keepWarmBuffer
@@ -179,28 +186,52 @@ final class SuperFastCaptureController {
       }
     }
 
-    if engine?.isRunning == true {
+    if engine?.isRunning == true, configuredDeviceID == deviceID {
       logger.debug("Capture engine already armed reason=\(reason)")
       return
     }
 
     stop(reason: "restart-before-arm")
-    try armEngine(reason: reason)
+    try armEngine(deviceID: deviceID, reason: reason)
   }
 
   /// Tears down and recreates the engine while keeping the active recording file open, so
   /// capture resumes onto the same file after a device/route change mid-recording
   /// (#251, #252, #218, #226). The ring buffer, timing metrics, and active recording survive;
   /// only the engine, tap, and converter are rebuilt.
-  func restartPreservingRecording(reason: String) throws {
+  func restartPreservingRecording(deviceID: AudioDeviceID?, reason: String) throws {
     logger.notice("Restarting capture engine preserving active recording reason=\(reason)")
     detachEngine()
-    try armEngine(reason: reason)
+    try armEngine(deviceID: deviceID, reason: reason)
   }
 
-  private func armEngine(reason: String) throws {
+  private func armEngine(deviceID: AudioDeviceID?, reason: String) throws {
     let engine = AVAudioEngine()
     let inputNode = engine.inputNode
+    if var deviceID {
+      guard let audioUnit = inputNode.audioUnit else {
+        throw NSError(
+          domain: "SuperFastCapture",
+          code: -2,
+          userInfo: [NSLocalizedDescriptionKey: "Unable to access the capture engine input unit."]
+        )
+      }
+      let status = AudioUnitSetProperty(
+        audioUnit,
+        kAudioOutputUnitProperty_CurrentDevice,
+        kAudioUnitScope_Global,
+        0,
+        &deviceID,
+        UInt32(MemoryLayout<AudioDeviceID>.size)
+      )
+      guard status == noErr else {
+        throw NSError(
+          domain: "SuperFastCapture",
+          code: Int(status),
+          userInfo: [NSLocalizedDescriptionKey: "Unable to bind the selected input device (Core Audio status \(status))."]
+        )
+      }
+    }
     let inputFormat = inputNode.inputFormat(forBus: 0)
     guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
       throw NSError(
@@ -237,6 +268,7 @@ final class SuperFastCaptureController {
       throw error
     }
     self.engine = engine
+    configuredDeviceID = deviceID
     configurationChangeObserver = NotificationCenter.default.addObserver(
       forName: .AVAudioEngineConfigurationChange,
       object: engine,
@@ -282,6 +314,7 @@ final class SuperFastCaptureController {
     }
     engine?.stop()
     engine = nil
+    configuredDeviceID = nil
   }
 
   private func handleConfigurationChange(generation: Int) {
@@ -300,8 +333,17 @@ final class SuperFastCaptureController {
     processingQueue.sync { generation == captureGeneration }
   }
 
-  func beginRecording(to url: URL, requestedAt: Date = Date(), mode: CaptureRecordingMode) throws {
-    try startIfNeeded(reason: "begin-recording", keepWarmBuffer: mode.keepsWarmBuffer)
+  func beginRecording(
+    to url: URL,
+    deviceID: AudioDeviceID?,
+    requestedAt: Date = Date(),
+    mode: CaptureRecordingMode
+  ) throws {
+    try startIfNeeded(
+      deviceID: deviceID,
+      reason: "begin-recording",
+      keepWarmBuffer: mode.keepsWarmBuffer
+    )
 
     var startError: Error?
     processingQueue.sync {

--- a/HexTests/RecordingRaceTests.swift
+++ b/HexTests/RecordingRaceTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ComposableArchitecture
+import CoreAudio
 import Foundation
 import HexCore
 import XCTest
@@ -100,6 +101,41 @@ final class RecordingRaceTests: XCTestCase {
         callbackGeneration: 1,
         currentGeneration: 2
       )
+    )
+  }
+
+  func testInputOnlyCaptureIgnoresCallbacksFromOlderGeneration() {
+    XCTAssertTrue(
+      InputOnlyCaptureController.shouldProcessCallback(
+        callbackGeneration: 4,
+        currentGeneration: 4
+      )
+    )
+    XCTAssertFalse(
+      InputOnlyCaptureController.shouldProcessCallback(
+        callbackGeneration: 3,
+        currentGeneration: 4
+      )
+    )
+  }
+
+  func testPreferredMicrophoneIsBoundWithoutReplacingSystemDefault() {
+    let macBookMicrophone = AudioDeviceID(42)
+    let airPodsMicrophone = AudioDeviceID(84)
+
+    XCTAssertEqual(
+      RecordingClientLive.captureDeviceID(
+        preferredDeviceID: macBookMicrophone,
+        systemDefaultDeviceID: airPodsMicrophone
+      ),
+      macBookMicrophone
+    )
+    XCTAssertEqual(
+      RecordingClientLive.captureDeviceID(
+        preferredDeviceID: nil,
+        systemDefaultDeviceID: airPodsMicrophone
+      ),
+      airPodsMicrophone
     )
   }
 


### PR DESCRIPTION
I noticed two issues when using Hex with the following settings:

- Input Device: MacBook Microphone
- MacBook Output Device: AirPods
- Audio Behavior While Recording: Do Nothing
- Super Fast Mode: Off

Activating Hex would:

1. Switch the AirPods into Bluetooth call mode—raising the volume and reducing audio quality—even though the MacBook microphone was selected as the input device.
2. Leave the AirPods in call mode after transcription finished. Pausing and resuming audio was required to restore normal audio quality.

This PR resolves both issues in my testing.

---

- Prevent Bluetooth audio from remaining in degraded call mode after recording.
- Replace the default AVAudioEngine input tap with an on-demand, input-only Audio Queue bound directly to the selected microphone’s Core Audio UID.
- Resolve saved microphone selections without changing macOS’s global default input device.
- Preserve Super Fast pre-roll while capturing from the selected input.
- Release the sound-effects engine after playback, with a timeout fallback for missed completion callbacks.
- Treat empty input-only captures as recording failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input-only microphone recording for standard recordings, improving Bluetooth playback quality while recording.
  * Preferred microphones are now selected more reliably, including after audio-device changes.
  * Recording can continue smoothly when the active audio route changes.

* **Bug Fixes**
  * Bluetooth audio now returns to normal quality promptly after recording and sound effects finish.
  * Improved sound-effect playback cleanup, including during audio-route changes.
  * Prevented outdated recording callbacks from affecting newer recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->