### PR TITLE
Add Apple SpeechAnalyzer (macOS 26+) as a third transcription engine

### DIFF
--- a/.changeset/766b5f22.md
+++ b/.changeset/766b5f22.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Add Apple's on-device SpeechAnalyzer (macOS 26+) as a selectable transcription engine in the model library (#255)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ The app uses **The Composable Architecture (TCA)** for state management. Key arc
 
 - Default: Parakeet TDT v3 (multilingual) via FluidAudio
 - Additional curated: Whisper Small (Tiny), Whisper Medium (Base), Whisper Large v3
+- Apple Speech (`apple-speechanalyzer`): Apple's on‑device SpeechAnalyzer engine, shown only on macOS 26+ with capable hardware and only in builds made with the macOS 26 SDK (Xcode 26; older toolchains compile a stub via `#if compiler(>=6.2)`). Locale assets are OS‑managed via AssetInventory and follow the Output Language setting — there is no Finder location and no uninstall API, so the row hides Show in Finder / Delete. Batch‑only today (transcribes the recorded file); streaming is a possible follow‑up.
 - Note: Distil‑Whisper is English‑only and not shown by default
 
 ### Storage Locations

--- a/Hex/Clients/AppleSpeechClient.swift
+++ b/Hex/Clients/AppleSpeechClient.swift
@@ -1,0 +1,275 @@
+import Foundation
+import HexCore
+
+// SpeechAnalyzer requires the macOS 26 SDK, which ships with the Swift 6.2+
+// toolchain (Xcode 26). Older toolchains compile the stub at the bottom of
+// this file instead — mirroring ParakeetClient's `canImport(FluidAudio)`
+// guard — so the app still builds on Xcode 16, just without this engine.
+// (`compiler(>=6.2)` checks the toolchain, not the project's language mode,
+// and xcodebuild always pairs the toolchain with its bundled SDK.)
+#if compiler(>=6.2)
+import AVFoundation
+import Speech
+
+/// Batch transcription via Apple's on-device SpeechAnalyzer (macOS 26+). (#255)
+///
+/// Deliberately stateless: locale assets live in the OS-managed AssetInventory
+/// and `SpeechTranscriber` construction is cheap, so there is nothing worth
+/// caching between calls. That statelessness is also what lets this actor be
+/// stored by the non-`@available` `TranscriptionClientLive` — no stored
+/// property here has a macOS-26-only type. (If future work ever needs cached
+/// 26-only state, box it as `Any?` and re-cast inside `if #available`.)
+actor AppleSpeechClient {
+  private let logger = HexLog.appleSpeech
+
+  /// Whether the engine can run at all: macOS 26+ on supported hardware,
+  /// built with a toolchain that has the Speech SDK.
+  func isSupported() -> Bool {
+    guard #available(macOS 26.0, *) else { return false }
+    return SpeechTranscriber.isAvailable
+  }
+
+  /// Whether assets for the locale resolved from `languagePreference`
+  /// (Hex's `outputLanguage` setting; nil = Auto) are installed on-device.
+  func isModelInstalled(languagePreference: String?) async -> Bool {
+    guard #available(macOS 26.0, *) else { return false }
+    return await AppleSpeechEngine.isInstalled(languagePreference: languagePreference)
+  }
+
+  /// Downloads and installs the locale assets if missing, reporting native
+  /// download progress. Safe to call repeatedly.
+  func ensureModel(languagePreference: String?, progress: @escaping (Progress) -> Void) async throws {
+    guard #available(macOS 26.0, *) else { throw AppleSpeechError.requiresMacOS26 }
+    try await AppleSpeechEngine.ensureAssets(languagePreference: languagePreference, progress: progress)
+  }
+
+  /// Transcribes the recorded audio file, installing locale assets first if
+  /// needed (slower first run after a language switch, but never a dead end).
+  func transcribe(url: URL, languagePreference: String?, progress: @escaping (Progress) -> Void) async throws -> String {
+    guard #available(macOS 26.0, *) else { throw AppleSpeechError.requiresMacOS26 }
+    return try await AppleSpeechEngine.transcribe(url: url, languagePreference: languagePreference, progress: progress)
+  }
+}
+
+/// All Speech-SDK calls live here so the surrounding actor needs no
+/// availability annotation.
+@available(macOS 26.0, *)
+private enum AppleSpeechEngine {
+  private static let logger = HexLog.appleSpeech
+
+  private static func makeTranscriber(locale: Locale) -> SpeechTranscriber {
+    SpeechTranscriber(
+      locale: locale,
+      transcriptionOptions: [],
+      reportingOptions: [], // no volatile results — batch semantics, finalized text only
+      attributeOptions: []
+    )
+  }
+
+  private static func resolveLocale(_ preference: String?) async throws -> Locale {
+    let supported = await SpeechTranscriber.supportedLocales
+    guard !supported.isEmpty else { throw AppleSpeechError.engineUnavailable }
+    guard let locale = SpeechLocaleResolution.resolve(preference: preference, supported: supported) else {
+      throw AppleSpeechError.unsupportedLanguage(preference ?? "auto")
+    }
+    return locale
+  }
+
+  static func isInstalled(languagePreference: String?) async -> Bool {
+    guard SpeechTranscriber.isAvailable else { return false }
+    guard let locale = try? await resolveLocale(languagePreference) else { return false }
+    let target = locale.identifier(.bcp47)
+    let installed = await SpeechTranscriber.installedLocales
+    return installed.contains { $0.identifier(.bcp47) == target }
+  }
+
+  static func ensureAssets(languagePreference: String?, progress: @escaping (Progress) -> Void) async throws {
+    guard SpeechTranscriber.isAvailable else { throw AppleSpeechError.engineUnavailable }
+    let locale = try await resolveLocale(languagePreference)
+    try await ensureAssets(for: makeTranscriber(locale: locale), locale: locale, progress: progress)
+  }
+
+  /// Installs assets for `locale` if missing and keeps it reserved. Safe to
+  /// call repeatedly; returns immediately when everything is installed.
+  private static func ensureAssets(
+    for transcriber: SpeechTranscriber,
+    locale: Locale,
+    progress: @escaping (Progress) -> Void
+  ) async throws {
+    let target = locale.identifier(.bcp47)
+    let installed = await SpeechTranscriber.installedLocales
+    if !installed.contains(where: { $0.identifier(.bcp47) == target }) {
+      if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+        logger.notice("Downloading Apple Speech assets for locale=\(target)")
+        let nativeProgress = request.progress
+        let pollTask = Task {
+          while !Task.isCancelled {
+            progress(nativeProgress)
+            try? await Task.sleep(nanoseconds: 250_000_000)
+          }
+        }
+        defer { pollTask.cancel() }
+        try await withTaskCancellationHandler {
+          try await request.downloadAndInstall()
+        } onCancel: {
+          // The user's Cancel button cancels our task; forward it to the OS download.
+          nativeProgress.cancel()
+        }
+        progress(nativeProgress)
+        logger.notice("Apple Speech assets installed for locale=\(target)")
+      }
+    }
+
+    // The system caps how many locales an app may keep reserved
+    // (AssetInventory.maximumReservedLocales). Hex only ever needs the active
+    // one, so release stale reservations before reserving — otherwise a few
+    // language switches could exhaust the quota. Reservation failure is
+    // non-fatal: already-installed assets keep working.
+    let reserved = await AssetInventory.reservedLocales
+    if !reserved.contains(where: { $0.identifier(.bcp47) == target }) {
+      for staleLocale in reserved {
+        await AssetInventory.release(reservedLocale: staleLocale)
+      }
+      do {
+        try await AssetInventory.reserve(locale: locale)
+      } catch {
+        logger.error("Could not reserve locale \(target): \(error.localizedDescription)")
+      }
+    }
+  }
+
+  static func transcribe(
+    url: URL,
+    languagePreference: String?,
+    progress: @escaping (Progress) -> Void
+  ) async throws -> String {
+    guard SpeechTranscriber.isAvailable else { throw AppleSpeechError.engineUnavailable }
+    let locale = try await resolveLocale(languagePreference)
+    let transcriber = makeTranscriber(locale: locale)
+    // Self-heal if assets are missing (e.g. evicted by the OS, or the user
+    // switched language and dictated before downloading the new pack).
+    try await ensureAssets(for: transcriber, locale: locale, progress: progress)
+
+    let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+    // Drain results concurrently so nothing is dropped while audio is fed in.
+    let resultsTask = Task<String, Error> {
+      var transcript = AttributedString("")
+      for try await result in transcriber.results {
+        transcript += result.text
+      }
+      return String(transcript.characters)
+    }
+    // Every failure path must run this so no analyzer outlives the request —
+    // including TCA effect cancellation (ESC), which surfaces as a thrown
+    // CancellationError at the next await.
+    func tearDown() async {
+      resultsTask.cancel()
+      await analyzer.cancelAndFinishNow()
+    }
+
+    let audioFile: AVAudioFile
+    do {
+      audioFile = try AVAudioFile(forReading: url)
+    } catch {
+      await tearDown()
+      throw error
+    }
+    let audioDuration = Double(audioFile.length) / max(audioFile.processingFormat.sampleRate, 1)
+
+    let t0 = Date()
+    logger.notice("Transcribing with Apple Speech locale=\(locale.identifier(.bcp47)) file=\(url.lastPathComponent)")
+    do {
+      guard let lastSampleTime = try await analyzer.analyzeSequence(from: audioFile) else {
+        await tearDown()
+        throw AppleSpeechError.noAudioSamples
+      }
+      try await analyzer.finalizeAndFinish(through: lastSampleTime)
+    } catch {
+      await tearDown()
+      throw error
+    }
+
+    do {
+      let text = try await awaiting(resultsTask, timeout: max(30, audioDuration + 30))
+      logger.info("Apple Speech transcription finished in \(String(format: "%.2f", Date().timeIntervalSince(t0)))s")
+      return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    } catch {
+      await tearDown()
+      throw error
+    }
+  }
+
+  /// Awaits `task` but gives up after `timeout` seconds. The cancellation
+  /// handler is load-bearing: cancelling a task-group child does not cancel
+  /// the unstructured task it is awaiting, so it must be cancelled explicitly
+  /// or the results stream could leak past the request.
+  private static func awaiting(_ task: Task<String, Error>, timeout: TimeInterval) async throws -> String {
+    try await withThrowingTaskGroup(of: String.self) { group in
+      group.addTask {
+        try await withTaskCancellationHandler {
+          try await task.value
+        } onCancel: {
+          task.cancel()
+        }
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+        throw AppleSpeechError.resultStreamTimedOut
+      }
+      guard let first = try await group.next() else {
+        throw AppleSpeechError.resultStreamTimedOut
+      }
+      group.cancelAll()
+      return first
+    }
+  }
+}
+
+enum AppleSpeechError: Error, LocalizedError {
+  case requiresMacOS26
+  case engineUnavailable
+  case unsupportedLanguage(String)
+  case noAudioSamples
+  case resultStreamTimedOut
+
+  var errorDescription: String? {
+    switch self {
+    case .requiresMacOS26:
+      return "Apple Speech requires macOS 26 or later. Choose a different model in Settings → Transcription Model."
+    case .engineUnavailable:
+      return "Apple Speech is not available on this Mac. Choose a different model in Settings → Transcription Model."
+    case let .unsupportedLanguage(code):
+      return "Apple Speech does not support the selected output language (\(code)). Pick another language or model in Settings."
+    case .noAudioSamples:
+      return "No audio reached the Apple Speech engine."
+    case .resultStreamTimedOut:
+      return "Apple Speech did not finish returning results. Please try again."
+    }
+  }
+}
+
+#else
+
+/// Stub for toolchains without the macOS 26 SDK (Xcode < 26). The engine
+/// reports itself unsupported, so the Apple Speech row never appears.
+actor AppleSpeechClient {
+  func isSupported() -> Bool { false }
+  func isModelInstalled(languagePreference: String?) async -> Bool { false }
+  func ensureModel(languagePreference: String?, progress: @escaping (Progress) -> Void) async throws {
+    throw NSError(
+      domain: "AppleSpeech",
+      code: -2,
+      userInfo: [NSLocalizedDescriptionKey: "Hex was built without SpeechAnalyzer support (requires Xcode 26)."]
+    )
+  }
+  func transcribe(url: URL, languagePreference: String?, progress: @escaping (Progress) -> Void) async throws -> String {
+    throw NSError(
+      domain: "AppleSpeech",
+      code: -3,
+      userInfo: [NSLocalizedDescriptionKey: "Apple Speech is not available in this build."]
+    )
+  }
+}
+
+#endif

