### PR TITLE
Fix: Persist cleared Paste Last Transcript shortcut

### DIFF
--- a/.changeset/eafa074a.md
+++ b/.changeset/eafa074a.md
@@ -1,0 +1,5 @@
+---
+"hex-app": patch
+---
+
+Persist a cleared Paste Last Transcript shortcut (#278).

--- a/HexCore/Sources/HexCore/Settings/HexSettings.swift
+++ b/HexCore/Sources/HexCore/Settings/HexSettings.swift
@@ -276,8 +276,12 @@ private enum HexSettingsSchema {
 			.pasteLastTranscriptHotkey,
 			keyPath: \.pasteLastTranscriptHotkey,
 			default: defaults.pasteLastTranscriptHotkey,
+			decode: { container, key, defaultValue in
+				guard container.contains(key) else { return defaultValue }
+				return try container.decode(HotKey?.self, forKey: key)
+			},
 			encode: { container, key, value in
-				try container.encodeIfPresent(value, forKey: key)
+				try container.encode(value, forKey: key)
 			}
 		).eraseToAny(),
 		SettingsField(.hasCompletedModelBootstrap, keyPath: \.hasCompletedModelBootstrap, default: defaults.hasCompletedModelBootstrap).eraseToAny(),

--- a/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
+++ b/HexCore/Tests/HexCoreTests/HexSettingsMigrationTests.swift
@@ -36,6 +36,23 @@ final class HexSettingsMigrationTests: XCTestCase {
 		XCTAssertEqual(decoded, settings)
 	}
 
+	func testMissingPasteLastTranscriptHotkeyUsesDefault() throws {
+		let data = Data("{}".utf8)
+		let decoded = try JSONDecoder().decode(HexSettings.self, from: data)
+
+		XCTAssertEqual(decoded.pasteLastTranscriptHotkey, HexSettings.defaultPasteLastTranscriptHotkey)
+	}
+
+	func testClearedPasteLastTranscriptHotkeyPersists() throws {
+		let settings = HexSettings(pasteLastTranscriptHotkey: nil)
+		let data = try JSONEncoder().encode(settings)
+		let encoded = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+		let decoded = try JSONDecoder().decode(HexSettings.self, from: data)
+
+		XCTAssertTrue(encoded?["pasteLastTranscriptHotkey"] is NSNull)
+		XCTAssertNil(decoded.pasteLastTranscriptHotkey)
+	}
+
 	func testNewSettingsEnableSuperFastModeByDefault() {
 		XCTAssertTrue(HexSettings().superFastModeEnabled)
 	}


### PR DESCRIPTION
Hello!

As mentioned in #278, here's the fix on persisting the cleared shortcut.

Let me know if you need/want any changes!

Thanks!

------

<details><summary>Summary by GPT-5.6 Terra:</summary>
<p>

## Summary

- encode a cleared Paste Last Transcript shortcut as an explicit JSON `null`
- preserve the default shortcut for legacy settings that omit the key
- add migration and persistence regression tests
- add a patch changeset

Fixes #278

## Verification

- `cd HexCore && swift test`

</p>
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing the “Paste Last Transcript” keyboard shortcut now persists correctly.
  * Existing settings without this shortcut continue to use the default hotkey.
  * Explicitly cleared shortcuts remain cleared after saving and restarting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->