### PR TITLE
Show which model transcribed each entry in History

### DIFF
--- a/.changeset/38869c4f.md
+++ b/.changeset/38869c4f.md
@@ -2,4 +2,4 @@
 "hex-app": minor
 ---
 
-Show which model transcribed each entry in History
+Show which model transcribed each entry in History (#270)

--- a/.changeset/38869c4f.md
+++ b/.changeset/38869c4f.md
@@ -1,0 +1,5 @@
+---
+"hex-app": minor
+---
+
+Show which model transcribed each entry in History

--- a/Hex/Features/History/HistoryFeature.swift
+++ b/Hex/Features/History/HistoryFeature.swift
@@ -255,6 +255,14 @@ struct TranscriptView: View {
 					Text(transcript.timestamp.formatted(date: .omitted, time: .shortened))
 					Text("•")
 					Text(String(format: "%.1fs", transcript.duration))
+					// Which model produced this transcript (absent on entries
+					// saved before model attribution existed).
+					if let modelIdentifier = transcript.modelIdentifier {
+						Text("•")
+						Text(CuratedModelLoader.displayName(for: modelIdentifier))
+							.lineLimit(1)
+							.truncationMode(.tail)
+					}
 				}
 				.font(.subheadline)
 				.foregroundStyle(.secondary)
@@ -333,7 +341,7 @@ struct TranscriptView: View {
 
 #Preview {
 	TranscriptView(
-		transcript: Transcript(timestamp: Date(), text: "Hello, world!", audioPath: URL(fileURLWithPath: "/Users/langton/Downloads/test.m4a"), duration: 1.0),
+		transcript: Transcript(timestamp: Date(), text: "Hello, world!", audioPath: URL(fileURLWithPath: "/Users/langton/Downloads/test.m4a"), duration: 1.0, modelIdentifier: "parakeet-tdt-0.6b-v3-coreml"),
 		isPlaying: false,
 		onPlay: {},
 		onCopy: {},

--- a/Hex/Features/Settings/ModelDownload/ModelDownloadFeature.swift
+++ b/Hex/Features/Settings/ModelDownload/ModelDownloadFeature.swift
@@ -88,7 +88,9 @@ public struct CuratedModelInfo: Equatable, Identifiable, Codable {
 }
 
 // Convenience helper for loading the bundled models.json once.
-private enum CuratedModelLoader {
+// (Internal rather than private so the History view can resolve model
+// display names for transcript attribution.)
+enum CuratedModelLoader {
 	private static let bundledModels: [CuratedModelInfo] = {
 		guard let url = Bundle.main.url(forResource: "models", withExtension: "json") ??
 			Bundle.main.url(forResource: "models", withExtension: "json", subdirectory: "Data")
@@ -102,6 +104,20 @@ private enum CuratedModelLoader {
 
 	static func load() -> [CuratedModelInfo] {
 		bundledModels
+	}
+
+	/// Friendly label for a raw model identifier (e.g. history attribution).
+	/// Resolves against the unfiltered bundled list so transcripts keep their
+	/// label even when the model is no longer offered on this system, and
+	/// prettifies unknown identifiers instead of failing.
+	static func displayName(for identifier: String) -> String {
+		if let match = bundledModels.first(where: { ModelPatternMatcher.matches($0.internalName, identifier) }) {
+			return match.displayName
+		}
+		return identifier
+			.replacingOccurrences(of: "-", with: " ")
+			.replacingOccurrences(of: "_", with: " ")
+			.capitalized
 	}
 }
 
@@ -213,10 +229,7 @@ public struct ModelDownloadFeature {
 		if let match = curated.first(where: { ModelPatternMatcher.matches($0.internalName, model) }) {
 			return match.displayName
 		}
-		return model
-			.replacingOccurrences(of: "-", with: " ")
-			.replacingOccurrences(of: "_", with: " ")
-			.capitalized
+		return CuratedModelLoader.displayName(for: model)
 	}
 
 	private func updateBootstrapState(_ state: inout State) {

--- a/Hex/Features/Transcription/TranscriptionFeature.swift
+++ b/Hex/Features/Transcription/TranscriptionFeature.swift
@@ -50,7 +50,7 @@ struct TranscriptionFeature {
     case discard  // Silent discard (too short/accidental)
 
     // Transcription result flow
-    case transcriptionResult(String, URL, TimeInterval)
+    case transcriptionResult(String, URL, TimeInterval, String?)
     case transcriptionError(Error, URL?)
 
     // Model availability
@@ -117,8 +117,8 @@ struct TranscriptionFeature {
 
       // MARK: - Transcription Results
 
-      case let .transcriptionResult(result, audioURL, duration):
-        return handleTranscriptionResult(&state, result: result, audioURL: audioURL, duration: duration)
+      case let .transcriptionResult(result, audioURL, duration, modelIdentifier):
+        return handleTranscriptionResult(&state, result: result, audioURL: audioURL, duration: duration, modelIdentifier: modelIdentifier)
 
       case let .transcriptionError(error, audioURL):
         return handleTranscriptionError(&state, error: error, audioURL: audioURL)
@@ -414,7 +414,9 @@ private extension TranscriptionFeature {
 
           transcriptionFeatureLogger.notice("Transcribed audio from \(capturedURL.lastPathComponent) to text length \(result.count)")
           audioURL = nil
-          await send(.transcriptionResult(result, capturedURL, duration))
+          // Attribute the transcript to the model actually used for this run
+          // (the selection could change in Settings while transcription runs).
+          await send(.transcriptionResult(result, capturedURL, duration, model))
         } catch {
           transcriptionFeatureLogger.error("Transcription failed: \(error.localizedDescription)")
           await send(.transcriptionError(error, nil))
@@ -432,7 +434,8 @@ private extension TranscriptionFeature {
     _ state: inout State,
     result: String,
     audioURL: URL,
-    duration: TimeInterval
+    duration: TimeInterval,
+    modelIdentifier: String?
   ) -> Effect<Action> {
     state.isTranscribing = false
     state.isPrewarming = false
@@ -505,6 +508,7 @@ private extension TranscriptionFeature {
           duration: duration,
           sourceAppBundleID: sourceAppBundleID,
           sourceAppName: sourceAppName,
+          modelIdentifier: modelIdentifier,
           audioURL: audioURL,
           transcriptionHistory: transcriptionHistory
         )
@@ -537,6 +541,7 @@ private extension TranscriptionFeature {
     duration: TimeInterval,
     sourceAppBundleID: String?,
     sourceAppName: String?,
+    modelIdentifier: String?,
     audioURL: URL,
     transcriptionHistory: Shared<TranscriptionHistory>
   ) async throws {
@@ -548,7 +553,8 @@ private extension TranscriptionFeature {
         audioURL,
         duration,
         sourceAppBundleID,
-        sourceAppName
+        sourceAppName,
+        modelIdentifier
       )
 
       transcriptionHistory.withLock { history in

--- a/HexCore/Sources/HexCore/Models/TranscriptionHistory.swift
+++ b/HexCore/Sources/HexCore/Models/TranscriptionHistory.swift
@@ -8,7 +8,11 @@ public struct Transcript: Codable, Equatable, Identifiable, Sendable {
     public var duration: TimeInterval
     public var sourceAppBundleID: String?
     public var sourceAppName: String?
-    
+    /// Raw identifier of the model that produced this transcript (e.g.
+    /// "parakeet-tdt-0.6b-v3-coreml"). Optional so history saved by older
+    /// versions keeps decoding (same pattern as sourceAppBundleID).
+    public var modelIdentifier: String?
+
     public init(
         id: UUID = UUID(),
         timestamp: Date,
@@ -16,7 +20,8 @@ public struct Transcript: Codable, Equatable, Identifiable, Sendable {
         audioPath: URL,
         duration: TimeInterval,
         sourceAppBundleID: String? = nil,
-        sourceAppName: String? = nil
+        sourceAppName: String? = nil,
+        modelIdentifier: String? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -25,6 +30,7 @@ public struct Transcript: Codable, Equatable, Identifiable, Sendable {
         self.duration = duration
         self.sourceAppBundleID = sourceAppBundleID
         self.sourceAppName = sourceAppName
+        self.modelIdentifier = modelIdentifier
     }
 }
 

--- a/HexCore/Sources/HexCore/TranscriptPersistenceClient/TranscriptPersistenceClient.swift
+++ b/HexCore/Sources/HexCore/TranscriptPersistenceClient/TranscriptPersistenceClient.swift
@@ -7,7 +7,8 @@ public struct TranscriptPersistenceClient: Sendable {
         _ audioURL: URL,
         _ duration: TimeInterval,
         _ sourceAppBundleID: String?,
-        _ sourceAppName: String?
+        _ sourceAppName: String?,
+        _ modelIdentifier: String?
     ) async throws -> Transcript
     
     public var deleteAudio: @Sendable (_ transcript: Transcript) async throws -> Void
@@ -16,22 +17,23 @@ public struct TranscriptPersistenceClient: Sendable {
 extension TranscriptPersistenceClient: DependencyKey {
     public static let liveValue: TranscriptPersistenceClient = {
         return TranscriptPersistenceClient(
-            save: { result, audioURL, duration, sourceAppBundleID, sourceAppName in
+            save: { result, audioURL, duration, sourceAppBundleID, sourceAppName, modelIdentifier in
                 let fm = FileManager.default
                 let recordingsFolder = try URL.hexApplicationSupport.appendingPathComponent("Recordings", isDirectory: true)
                 try fm.createDirectory(at: recordingsFolder, withIntermediateDirectories: true)
-                
+
                 let filename = "\(Date().timeIntervalSince1970).wav"
                 let finalURL = recordingsFolder.appendingPathComponent(filename)
                 try fm.moveItem(at: audioURL, to: finalURL)
-                
+
                 return Transcript(
                     timestamp: Date(),
                     text: result,
                     audioPath: finalURL,
                     duration: duration,
                     sourceAppBundleID: sourceAppBundleID,
-                    sourceAppName: sourceAppName
+                    sourceAppName: sourceAppName,
+                    modelIdentifier: modelIdentifier
                 )
             },
             deleteAudio: { transcript in
@@ -41,7 +43,7 @@ extension TranscriptPersistenceClient: DependencyKey {
     }()
     
     public static let testValue = TranscriptPersistenceClient(
-        save: { _, _, _, _, _ in
+        save: { _, _, _, _, _, _ in
             Transcript(timestamp: Date(), text: "", audioPath: URL(fileURLWithPath: "/"), duration: 0)
         },
         deleteAudio: { _ in }

--- a/HexCore/Tests/HexCoreTests/TranscriptionHistoryDecodingTests.swift
+++ b/HexCore/Tests/HexCoreTests/TranscriptionHistoryDecodingTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import HexCore
+
+/// Transcript uses synthesized Codable, so persisted history written by older
+/// app versions must keep decoding as fields are added. These tests pin that
+/// contract the same way HexSettingsMigrationTests does for settings.
+struct TranscriptionHistoryDecodingTests {
+	/// A history entry exactly as written before modelIdentifier existed.
+	private let legacyJSON = Data(
+		"""
+		{
+			"history": [
+				{
+					"id": "6F1E5A31-98D2-4D30-92F8-4E1B4C43B1AA",
+					"timestamp": 730000000,
+					"text": "hello world",
+					"audioPath": "file:///tmp/recording.wav",
+					"duration": 2.5,
+					"sourceAppBundleID": "com.apple.Notes",
+					"sourceAppName": "Notes"
+				}
+			]
+		}
+		""".utf8
+	)
+
+	@Test
+	func legacyHistoryWithoutModelIdentifierDecodes() throws {
+		let history = try JSONDecoder().decode(TranscriptionHistory.self, from: legacyJSON)
+
+		#expect(history.history.count == 1)
+		let transcript = try #require(history.history.first)
+		#expect(transcript.text == "hello world")
+		#expect(transcript.modelIdentifier == nil)
+	}
+
+	@Test
+	func modelIdentifierRoundTrips() throws {
+		let original = Transcript(
+			timestamp: Date(timeIntervalSinceReferenceDate: 730_000_000),
+			text: "hi",
+			audioPath: URL(fileURLWithPath: "/tmp/hi.wav"),
+			duration: 1.0,
+			modelIdentifier: "parakeet-tdt-0.6b-v3-coreml"
+		)
+
+		let data = try JSONEncoder().encode(original)
+		let decoded = try JSONDecoder().decode(Transcript.self, from: data)
+
+		#expect(decoded == original)
+		#expect(decoded.modelIdentifier == "parakeet-tdt-0.6b-v3-coreml")
+	}
+}

--- a/HexTests/RecordingRaceTests.swift
+++ b/HexTests/RecordingRaceTests.swift
@@ -232,7 +232,7 @@ final class RecordingRaceTests: XCTestCase {
       TranscriptionFeature()
     }
 
-    await store.send(.transcriptionResult("", audioURL, 1.25))
+    await store.send(.transcriptionResult("", audioURL, 1.25, nil))
     await store.finish()
 
     XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
@@ -248,13 +248,14 @@ final class RecordingRaceTests: XCTestCase {
       audioPath: audioURL,
       duration: duration,
       sourceAppBundleID: nil,
-      sourceAppName: nil
+      sourceAppName: nil,
+      modelIdentifier: "test-model"
     )
     let probe = TranscriptPersistenceProbe()
     let store = TestStore(initialState: Self.makeState()) {
       TranscriptionFeature()
     } withDependencies: {
-      $0.transcriptPersistence.save = { text, audioURL, duration, sourceAppBundleID, sourceAppName in
+      $0.transcriptPersistence.save = { text, audioURL, duration, sourceAppBundleID, sourceAppName, modelIdentifier in
         await probe.record(duration: duration)
         return transcript
       }
@@ -262,7 +263,7 @@ final class RecordingRaceTests: XCTestCase {
       $0.soundEffects.play = { _ in }
     }
 
-    await store.send(.transcriptionResult("hello", audioURL, duration))
+    await store.send(.transcriptionResult("hello", audioURL, duration, "test-model"))
     while await probe.duration == nil {
       await Task.yield()
     }


### PR DESCRIPTION
Each history row's metadata line now ends with the display name of the model that produced the transcript (e.g. "Parakeet TDT v3", "Whisper Large v3"), making it easy to compare output quality after switching models.

## Implementation notes

- `Transcript` gains an optional `modelIdentifier`, persisted with each entry. Optional with a `nil` default, following the `sourceAppBundleID` precedent: `Transcript` uses synthesized `Codable`, so a required field would throw `keyNotFound` on every pre-existing `transcription_history.json`. Two new HexCore tests pin the contract (legacy JSON without the field decodes to `nil`; the field round-trips).
- The identifier is captured from the transcribe call itself and threaded through `.transcriptionResult` — not read from settings at save time, since the selection can change in Settings while a transcription is in flight.
- `TranscriptPersistenceClient.save` takes the identifier as a new parameter (the client deliberately has no settings access).
- Display names resolve via a new `CuratedModelLoader.displayName(for:)` (curated match → prettified fallback for unknown identifiers), so entries keep a sensible label even for models no longer in the curated list. The existing bootstrap display-name helper now delegates to it. Entries saved before this change simply show no label.

## Tests

- `TranscriptionHistoryDecodingTests` (HexCore): legacy-JSON backward compatibility + round-trip.
- Updated `RecordingRaceTests` for the new `save` arity and action payload.
- Full suite green; `cd HexCore && swift test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * History entries now display which transcription model produced each transcript.
  * Model attribution uses a readable name with a fallback for unknown models.
  * Saved transcripts now retain the transcription model used.

* **Bug Fixes**
  * Existing history data from earlier app versions remains compatible and continues loading correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->