--- a/Hex/Clients/TranscriptionClient.swift
+++ b/Hex/Clients/TranscriptionClient.swift
@@ -6,6 +6,7 @@
 //
 
 import AVFoundation
+import ComposableArchitecture
 import Dependencies
 import DependenciesMacros
 import Foundation
@@ -73,6 +74,12 @@ actor TranscriptionClientLive {
   /// The name of the currently loaded model, if any.
   private var currentModelName: String?
   private var parakeet: ParakeetClient = ParakeetClient()
+  private let appleSpeech = AppleSpeechClient()
+
+  /// Apple Speech resolves its locale from the user's Output Language setting;
+  /// reading settings directly is the established client pattern (see
+  /// RecordingClient, SoundEffect, PasteboardClient).
+  @Shared(.hexSettings) var hexSettings: HexSettings
 
   /// The base folder under which we store model data (e.g., ~/Library/Application Support/...).
   private lazy var modelsBaseFolder: URL = {
@@ -91,6 +98,12 @@ actor TranscriptionClientLive {
     // If Parakeet, use Parakeet client path
     if isParakeet(variant) {
       try await parakeet.ensureLoaded(modelName: variant, progress: progressCallback)
+      currentModelName = variant
+      return
+    }
+    // Apple Speech: "download" means installing OS-managed locale assets.
+    if isAppleSpeech(variant) {
+      try await appleSpeech.ensureModel(languagePreference: hexSettings.outputLanguage, progress: progressCallback)
       currentModelName = variant
       return
     }
@@ -145,6 +158,13 @@ actor TranscriptionClientLive {
       if currentModelName == variant { unloadCurrentModel() }
       return
     }
+    if isAppleSpeech(variant) {
+      // Apple Speech assets are managed by macOS (AssetInventory has no
+      // uninstall API); the UI hides Delete for this row, so this is
+      // defense in depth.
+      modelsLogger.info("Apple Speech assets are managed by macOS; nothing to delete")
+      return
+    }
     let modelFolder = modelPath(for: variant)
 
     // Check if the model exists
@@ -171,6 +191,11 @@ actor TranscriptionClientLive {
       let available = await parakeet.isModelAvailable(modelName)
       parakeetLogger.debug("Parakeet available? \(available)")
       return available
+    }
+    if isAppleSpeech(modelName) {
+      // "Downloaded" = assets for the locale resolved from the current
+      // Output Language setting are installed on-device.
+      return await appleSpeech.isModelInstalled(languagePreference: hexSettings.outputLanguage)
     }
     let modelFolderPath = modelPath(for: modelName).path
     let fileManager = FileManager.default
@@ -215,6 +240,12 @@ actor TranscriptionClientLive {
       if !names.contains(model.identifier) { names.insert(model.identifier, at: 0) }
     }
     #endif
+    // Offer Apple Speech only when the engine reports itself usable
+    // (macOS 26+, supported hardware, built with the macOS 26 SDK). The UI
+    // keys the row's visibility off this list.
+    if await appleSpeech.isSupported(), !names.contains(AppleSpeechModel.system.identifier) {
+      names.insert(AppleSpeechModel.system.identifier, at: 0)
+    }
     return names
   }
 
@@ -228,6 +259,15 @@ actor TranscriptionClientLive {
     progressCallback: @escaping (Progress) -> Void
   ) async throws -> String {
     let startAll = Date()
+    if isAppleSpeech(model) {
+      transcriptionLogger.notice("Transcribing with Apple Speech model=\(model) file=\(url.lastPathComponent)")
+      // Language rides in on the caller's DecodingOptions; assets are ensured
+      // inside the client, so no separate load step is needed.
+      let text = try await appleSpeech.transcribe(url: url, languagePreference: options.language, progress: progressCallback)
+      currentModelName = model
+      transcriptionLogger.info("Apple Speech request total elapsed \(String(format: "%.2f", Date().timeIntervalSince(startAll)))s")
+      return text
+    }
     if isParakeet(model) {
       transcriptionLogger.notice("Transcribing with Parakeet model=\(model) file=\(url.lastPathComponent)")
       let startLoad = Date()
@@ -299,6 +339,10 @@ actor TranscriptionClientLive {
 
   private func isParakeet(_ name: String) -> Bool {
     ParakeetModel(rawValue: name) != nil
+  }
+
+  private func isAppleSpeech(_ name: String) -> Bool {
+    AppleSpeechModel(rawValue: name) != nil
   }
 
   /// Creates or returns the local folder (on disk) for a given `variant` model.

--- a/Hex/Clients/TranscriptionClient.swift
+++ b/Hex/Clients/TranscriptionClient.swift
@@ -101,7 +101,7 @@ actor TranscriptionClientLive {
       currentModelName = variant
       return
     }
-    // Apple Speech: "download" means installing OS-managed locale assets.
+    // Apple Speech: "download" means installing OS-managed locale assets (#255).
     if isAppleSpeech(variant) {
       try await appleSpeech.ensureModel(languagePreference: hexSettings.outputLanguage, progress: progressCallback)
       currentModelName = variant

--- a/Hex/Features/Settings/ModelDownload/ModelDownloadFeature.swift
+++ b/Hex/Features/Settings/ModelDownload/ModelDownloadFeature.swift
@@ -55,6 +55,16 @@ public struct CuratedModelInfo: Equatable, Identifiable, Codable {
 		parakeetModel != nil
 	}
 
+	var isAppleSpeech: Bool {
+		AppleSpeechModel(rawValue: internalName) != nil
+	}
+
+	/// Apple Speech assets are OS-managed: there is no Finder location to show
+	/// and AssetInventory offers no uninstall API, so the UI hides both.
+	var supportsLocalFileManagement: Bool {
+		!isAppleSpeech
+	}
+
 	public init(
 		displayName: String,
 		internalName: String,
@@ -88,7 +98,8 @@ public struct CuratedModelInfo: Equatable, Identifiable, Codable {
 }
 
 // Convenience helper for loading the bundled models.json once.
-private enum CuratedModelLoader {
+// (Internal rather than private so tests can exercise the platform filter.)
+enum CuratedModelLoader {
 	private static let bundledModels: [CuratedModelInfo] = {
 		guard let url = Bundle.main.url(forResource: "models", withExtension: "json") ??
 			Bundle.main.url(forResource: "models", withExtension: "json", subdirectory: "Data")
@@ -100,8 +111,21 @@ private enum CuratedModelLoader {
 		catch { assertionFailure("Failed to decode models.json - \(error)"); return [] }
 	}()
 
+	/// Drops curated rows whose engine cannot exist on this OS: Apple Speech
+	/// requires macOS 26+, so on older systems the row never appears (not even
+	/// for a frame — this runs at State init).
+	static func filterForPlatform(_ models: [CuratedModelInfo], osSupportsAppleSpeech: Bool) -> [CuratedModelInfo] {
+		osSupportsAppleSpeech ? models : models.filter { !$0.isAppleSpeech }
+	}
+
 	static func load() -> [CuratedModelInfo] {
-		bundledModels
+		let osSupportsAppleSpeech: Bool
+		if #available(macOS 26.0, *) {
+			osSupportsAppleSpeech = true
+		} else {
+			osSupportsAppleSpeech = false
+		}
+		return filterForPlatform(bundledModels, osSupportsAppleSpeech: osSupportsAppleSpeech)
 	}
 }
 
@@ -326,13 +350,28 @@ public struct ModelDownloadFeature {
 					curated[idx].isDownloaded = false
 				}
 			}
+			// Apple Speech is only offered when the engine reported itself usable
+			// (macOS 26+ on capable hardware, built with the macOS 26 SDK) — its
+			// identifier's presence in the available list is that signal.
+			curated.removeAll { model in
+				model.isAppleSpeech && !available.contains(where: { $0.name == AppleSpeechModel.system.identifier })
+			}
 			state.curatedModels = IdentifiedArrayOf(uniqueElements: curated)
 			// If the selection isn't installed but another model is, switch to the
 			// installed one so transcription keeps working. Never clear the user's
 			// selection outright: availability scans can produce false negatives
 			// (e.g. after a dependency changes its cache layout), and wiping the
 			// setting turns a transient glitch into a permanent silent failure.
+			//
+			// Apple Speech exception: when its row is present, "not downloaded"
+			// only means the current language's locale pack is missing — the user
+			// should see the Download prompt, not have their engine silently
+			// switched. When the row is absent (OS downgrade, unsupported
+			// hardware), the normal healing below still applies.
+			let appleSpeechSelectionPresent = AppleSpeechModel(rawValue: state.selectedModel) != nil
+				&& state.curatedModels.contains(where: \.isAppleSpeech)
 			if !state.selectedModelIsDownloaded,
+			   !appleSpeechSelectionPresent,
 			   let installedModel = state.curatedModels.first(where: \.isDownloaded)
 			{
 				let fallback = resolvePattern(installedModel.internalName, from: Array(state.availableModels)) ?? installedModel.internalName

--- a/Hex/Features/Settings/ModelDownload/ModelDownloadView.swift
+++ b/Hex/Features/Settings/ModelDownload/ModelDownloadView.swift
@@ -535,9 +535,11 @@ private struct ModelLibraryRow: View {
 		.contextMenu {
 			if isDownloading {
 				Button("Cancel Download", role: .destructive, action: onCancelDownload)
-				Button("Show in Finder", action: onShowInFinder)
+				if model.supportsLocalFileManagement {
+					Button("Show in Finder", action: onShowInFinder)
+				}
 			}
-			if model.isDownloaded {
+			if model.isDownloaded, model.supportsLocalFileManagement {
 				managementMenuItems
 			}
 		}
@@ -566,21 +568,29 @@ private struct ModelLibraryRow: View {
 					.controlSize(.small)
 			}
 		} else if model.isDownloaded {
-			Menu {
-				managementMenuItems
-			} label: {
-				Image(systemName: "ellipsis.circle")
-					.font(.body)
-					.foregroundStyle(.secondary)
+			// Apple Speech assets have no Finder location and no uninstall API,
+			// so there is nothing to manage — the "Installed" status says it all.
+			if model.supportsLocalFileManagement {
+				Menu {
+					managementMenuItems
+				} label: {
+					Image(systemName: "ellipsis.circle")
+						.font(.body)
+						.foregroundStyle(.secondary)
+				}
+				.menuStyle(.borderlessButton)
+				.menuIndicator(.hidden)
+				.fixedSize()
+				.help("Show in Finder or remove this download")
 			}
-			.menuStyle(.borderlessButton)
-			.menuIndicator(.hidden)
-			.fixedSize()
-			.help("Show in Finder or remove this download")
 		} else {
 			Button("Download", action: onDownload)
 				.controlSize(.small)
-				.help("Download \(model.storageSize) and switch to this model")
+				.help(
+					model.supportsLocalFileManagement
+						? "Download \(model.storageSize) and switch to this model"
+						: "Download speech assets for your language and switch to this model"
+				)
 		}
 	}
 

--- a/Hex/Features/Settings/SettingsFeature.swift
+++ b/Hex/Features/Settings/SettingsFeature.swift
@@ -488,7 +488,9 @@ struct SettingsFeature {
 
       case let .setOutputLanguage(language):
         state.$hexSettings.withLock { $0.outputLanguage = language }
-        return .none
+        // Apple Speech's installed-state is per-locale (OS-managed asset
+        // packs), so refresh the model list to reflect the new language.
+        return .send(.modelDownload(.fetchModels))
 
       case let .setSelectedMicrophoneID(deviceID):
         state.$hexSettings.withLock { $0.selectedMicrophoneID = deviceID }

--- a/Hex/Resources/Data/models.json
+++ b/Hex/Resources/Data/models.json
@@ -46,5 +46,13 @@
     "accuracyStars": 5,
     "speedStars": 2,
     "storageSize": "1.5GB"
+  },
+  {
+    "displayName": "Apple Speech",
+    "internalName": "apple-speechanalyzer",
+    "size": "Multilingual",
+    "accuracyStars": 4,
+    "speedStars": 5,
+    "storageSize": "Managed by macOS"
   }
 ]

--- a/HexCore/Sources/HexCore/Logging.swift
+++ b/HexCore/Sources/HexCore/Logging.swift
@@ -16,6 +16,7 @@ public enum HexLog {
     case hotKey = "HotKey"
     case keyEvent = "KeyEvent"
     case parakeet = "Parakeet"
+    case appleSpeech = "AppleSpeech"
     case history = "History"
     case settings = "Settings"
     case permissions = "Permissions"
@@ -36,6 +37,7 @@ public enum HexLog {
   public static let hotKey = logger(.hotKey)
   public static let keyEvent = logger(.keyEvent)
   public static let parakeet = logger(.parakeet)
+  public static let appleSpeech = logger(.appleSpeech)
   public static let history = logger(.history)
   public static let settings = logger(.settings)
   public static let permissions = logger(.permissions)

--- a/HexCore/Sources/HexCore/Logic/SpeechLocaleResolution.swift
+++ b/HexCore/Sources/HexCore/Logic/SpeechLocaleResolution.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Maps Hex's `outputLanguage` setting (bare ISO codes from languages.json,
+/// e.g. "en", "zh"; nil = Auto) onto one of the locales supported by Apple's
+/// SpeechTranscriber.
+///
+/// Pure logic: callers pass in the supported-locale list, so this compiles and
+/// unit-tests on macOS 14 even though the Speech APIs that produce that list
+/// require macOS 26.
+public enum SpeechLocaleResolution {
+	/// Resolves a language preference against the supported locales.
+	///
+	/// - `nil`, empty, or "auto" preference: best match for the user's current
+	///   locale, falling back to English, then the first supported locale.
+	/// - Explicit code (e.g. "en"): exact BCP-47 match, else any supported
+	///   locale sharing the language code (preferring the user's region, so
+	///   "en" resolves to "en-US" on a US Mac rather than whatever sorts
+	///   first).
+	/// - Returns nil when the engine cannot serve the preference; callers
+	///   should surface a clear error rather than silently transcribing in the
+	///   wrong language.
+	public static func resolve(
+		preference: String?,
+		supported: [Locale],
+		current: Locale = .current
+	) -> Locale? {
+		guard !supported.isEmpty else { return nil }
+		let trimmed = (preference ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+		if trimmed.isEmpty || trimmed.lowercased() == "auto" {
+			return bestMatch(for: current, in: supported, current: current)
+				?? preferredEnglish(in: supported)
+				?? supported.first
+		}
+		return bestMatch(for: Locale(identifier: trimmed), in: supported, current: current)
+	}
+
+	static func bestMatch(for locale: Locale, in supported: [Locale], current: Locale) -> Locale? {
+		let target = locale.identifier(.bcp47)
+		if let exact = supported.first(where: { $0.identifier(.bcp47) == target }) {
+			return exact
+		}
+		guard let language = locale.language.languageCode?.identifier, !language.isEmpty else {
+			return nil
+		}
+		let candidates = supported.filter { $0.language.languageCode?.identifier == language }
+		if let region = current.region?.identifier,
+		   let regional = candidates.first(where: { $0.region?.identifier == region })
+		{
+			return regional
+		}
+		return candidates.first
+	}
+
+	private static func preferredEnglish(in supported: [Locale]) -> Locale? {
+		supported.first { $0.identifier(.bcp47) == "en-US" }
+			?? supported.first { $0.language.languageCode?.identifier == "en" }
+	}
+}

--- a/HexCore/Sources/HexCore/Models/AppleSpeechModel.swift
+++ b/HexCore/Sources/HexCore/Models/AppleSpeechModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Apple's on-device SpeechAnalyzer engine (macOS 26+), exposed as a single
+/// selectable "model" in the library. Per-locale assets are managed by the OS
+/// via AssetInventory and follow the user's Output Language setting, so the
+/// engine is one entry from the user's perspective — there are no variants to
+/// choose between. (#255)
+public enum AppleSpeechModel: String, CaseIterable, Sendable {
+	case system = "apple-speechanalyzer"
+
+	/// The identifier used throughout the app (stored in `selectedModel`).
+	public var identifier: String { rawValue }
+}

--- a/HexCore/Tests/HexCoreTests/SpeechLocaleResolutionTests.swift
+++ b/HexCore/Tests/HexCoreTests/SpeechLocaleResolutionTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import HexCore
+
+struct SpeechLocaleResolutionTests {
+	/// A realistic slice of SpeechTranscriber.supportedLocales.
+	private let supported = [
+		Locale(identifier: "en-US"),
+		Locale(identifier: "en-GB"),
+		Locale(identifier: "fr-FR"),
+		Locale(identifier: "de-DE"),
+		Locale(identifier: "es-ES"),
+		Locale(identifier: "pt-BR"),
+	]
+
+	@Test
+	func exactBCP47MatchWins() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "en-GB",
+			supported: supported,
+			current: Locale(identifier: "en-US")
+		)
+		#expect(result?.identifier(.bcp47) == "en-GB")
+	}
+
+	@Test
+	func bareLanguageCodePrefersCurrentRegion() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "en",
+			supported: supported,
+			current: Locale(identifier: "en-GB")
+		)
+		#expect(result?.identifier(.bcp47) == "en-GB")
+	}
+
+	@Test
+	func bareLanguageCodeFallsBackToFirstCandidateWhenRegionUnavailable() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "en",
+			supported: supported,
+			current: Locale(identifier: "fr-FR")
+		)
+		#expect(result?.identifier(.bcp47) == "en-US")
+	}
+
+	@Test
+	func nilPreferenceResolvesFromCurrentLocale() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: nil,
+			supported: supported,
+			current: Locale(identifier: "de-DE")
+		)
+		#expect(result?.identifier(.bcp47) == "de-DE")
+	}
+
+	@Test
+	func autoPreferenceBehavesLikeNil() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "auto",
+			supported: supported,
+			current: Locale(identifier: "fr-FR")
+		)
+		#expect(result?.identifier(.bcp47) == "fr-FR")
+	}
+
+	@Test
+	func unsupportedCurrentLocaleFallsBackToEnglish() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: nil,
+			supported: supported,
+			current: Locale(identifier: "am-ET")
+		)
+		#expect(result?.identifier(.bcp47) == "en-US")
+	}
+
+	@Test
+	func autoWithoutEnglishFallsBackToFirstSupported() {
+		let noEnglish = [Locale(identifier: "fr-FR"), Locale(identifier: "de-DE")]
+		let result = SpeechLocaleResolution.resolve(
+			preference: nil,
+			supported: noEnglish,
+			current: Locale(identifier: "am-ET")
+		)
+		#expect(result?.identifier(.bcp47) == "fr-FR")
+	}
+
+	@Test
+	func unsupportedExplicitLanguageReturnsNil() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "am",
+			supported: supported,
+			current: Locale(identifier: "en-US")
+		)
+		#expect(result == nil)
+	}
+
+	@Test
+	func emptySupportedListReturnsNil() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "en",
+			supported: [],
+			current: Locale(identifier: "en-US")
+		)
+		#expect(result == nil)
+	}
+
+	@Test
+	func whitespacePreferenceBehavesLikeAuto() {
+		let result = SpeechLocaleResolution.resolve(
+			preference: "  ",
+			supported: supported,
+			current: Locale(identifier: "es-ES")
+		)
+		#expect(result?.identifier(.bcp47) == "es-ES")
+	}
+}

--- a/HexTests/ModelDownloadFeatureTests.swift
+++ b/HexTests/ModelDownloadFeatureTests.swift
@@ -120,6 +120,128 @@ final class ModelDownloadFeatureTests: XCTestCase {
     await store.skipInFlightEffects()
   }
 
+  // MARK: – Apple Speech (SpeechAnalyzer) row
+
+  func testFilterForPlatformDropsAppleSpeechOnOlderOS() {
+    let models = [makeAppleSpeechCuratedInfo(), makeParakeetCuratedInfo()]
+
+    let filtered = CuratedModelLoader.filterForPlatform(models, osSupportsAppleSpeech: false)
+    XCTAssertFalse(filtered.contains(where: \.isAppleSpeech))
+    XCTAssertTrue(filtered.contains(where: \.isParakeet))
+
+    let kept = CuratedModelLoader.filterForPlatform(models, osSupportsAppleSpeech: true)
+    XCTAssertTrue(kept.contains(where: \.isAppleSpeech))
+  }
+
+  func testModelsLoadedDropsAppleRowWhenEngineUnsupported() async {
+    // The engine advertises itself by injecting its identifier into the
+    // available list; when absent (old hardware, Xcode 16 build), the curated
+    // row must disappear.
+    let state = makeState(selectedModel: ParakeetModel.multilingualV3.identifier)
+
+    let store = TestStore(initialState: state) {
+      ModelDownloadFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.modelsLoaded(
+      recommended: "",
+      available: [ModelInfo(name: ParakeetModel.multilingualV3.identifier, isDownloaded: true)]
+    ))
+
+    XCTAssertFalse(store.state.curatedModels.contains(where: \.isAppleSpeech))
+  }
+
+  func testModelsLoadedKeepsAppleRowAndMergesInstalledState() async throws {
+    // Requires the bundled apple row, which CuratedModelLoader filters out on
+    // hosts older than macOS 26.
+    guard #available(macOS 26.0, *) else {
+      throw XCTSkip("Apple Speech curated row only exists on macOS 26+")
+    }
+    let state = makeState(selectedModel: ParakeetModel.multilingualV3.identifier)
+
+    let store = TestStore(initialState: state) {
+      ModelDownloadFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.modelsLoaded(
+      recommended: "",
+      available: [ModelInfo(name: AppleSpeechModel.system.identifier, isDownloaded: true)]
+    ))
+
+    let appleRow = store.state.curatedModels.first(where: \.isAppleSpeech)
+    XCTAssertNotNil(appleRow)
+    XCTAssertTrue(appleRow?.isDownloaded == true)
+  }
+
+  func testAppleSelectionSurvivesMissingLocaleAssets() async throws {
+    // When Apple Speech is selected and its row is present, "not downloaded"
+    // only means the current language's locale pack is missing — the engine
+    // selection must not silently switch to another installed model.
+    guard #available(macOS 26.0, *) else {
+      throw XCTSkip("Apple Speech curated row only exists on macOS 26+")
+    }
+    let state = makeState(selectedModel: AppleSpeechModel.system.identifier)
+
+    let store = TestStore(initialState: state) {
+      ModelDownloadFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.modelsLoaded(
+      recommended: "",
+      available: [
+        ModelInfo(name: AppleSpeechModel.system.identifier, isDownloaded: false),
+        ModelInfo(name: ParakeetModel.multilingualV3.identifier, isDownloaded: true),
+      ]
+    ))
+
+    XCTAssertEqual(store.state.hexSettings.selectedModel, AppleSpeechModel.system.identifier)
+  }
+
+  func testAppleSelectionAutoSwitchesWhenEngineAbsent() async {
+    // OS downgrade / unsupported hardware: the persisted apple selection heals
+    // to an installed local model via the existing fallback logic.
+    let state = makeState(selectedModel: AppleSpeechModel.system.identifier)
+
+    let store = TestStore(initialState: state) {
+      ModelDownloadFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.modelsLoaded(
+      recommended: "",
+      available: [ModelInfo(name: ParakeetModel.multilingualV3.identifier, isDownloaded: true)]
+    ))
+
+    XCTAssertEqual(store.state.hexSettings.selectedModel, ParakeetModel.multilingualV3.identifier)
+  }
+
+  private func makeAppleSpeechCuratedInfo(isDownloaded: Bool = false) -> CuratedModelInfo {
+    CuratedModelInfo(
+      displayName: "Apple Speech",
+      internalName: AppleSpeechModel.system.identifier,
+      size: "Multilingual",
+      accuracyStars: 4,
+      speedStars: 5,
+      storageSize: "Managed by macOS",
+      isDownloaded: isDownloaded
+    )
+  }
+
+  private func makeParakeetCuratedInfo() -> CuratedModelInfo {
+    CuratedModelInfo(
+      displayName: "Parakeet TDT v3",
+      internalName: ParakeetModel.multilingualV3.identifier,
+      size: "Multilingual",
+      accuracyStars: 5,
+      speedStars: 5,
+      storageSize: "650MB",
+      isDownloaded: false
+    )
+  }
+
   private func makeState(selectedModel: String) -> ModelDownloadFeature.State {
     var settings = HexSettings()
     settings.selectedModel = selectedModel


### PR DESCRIPTION
Closes #255

Adds Apple's on-device `SpeechAnalyzer`/`SpeechTranscriber` engine as a selectable "Apple Speech" entry in the model library, alongside WhisperKit and Parakeet. Batch-only: it transcribes the recorded file after the hotkey is released, exactly like the existing engines.

## How it fits the existing architecture

Routing follows the Parakeet pattern precisely: a new `AppleSpeechModel` enum (`"apple-speechanalyzer"`) acts as the routing identifier, and `TranscriptionClientLive` gains an `isAppleSpeech` branch parallel to `isParakeet` in each method. The engine lives in a new `AppleSpeechClient` actor mirroring `ParakeetClient`'s structure, including the compile-time fallback stub — here keyed on `#if compiler(>=6.2)` (the toolchain that ships the macOS 26 SDK) instead of `canImport(FluidAudio)`.

## Design decisions (and why)

- **One row, not per-locale rows.** SpeechAnalyzer is one engine with OS-managed per-locale asset packs, and the existing Output Language setting already expresses "which language". "Installed" for this row means "assets for the currently selected language are on-device"; switching to a language without assets flips the row to not-downloaded and the normal Download button installs the new locale pack — with the OS's native download `Progress`, and Cancel wired through.
- **Deployment target stays macOS 14.** Two gates: `CuratedModelLoader` filters the row out below macOS 26 at `State` init, and `.modelsLoaded` drops it unless the engine advertised its identifier via `getAvailableModels` (macOS 26 + `SpeechTranscriber.isAvailable` hardware check + macOS 26 SDK build). The `AppleSpeechClient` actor is deliberately stateless so the non-`@available` `TranscriptionClientLive` can store it; all SDK calls live in a private `@available(macOS 26.0, *)` enum.
- **Auto-switch exemption.** The `.modelsLoaded` fallback that switches away from not-downloaded selections gets a narrow exception: when Apple Speech is selected and its row is present, a missing locale pack prompts a download instead of silently switching engines. When the row is absent (OS downgrade, unsupported hardware), the existing healing to an installed local model still applies.
- **Show in Finder / Remove Download are hidden for this row.** Assets live in OS-private storage and `AssetInventory` has no uninstall API — offering either would mislead. `deleteModel` is a defensive no-op.
- **Recommended default unchanged** (Parakeet). Promoting Apple Speech is a separate discussion.
- **Locale resolution is pure logic in HexCore** (`SpeechLocaleResolution`): exact BCP-47 match, else same-language preferring the user's region ("en" → "en-US" on a US Mac); Auto falls back through the current locale → English → first supported. Unsupported languages throw an actionable error rather than silently transcribing in the wrong language. Being OS-independent, it unit-tests on macOS 14.
- **Reservation quota:** stale locale reservations are released before reserving the active one (the system caps per-app reservations); reservation failure is non-fatal since installed assets keep working.

## Toolchain note for releases

The engine only exists in binaries built with Xcode 26. A build from Xcode 16 compiles the stub and the row simply never appears — graceful, but worth knowing that the release toolchain gates the feature.

## Tests

- 10 new HexCore tests for the locale resolver (`cd HexCore && swift test`, runs on any macOS).
- 5 new `ModelDownloadFeatureTests` covering the OS filter, the engine-advertisement gating, installed-state merging, the auto-switch exemption, and OS-downgrade healing. Two skip via `XCTSkip` on hosts below macOS 26 (they need the bundled curated row).
- Full suite green (`xcodebuild test`), Release build compiles.

## Manual verification (macOS 26, Apple Silicon)

- Selected Apple Speech in the model library; row renders with dots and "Managed by macOS", no Finder/Delete menu items.
- Repeated hotkey dictations transcribe and paste correctly; Console shows `AppleSpeech` category logs with transcript text and file names correctly marked private.
- Locale assets already installed system-wide were detected immediately (no download needed for English).
- Permissions: microphone only — no speech-recognition TCC prompt, no new entitlements.

Possible follow-up (intentionally out of scope): streaming transcription while recording via `SpeechAnalyzer`'s volatile results, which would pair naturally with the live-preview work in #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apple’s on-device SpeechAnalyzer (Apple Speech) as a selectable transcription engine on supported macOS 26+ systems.
  * Added per-language Apple Speech locale assets and installation handling.
  * Added Apple Speech to the model library with download/install state support.
* **Improvements**
  * Refresh model availability when changing output language.
  * Updated Apple Speech UI so local file management options are hidden when not supported.
  * Enhanced Apple Speech transcription reliability with safer cancellation and result handling.
* **Tests**
  * Added coverage for Apple Speech availability/selection and locale resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->